### PR TITLE
Make `reportTheException` public; record definitions pending a flush only by their local name.

### DIFF
--- a/packages/custom-elements/src/CustomElementInternals.js
+++ b/packages/custom-elements/src/CustomElementInternals.js
@@ -293,7 +293,7 @@ export default class CustomElementInternals {
         this._upgradeAnElement(element, definition);
       }
     } catch (e) {
-      this._reportTheException(e);
+      this.reportTheException(e);
     }
   }
 
@@ -352,7 +352,7 @@ export default class CustomElementInternals {
       try {
         definition.connectedCallback.call(element);
       } catch (e) {
-        this._reportTheException(e);
+        this.reportTheException(e);
       }
     }
   }
@@ -366,7 +366,7 @@ export default class CustomElementInternals {
       try {
         definition.disconnectedCallback.call(element);
       } catch (e) {
-        this._reportTheException(e);
+        this.reportTheException(e);
       }
     }
   }
@@ -387,7 +387,7 @@ export default class CustomElementInternals {
       try {
         definition.attributeChangedCallback.call(element, name, oldValue, newValue, namespace);
       } catch (e) {
-        this._reportTheException(e);
+        this.reportTheException(e);
       }
     }
   }
@@ -497,7 +497,7 @@ export default class CustomElementInternals {
 
           return result;
         } catch (e) {
-          this._reportTheException(e);
+          this.reportTheException(e);
 
           // When construction fails, a new HTMLUnknownElement is produced.
           // However, there's no direct way to create one, so we create a
@@ -524,11 +524,10 @@ export default class CustomElementInternals {
   /**
    * Runs the DOM's 'report the exception' algorithm.
    *
-   * @private
    * @param {!Error} error
    * @see https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception
    */
-  _reportTheException(error) {
+  reportTheException(error) {
     const message = error.message;
     /** @type {string} */
     const filename =

--- a/packages/custom-elements/src/CustomElementRegistry.js
+++ b/packages/custom-elements/src/CustomElementRegistry.js
@@ -190,9 +190,9 @@ export default class CustomElementRegistry {
      * @type {!Map<string, !Array<!HTMLElement>>}
      */
     const elementsWithPendingDefinitions = new Map();
-    for (const localName of unflushedLocalNames) {
+    unflushedLocalNames.forEach(localName => {
       elementsWithPendingDefinitions.set(localName, []);
-    }
+    });
 
     this._internals.patchAndUpgradeTree(document, {
       upgrade: element => {
@@ -220,7 +220,7 @@ export default class CustomElementRegistry {
     }
 
     // Upgrade elements with 'pending' definitions in the order they were defined.
-    for (const localName of unflushedLocalNames) {
+    unflushedLocalNames.forEach(localName => {
       // Attempt to upgrade all applicable elements.
       const pendingUpgradableElements = elementsWithPendingDefinitions.get(localName);
       for (let i = 0; i < pendingUpgradableElements.length; i++) {
@@ -232,7 +232,7 @@ export default class CustomElementRegistry {
       if (deferred) {
         deferred.resolve(undefined);
       }
-    }
+    });
 
     unflushedLocalNames.clear();
   }

--- a/packages/custom-elements/src/CustomElementRegistry.js
+++ b/packages/custom-elements/src/CustomElementRegistry.js
@@ -187,11 +187,6 @@ export default class CustomElementRegistry {
      */
     const elementsWithStableDefinitions = [];
 
-    /**
-     * A map from `localName`s of definitions that were defined *after* the last
-     * flush to unupgraded elements matching that definition, in document order.
-     * @type {!Map<string, !Array<!HTMLElement>>}
-     */
     const elementsWithPendingDefinitions = this._elementsWithPendingDefinitions;
 
     this._internals.patchAndUpgradeTree(document, {

--- a/packages/custom-elements/src/CustomElementRegistry.js
+++ b/packages/custom-elements/src/CustomElementRegistry.js
@@ -265,7 +265,7 @@ export default class CustomElementRegistry {
     // Resolve immediately only if the given local name has a definition *and*
     // the full document walk to upgrade elements with that local name has
     // already happened.
-    if (definition && this._elementsWithPendingDefinitions.has(localName)) {
+    if (definition && !this._elementsWithPendingDefinitions.has(localName)) {
       deferred.resolve(undefined);
     }
 

--- a/packages/custom-elements/tests/html/polyfillWrapFlushCallback/whenDefined_after.html
+++ b/packages/custom-elements/tests/html/polyfillWrapFlushCallback/whenDefined_after.html
@@ -49,7 +49,6 @@ test('`whenDefined` called after `define` does not resolve until its local name 
   promise.then(function() {
     resolved = true;
     assert(element.upgraded);
-    done();
   }).catch(function(err) {
     done(err);
   });
@@ -60,6 +59,14 @@ test('`whenDefined` called after `define` does not resolve until its local name 
     assert(!element.upgraded);
     flushFn();
     assert(element.upgraded);
+
+    // The promise resolves in the set of microtasks after the task that ran
+    // the flush.
+    assert(!resolved);
+    setTimeout(function() {
+      assert(resolved);
+      done();
+    }, 0);
   }, 0);
 });
 </script>

--- a/packages/custom-elements/tests/html/polyfillWrapFlushCallback/whenDefined_after.html
+++ b/packages/custom-elements/tests/html/polyfillWrapFlushCallback/whenDefined_after.html
@@ -54,11 +54,13 @@ test('`whenDefined` called after `define` does not resolve until its local name 
     done(err);
   });
 
-  assert(!element.upgraded);
-
-  flushFn();
-
-  assert(element.upgraded);
+  // Delay until the next task to give the promise the opportunity to
+  // potentially resolve incorrectly.
+  setTimeout(function() {
+    assert(!element.upgraded);
+    flushFn();
+    assert(element.upgraded);
+  }, 0);
 });
 </script>
 </body>

--- a/packages/custom-elements/tests/html/polyfillWrapFlushCallback/whenDefined_before.html
+++ b/packages/custom-elements/tests/html/polyfillWrapFlushCallback/whenDefined_before.html
@@ -54,11 +54,13 @@ test('`whenDefined` called before `define` does not resolve until its local name
     }
   });
 
-  assert(!element.upgraded);
-
-  flushFn();
-
-  assert(element.upgraded);
+  // Delay until the next task to give the promise the opportunity to
+  // potentially resolve incorrectly.
+  setTimeout(function() {
+    assert(!element.upgraded);
+    flushFn();
+    assert(element.upgraded);
+  }, 0);
 });
 </script>
 </body>

--- a/packages/custom-elements/tests/html/polyfillWrapFlushCallback/whenDefined_before.html
+++ b/packages/custom-elements/tests/html/polyfillWrapFlushCallback/whenDefined_before.html
@@ -37,7 +37,6 @@ test('`whenDefined` called before `define` does not resolve until its local name
   promise.then(function() {
     resolved = true;
     assert(element.upgraded);
-    done();
   }).catch(function(err) {
     done(err);
   });
@@ -60,6 +59,14 @@ test('`whenDefined` called before `define` does not resolve until its local name
     assert(!element.upgraded);
     flushFn();
     assert(element.upgraded);
+
+    // The promise resolves in the set of microtasks after the task that ran
+    // the flush.
+    assert(!resolved);
+    setTimeout(function() {
+      assert(resolved);
+      done();
+    }, 0);
   }, 0);
 });
 </script>


### PR DESCRIPTION
This PR is preparation for a lazy definition PR.