### PR TITLE
Add awesome badge to top level README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://travis-ci.org/webcomponents/polyfills.svg?branch=master)](https://travis-ci.org/webcomponents/polyfills)
+[![Mentioned in Web Components the Right Way](https://awesome.re/mentioned-badge.svg)](https://github.com/mateusortiz/webcomponents-the-right-way)
+
 # Monorepository for WebComponents v1 polyfills
 
 > **Note**. For polyfills that work with the older Custom Elements and Shadow DOM v0 specs,


### PR DESCRIPTION
Hi! I'm a maintainer of [Web Components the Right Way](https://github.com/mateusortiz/webcomponents-the-right-way), which is added to the main [awesome](https://github.com/sindresorhus/awesome/blob/master/readme.md#front-end-development) list.

Now when all the polyfills are in the monorepo, I would like to recommend you to add this badge for greater visibility, so as we could help more people with blog posts, tools etc.

The similar PR for lit-html has been previously accepted: https://github.com/Polymer/lit-html/pull/535