### PR TITLE
[Custom Elements] Lazy Definitions

### DIFF
--- a/packages/custom-elements/README.md
+++ b/packages/custom-elements/README.md
@@ -209,3 +209,41 @@ customElements.define('c-e', class extends HTMLElement {});
 // 'added first'
 // The document is walked to attempt upgrades.
 ```
+
+### `customElements.polyfillDefineLazy`
+
+Allows defining an element with a constructor getter function that returns an
+element constructor. It provides a small optimization over using
+`customElements.define` when producing the element class is expensive. The
+constructor getter function is called only the first time the polyfill tries
+to upgrade the given element.
+
+```javascript
+customElements.polyfillDefineLazy('c-e', () => {
+  // do some expensive work then...
+  return class extends HTMLElement {};
+});
+```
+
+Note, this API is not included in the custom elements spec and therefore
+requires use of the polyfill to function correctly.
+
+### Settings
+
+The polyfill provides a few settings to improve performance by tweaking behavior.
+These settings typically have correctness trade offs (noted below) and should be
+used with caution.
+
+* `customElements.noDocumentConstructionObserver`: Set this flag to true to
+prevent the polyfill from mutation observing and upgrading DOM as it is added
+to the main document. This provides a small performance improvement during
+document parsing. With this setting on, the polyfill will not upgrade elements
+created when parsing the main document's HTML. This setting should be
+used in conjunction with a `polyfillWrapFlushCallback` that defers element
+upgrades until the parser is complete.
+
+* `customElements.shadyDomFastWalk`: Set this flag to true when using the
+ShadyDOM polyfill to optimize how elements are found in the DOM. There are a
+couple of limitations: (1) Elements that are children of Shadow DOM hosts and
+are not distributed to slots may not upgrade; (2) This setting is not compatible
+with using native HTML Imports.

--- a/packages/custom-elements/tests/html/polyfill-define-lazy.html
+++ b/packages/custom-elements/tests/html/polyfill-define-lazy.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html>
+<head>
+<title>#polyfillDefineLazy</title>
+<script src="../catchReportedErrors.js"></script>
+<script>
+  (window.customElements = window.customElements || {}).forcePolyfill = true;
+</script>
+<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../../custom-elements.min.js"></script>
+</head>
+<body>
+<script type="module">
+import {safariGCBugWorkaround} from "../safari-gc-bug-workaround.js";
+suiteSetup(() => safariGCBugWorkaround());
+
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+suite('polyfillLazyDefine', function() {
+  var work;
+  var assert = chai.assert;
+
+  customElements.enableFlush = true;
+
+  setup(function() {
+    work = document.createElement('div');
+    document.body.appendChild(work);
+  });
+
+  teardown(function() {
+    document.body.removeChild(work);
+  });
+
+  suite('defining', function() {
+
+    test('requires a name argument', function() {
+      assert.throws(function() {
+        customElements.polyfillDefineLazy();
+      }, '', 'customElements.define failed to throw when given no arguments');
+    });
+
+    test('name must contain a dash', function() {
+      assert.throws(function () {
+        customElements.polyfillDefineLazy('xfoo', () => {prototype: Object.create(HTMLElement.prototype)});
+      }, '', 'customElements.define failed to throw when given no arguments');
+    });
+
+    test('name must not be a reserved name', function() {
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('font-face', () => {prototype: Object.create(HTMLElement.prototype)});
+      }, '', 'Failed to execute \'defineElement\' on \'Document\': Registration failed for type \'font-face\'. The type name is invalid.');
+    });
+
+    test('name must be unique', function() {
+      const generator = () => class XDuplicate extends HTMLElement {};
+      customElements.polyfillDefineLazy('x-lazy-duplicate', generator);
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('x-lazy-duplicate', generator);
+      }, '', 'customElements.define failed to throw when called multiple times with the same element name');
+    });
+
+    test('name must be unique and not defined', function() {
+      customElements.define('x-lazy-duplicate-define', class extends HTMLElement {});
+      assert.throws(function() {
+        customElements.polyfillDefineLazy('x-lazy-duplicate-define', () => class extends HTMLElement {});
+      }, '', 'customElements.define failed to throw when called multiple times with the same element name');
+    });
+
+    test('names are case-sensitive', function() {
+      const generator = () => class XCase extends HTMLElement {};
+      assert.throws(function() { customElements.polyfillDefineLazy('X-CASE', generator); });
+    });
+
+    test('requires a constructor argument', function() {
+      assert.throws(function () {
+        customElements.polyfillDefineLazy('x-no-options');
+      }, '', 'customElements.define failed to throw without a constructor argument');
+    });
+
+    test('define succeeds with named used for a polyfillDefineLazy with an invalid class', function() {
+      customElements.polyfillDefineLazy('x-failed-define-lazy', () => {});
+      const errors = [];
+      catchReportedErrors(() => {
+        assert.doesNotThrow(function() {
+          customElements.define('x-failed-define-lazy', class extends HTMLElement {});
+        });
+      }, (e) => {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        errors.push(e);
+      });
+      assert.equal(errors.length, 1, 'Error was not reported when defining an element using the same name as a failed definition with an invalid class.')
+    });
+
+    test('define succeeds with named used for a polyfillDefineLazy with invalid callbacks', function() {
+      customElements.polyfillDefineLazy('x-failed-define-lazy-callbacks', () => class extends HTMLElement {
+        attributeChangedCallback() {}
+        static get observedAttributes() {
+          throw new Error('no attributes');
+        }
+      });
+
+      const errors = [];
+      catchReportedErrors(() => {
+        assert.doesNotThrow(function() {
+          customElements.define('x-failed-define-lazy-callbacks', class extends HTMLElement {});
+        });
+      }, (e) => {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        errors.push(e);
+      });
+      assert.equal(errors.length, 1, 'Error was not reported when defining an element using the same name as a failed definition with invalid callbacks.')
+    });
+
+  });
+
+  suite('get', function() {
+
+    test('returns constructor', function() {
+      const ctor = class extends HTMLElement {};
+      customElements.polyfillDefineLazy('x-get-lazy', () => ctor);
+      assert.equal(customElements.get('x-get-lazy'), ctor);
+    });
+
+  });
+
+  suite('whenDefined', function() {
+
+    test('resolves', function() {
+      const ctor = class extends HTMLElement {};
+      customElements.polyfillDefineLazy('x-when-defined-lazy', () => ctor);
+      return customElements.whenDefined('x-when-defined-lazy');
+    });
+
+  });
+
+  suite('upgrades', function() {
+
+    test('createElement upgrades when defined', function() {
+      customElements.polyfillDefineLazy('lazy-create-upgrade', () => {
+        return class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+        }
+      });
+      const el = document.createElement('lazy-create-upgrade');
+      assert.isTrue(el.upgraded);
+    });
+
+    test('element in dom upgrades', function() {
+      const el = document.createElement('lazy-dom-upgrade');
+      work.appendChild(el);
+      customElements.polyfillDefineLazy('lazy-dom-upgrade', () => {
+        return class extends HTMLElement {
+          constructor() {
+            super();
+            this.upgraded = true;
+          }
+          connectedCallback() {
+            this.connected = true;
+          }
+        }
+      });
+      assert.isTrue(el.upgraded);
+      assert.isTrue(el.connected);
+    });
+
+    test('creating an element reports an error if a constructor getter is used with `define`', function() {
+      customElements.define('pass-getter-to-define', function() {});
+      const errors = [];
+      catchReportedErrors(() => {
+        assert.doesNotThrow(function() {
+          document.createElement('pass-getter-to-define');
+        });
+      }, (e) => {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        errors.push(e);
+      });
+      assert.equal(errors.length, 1);
+    });
+
+   });
+
+});
+</script>
+</body>
+</html>

--- a/packages/custom-elements/tests/html/polyfill-define-lazy.html
+++ b/packages/custom-elements/tests/html/polyfill-define-lazy.html
@@ -142,6 +142,30 @@ suite('polyfillLazyDefine', function() {
       return customElements.whenDefined('x-when-defined-lazy');
     });
 
+    test('The promise resolves even if the definition eventually fails. The ' +
+        'failed definition reports an error.', function() {
+      const ctor = class extends HTMLElement {
+        static get observedAttributes() { throw new Error(); }
+        // Must exist for `observedAttributes` to be read.
+        attributeChangedCallback() {}
+      };
+      customElements.polyfillDefineLazy('x-when-defined-lazy-fail', () => ctor);
+
+      return customElements.whenDefined('x-when-defined-lazy-fail').then(() => {
+        const errors = [];
+        catchReportedErrors(() => {
+          assert.doesNotThrow(function() {
+            document.createElement('x-when-defined-lazy-fail');
+          });
+        }, (e) => {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          errors.push(e);
+        });
+        assert.equal(errors.length, 1)
+      });
+    });
+
   });
 
   suite('upgrades', function() {

--- a/packages/custom-elements/tests/index.html
+++ b/packages/custom-elements/tests/index.html
@@ -22,6 +22,7 @@
     'html/closure.html',
     'html/upgrade.html',
     'html/shadow-dom.html',
+    'html/polyfill-define-lazy.html',
     'html/registry-upgrade.html',
     'html/polyfillWrapFlushCallback/index.html',
     'html/imports.html',


### PR DESCRIPTION
This PR implements 'lazy' definitions through a new function on `CustomElementRegistry` called `polyfillDefineLazy`. To add a lazy definition, call `polyfillDefineLazy` with a local name and a function that returns a custom element constructor:

```javascript
customElements.polyfillDefineLazy('some-element', () => {
  // Maybe do some expensive work that we want to delay until
  // we know we need an instance of <some-element>.
  return class extends HTMLElement {};
});
```

If a lazy definition exists when the polyfill would normally try to create or upgrade an element with that local name, it will call the function you've given it and attempt to create a definition from the returned constructor at that time, using it if it succeeds. Like the standard `define`, `polyfillDefineLazy` also triggers a full-document walk - only the process of retrieving and converting a constructor to a complete definition is lazy.

Calling `get`, `define`, or `polyfillLazyDefine` using a local name that already has a lazy definition will cause the old definition to be retrieved at that time to determine if it would be successful, which would either (for `get`) determine if the constructor or `undefined` is returned or (for `define` and `polyfillLazyDefine`) determine if the new definition attempt would fail due to an existing definition.

Promises returned by `whenDefined` will resolve immediately if a lazy definition exists for a given local name and the full-document upgrade walk associated with that definition has already occurred, even if that lazy definition has not yet been successfully completed. This differs from the standard behavior for `whenDefined` (where there are no lazy definitions), which guarantees that these promises would normally not resolve until both the definition for the given name has succeeded and an upgrade has been attempted for all elements in the main document having that local name.

`polyfillDefineLazy` will throw synchronously when the definition would normally fail during `define` for a reason that doesn't involve knowing the constructor - for example, if the given name is not a valid custom element name, a definition already exists for the given name, etc. If a lazy definition fails when it attempts to complete the definition, any error that would normally be thrown is [reported](https://html.spec.whatwg.org/C/#report-the-exception) instead.