### PR TITLE
Store custom element definitions at the registry, rather than the 'internals' class.

### DIFF
--- a/packages/custom-elements/externs/custom-elements.js
+++ b/packages/custom-elements/externs/custom-elements.js
@@ -44,8 +44,8 @@ let CustomElementDefinition;
 // Used for both Documents and Nodes which represent documents in the HTML
 // Imports polyfill.
 
-/** @type {boolean|undefined} */
-Node.prototype.__CE_hasRegistry;
+/** @type {!CustomElementRegistry|undefined} */
+Node.prototype.__CE_registry;
 
 /** @type {boolean|undefined} */
 Node.prototype.__CE_isImportDocument;

--- a/packages/custom-elements/src/CustomElementInternals.js
+++ b/packages/custom-elements/src/CustomElementInternals.js
@@ -23,12 +23,6 @@ export default class CustomElementInternals {
    * }} options
    */
   constructor(options) {
-    /** @type {!Map<string, !CustomElementDefinition>} */
-    this._localNameToDefinition = new Map();
-
-    /** @type {!Map<!Function, !CustomElementDefinition>} */
-    this._constructorToDefinition = new Map();
-
     /** @type {!Array<!function(!Node)>} */
     this._patchesNode = [];
 
@@ -43,31 +37,6 @@ export default class CustomElementInternals {
 
     /** @const {boolean} */
     this.useDocumentConstructionObserver = !options.noDocumentConstructionObserver;
-  }
-
-  /**
-   * @param {string} localName
-   * @param {!CustomElementDefinition} definition
-   */
-  setDefinition(localName, definition) {
-    this._localNameToDefinition.set(localName, definition);
-    this._constructorToDefinition.set(definition.constructorFunction, definition);
-  }
-
-  /**
-   * @param {string} localName
-   * @return {!CustomElementDefinition|undefined}
-   */
-  localNameToDefinition(localName) {
-    return this._localNameToDefinition.get(localName);
-  }
-
-  /**
-   * @param {!Function} constructor
-   * @return {!CustomElementDefinition|undefined}
-   */
-  constructorToDefinition(constructor) {
-    return this._constructorToDefinition.get(constructor);
   }
 
   /**
@@ -269,8 +238,8 @@ export default class CustomElementInternals {
 
         if (importNode instanceof Node) {
           importNode.__CE_isImportDocument = true;
-          // Connected links are associated with the registry.
-          importNode.__CE_hasRegistry = true;
+          // Connected links are associated with the global registry.
+          importNode.__CE_registry = document.__CE_registry;
         }
 
         if (importNode && importNode.readyState === 'complete') {
@@ -332,6 +301,10 @@ export default class CustomElementInternals {
     const currentState = element.__CE_state;
     if (currentState !== undefined) return;
 
+    const ownerDocument = element.ownerDocument;
+    const registry = ownerDocument.__CE_registry;
+    if (!registry) return;
+
     // Prevent elements created in documents without a browsing context from
     // upgrading.
     //
@@ -342,13 +315,12 @@ export default class CustomElementInternals {
     //   "The defaultView IDL attribute of the Document interface, on getting,
     //   must return this Document's browsing context's WindowProxy object, if
     //   this Document has an associated browsing context, or null otherwise."
-    const ownerDocument = element.ownerDocument;
     if (
       !ownerDocument.defaultView &&
-      !(ownerDocument.__CE_isImportDocument && ownerDocument.__CE_hasRegistry)
+      !(ownerDocument.__CE_isImportDocument && registry)
     ) return;
 
-    const definition = this._localNameToDefinition.get(element.localName);
+    const definition = registry.internal_localNameToDefinition(element.localName);
     if (!definition) return;
 
     definition.constructionStack.push(element);
@@ -450,10 +422,11 @@ export default class CustomElementInternals {
    * @see https://dom.spec.whatwg.org/#concept-create-element
    */
   createAnElement(doc, localName, namespace) {
-    // Only create custom elements if the document is associated with the
+    const registry = doc.__CE_registry;
+    // Only create custom elements if the document is associated with a
     // registry.
-    if (doc.__CE_hasRegistry && (namespace === null || namespace === NS_HTML)) {
-      const definition = this._localNameToDefinition.get(localName);
+    if (registry && (namespace === null || namespace === NS_HTML)) {
+      const definition = registry.internal_localNameToDefinition(localName);
       if (definition) {
         try {
           const result = new (definition.constructorFunction)();

--- a/packages/custom-elements/src/CustomElementInternals.js
+++ b/packages/custom-elements/src/CustomElementInternals.js
@@ -420,7 +420,7 @@ export default class CustomElementInternals {
     //   "The defaultView IDL attribute of the Document interface, on getting,
     //   must return this Document's browsing context's WindowProxy object, if
     //   this Document has an associated browsing context, or null otherwise."
-    if (!doc.defaultView && !(doc.__CE_isImportDocument && registry)) return;
+    if (!doc.defaultView && !doc.__CE_isImportDocument) return;
 
     return registry.internal_localNameToDefinition(localName);
   }

--- a/packages/custom-elements/src/CustomElementRegistry.js
+++ b/packages/custom-elements/src/CustomElementRegistry.js
@@ -14,7 +14,7 @@ import Deferred from './Deferred.js';
 import * as Utilities from './Utilities.js';
 
 /**
- * @unrestricted
+ * @extends {window.CustomElementRegistry}
  */
 export default class CustomElementRegistry {
 
@@ -234,7 +234,7 @@ export default class CustomElementRegistry {
 
   /**
    * @param {string} localName
-   * @return {Function|undefined}
+   * @return {function(new: HTMLElement)|undefined}
    */
   get(localName) {
     const definition = this._localNameToDefinition.get(localName);

--- a/packages/custom-elements/src/CustomElementRegistry.js
+++ b/packages/custom-elements/src/CustomElementRegistry.js
@@ -81,7 +81,7 @@ export default class CustomElementRegistry {
 
   /**
    * @param {string} localName
-   * @param {!Function} constructor
+   * @param {function(new: HTMLElement)} constructor
    */
   define(localName, constructor) {
     if (!(constructor instanceof Function)) {
@@ -158,10 +158,16 @@ export default class CustomElementRegistry {
     }
   }
 
-  upgrade(element) {
-    this._internals.patchAndUpgradeTree(element);
+  /**
+   * @param {!Node} node
+   */
+  upgrade(node) {
+    this._internals.patchAndUpgradeTree(node);
   }
 
+  /**
+   * @private
+   */
   _flush() {
     // If no new definitions were defined, don't attempt to flush. This could
     // happen if a flush callback keeps the function it is given and calls it
@@ -273,6 +279,9 @@ export default class CustomElementRegistry {
     return deferred.toPromise();
   }
 
+  /**
+   * @param {function(function())} outer
+   */
   polyfillWrapFlushCallback(outer) {
     if (this._documentConstructionObserver) {
       this._documentConstructionObserver.disconnect();

--- a/packages/custom-elements/src/CustomElementRegistry.js
+++ b/packages/custom-elements/src/CustomElementRegistry.js
@@ -24,6 +24,18 @@ export default class CustomElementRegistry {
   constructor(internals) {
     /**
      * @private
+     * @type {!Map<string, !CustomElementDefinition>}
+     */
+    this._localNameToDefinition = new Map();
+
+    /**
+     * @private
+     * @type {!Map<!Function, !CustomElementDefinition>}
+     */
+    this._constructorToDefinition = new Map();
+
+    /**
+     * @private
      * @type {boolean}
      */
     this._elementDefinitionIsRunning = false;
@@ -80,7 +92,7 @@ export default class CustomElementRegistry {
       throw new SyntaxError(`The element name '${localName}' is not valid.`);
     }
 
-    if (this._internals.localNameToDefinition(localName)) {
+    if (this._localNameToDefinition.has(localName)) {
       throw new Error(`A custom element with name '${localName}' has already been defined.`);
     }
 
@@ -134,7 +146,8 @@ export default class CustomElementRegistry {
       constructionStack: [],
     };
 
-    this._internals.setDefinition(localName, definition);
+    this._localNameToDefinition.set(localName, definition);
+    this._constructorToDefinition.set(definition.constructorFunction, definition);
     this._pendingDefinitions.push(definition);
 
     // If we've already called the flush callback and it hasn't called back yet,
@@ -189,7 +202,7 @@ export default class CustomElementRegistry {
           pendingElements.push(element);
         // If there is *any other* applicable definition for the element, add it
         // to the list of elements with stable definitions that need to be upgraded.
-        } else if (this._internals.localNameToDefinition(localName)) {
+        } else if (this._localNameToDefinition.has(localName)) {
           elementsWithStableDefinitions.push(element);
         }
       },
@@ -224,7 +237,7 @@ export default class CustomElementRegistry {
    * @return {Function|undefined}
    */
   get(localName) {
-    const definition = this._internals.localNameToDefinition(localName);
+    const definition = this._localNameToDefinition.get(localName);
     if (definition) {
       return definition.constructorFunction;
     }
@@ -249,7 +262,7 @@ export default class CustomElementRegistry {
     const deferred = new Deferred();
     this._whenDefinedDeferred.set(localName, deferred);
 
-    const definition = this._internals.localNameToDefinition(localName);
+    const definition = this._localNameToDefinition.get(localName);
     // Resolve immediately only if the given local name has a definition *and*
     // the full document walk to upgrade elements with that local name has
     // already happened.
@@ -266,6 +279,22 @@ export default class CustomElementRegistry {
     }
     const inner = this._flushCallback;
     this._flushCallback = flush => outer(() => inner(flush));
+  }
+
+  /**
+   * @param {string} localName
+   * @return {!CustomElementDefinition|undefined}
+   */
+  internal_localNameToDefinition(localName) {
+    return this._localNameToDefinition.get(localName);
+  }
+
+  /**
+   * @param {!Function} constructor
+   * @return {!CustomElementDefinition|undefined}
+   */
+  internal_constructorToDefinition(constructor) {
+    return this._constructorToDefinition.get(constructor);
   }
 }
 

--- a/packages/custom-elements/src/Patch/Document.js
+++ b/packages/custom-elements/src/Patch/Document.js
@@ -39,7 +39,7 @@ export default function(internals) {
     function(node, deep) {
       const clone = /** @type {!Node} */ (Native.Document_importNode.call(this, node, !!deep));
       // Only create custom elements if this document is associated with the registry.
-      if (!this.__CE_hasRegistry) {
+      if (!this.__CE_registry) {
         internals.patchTree(clone);
       } else {
         internals.patchAndUpgradeTree(clone);

--- a/packages/custom-elements/src/Patch/Element.js
+++ b/packages/custom-elements/src/Patch/Element.js
@@ -73,7 +73,7 @@ export default function(internals) {
 
         // Only create custom elements if this element's owner document is
         // associated with the registry.
-        if (!this.ownerDocument.__CE_hasRegistry) {
+        if (!this.ownerDocument.__CE_registry) {
           internals.patchTree(this);
         } else {
           internals.patchAndUpgradeTree(this);

--- a/packages/custom-elements/src/Patch/HTMLElement.js
+++ b/packages/custom-elements/src/Patch/HTMLElement.js
@@ -27,7 +27,9 @@ export default function(internals) {
       // prototype's `constructor` property, this is equivalent.
       const constructor = /** @type {!Function} */ (this.constructor);
 
-      const definition = internals.constructorToDefinition(constructor);
+      // Always look up the definition from the global registry.
+      const registry = document.__CE_registry;
+      const definition = registry.internal_constructorToDefinition(constructor);
       if (!definition) {
         throw new Error('Failed to construct a custom element: ' +
             'The constructor was not registered with `customElements`.');

--- a/packages/custom-elements/src/Patch/Node.js
+++ b/packages/custom-elements/src/Patch/Node.js
@@ -104,7 +104,7 @@ export default function(internals) {
       const clone = Native.Node_cloneNode.call(this, !!deep);
       // Only create custom elements if this element's owner document is
       // associated with the registry.
-      if (!this.ownerDocument.__CE_hasRegistry) {
+      if (!this.ownerDocument.__CE_registry) {
         internals.patchTree(clone);
       } else {
         internals.patchAndUpgradeTree(clone);

--- a/packages/custom-elements/src/custom-elements.js
+++ b/packages/custom-elements/src/custom-elements.js
@@ -35,11 +35,11 @@ function installPolyfill() {
   PatchNode(internals);
   PatchElement(internals);
 
-  // The main document is always associated with the registry.
-  document.__CE_hasRegistry = true;
-
   /** @type {!CustomElementRegistry} */
   const customElements = new CustomElementRegistry(internals);
+
+  // The main document is associated with the global registry.
+  document.__CE_registry = customElements;
 
   Object.defineProperty(window, 'customElements', {
     configurable: true,


### PR DESCRIPTION
Before this PR, definitions were stored on the CustomElementInternals object, which is passed to all of the patches and used to trigger reactions when those patched functions are called. Now, the definitions are lifted back into CustomElementRegistry and the CustomElementInternals object finds definitions for elements that need to be upgraded by using that element's `ownerDocument` instead. (Custom element definitions of elements that have already been upgraded are accessible via a private property, so there's no need to find a registry during the other reactions.)

This makes implementing lazy definitions simpler by allowing all of the associated behavior to stay in CustomElementRegistry. Also, moving the definitions to CustomElementRegistry is a prerequisite to prototyping scoped registries.