### PR TITLE
Make isValidCustomElementName spec-perfect

### DIFF
--- a/packages/custom-elements/src/Utilities.js
+++ b/packages/custom-elements/src/Utilities.js
@@ -22,14 +22,17 @@ const reservedElementNameSet = new Set();
   'missing-glyph',
 ].forEach(item => reservedElementNameSet.add(item));
 
+const nameChars = /^(?:[-.\d_a-z\xB7\xC0-\xD6\xD8-\xF6\xF8-\u037D\u037F-\u1FFF\u200C\u200D\u203F\u2040\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])*$/;
+
 /**
  * @param {string} localName
  * @returns {boolean}
  */
 export function isValidCustomElementName(localName) {
-  const reserved = reservedElementNameSet.has(localName);
-  const validForm = /^[a-z][.0-9_a-z]*-[\-.0-9_a-z]*$/.test(localName);
-  return !reserved && validForm;
+  return !reservedElementNameSet.has(localName) &&
+    localName.indexOf("-") !== -1 &&
+    /^[a-z]/.test(localName) &&
+    nameChars.test(localName);
 }
 
 // Note, IE11 doesn't have `document.contains`.


### PR DESCRIPTION
Follow-up of https://github.com/webcomponents/custom-elements/pull/197.