### PR TITLE
Fix issue #180: Add code to make sure the internal `inertDoc` has the…

### DIFF
--- a/packages/shadydom/src/patches/ElementOrShadowRoot.js
+++ b/packages/shadydom/src/patches/ElementOrShadowRoot.js
@@ -15,6 +15,11 @@ import {clearNode} from './Node.js';
 /** @type {!Document} */
 const inertDoc = document.implementation.createHTMLDocument('inert');
 
+// Make sure that the domains between the inertDoc and the 'real' document object match in order
+if (inertDoc.domain !== document.domain) {
+  inertDoc.domain = document.domain;
+}
+
 export const ElementOrShadowRootPatches = utils.getOwnPropertyDescriptors({
 
   /** @this {Element} */

--- a/packages/shadydom/src/patches/ElementOrShadowRoot.js
+++ b/packages/shadydom/src/patches/ElementOrShadowRoot.js
@@ -15,11 +15,6 @@ import {clearNode} from './Node.js';
 /** @type {!Document} */
 const inertDoc = document.implementation.createHTMLDocument('inert');
 
-// Make sure that the domains between the inertDoc and the 'real' document object match in order
-if (inertDoc.domain !== document.domain) {
-  inertDoc.domain = document.domain;
-}
-
 export const ElementOrShadowRootPatches = utils.getOwnPropertyDescriptors({
 
   /** @this {Element} */
@@ -42,6 +37,11 @@ export const ElementOrShadowRootPatches = utils.getOwnPropertyDescriptors({
       this[utils.NATIVE_PREFIX + 'innerHTML'] = value;
     } else {
       clearNode(this);
+      // Make sure that the domain attributes of inertDoc and the 'real' document object
+      // are the same in order to avoid WrongDocumentError in IE11.
+      if (inertDoc.domain !== document.domain) {
+        inertDoc.domain = document.domain;
+      }
       const containerName = this.localName || 'div';
       let htmlContainer;
       if (!this.namespaceURI || this.namespaceURI === inertDoc.namespaceURI) {

--- a/packages/shadydom/src/patches/ElementOrShadowRoot.js
+++ b/packages/shadydom/src/patches/ElementOrShadowRoot.js
@@ -37,10 +37,15 @@ export const ElementOrShadowRootPatches = utils.getOwnPropertyDescriptors({
       this[utils.NATIVE_PREFIX + 'innerHTML'] = value;
     } else {
       clearNode(this);
-      // Make sure that the domain attributes of inertDoc and the 'real' document object
+      // Make sure that the domain attributes of inertDoc and the document for
       // are the same in order to avoid WrongDocumentError in IE11.
-      if (inertDoc.domain !== document.domain) {
+      if ((inertDoc.domain.indexOf(document.domain) >= 0) && (inertDoc.domain !== document.domain)) {
         inertDoc.domain = document.domain;
+      }
+      // Some libraries, like Angular, create their own document object for their tags,
+      // so make sure that domain value matches as well.
+      if ((this.ownerDocument.domain.indexOf(document.domain) >= 0) && (this.ownerDocument.domain !== document.domain)) {
+        this.ownerDocument.domain = document.domain;
       }
       const containerName = this.localName || 'div';
       let htmlContainer;


### PR DESCRIPTION
… same domain as the real `document` object to avoid `WrongDocumentError` when setting `innerHTML` in IE11.

<!-- Instructions: https://github.com/webcomponents/shadydom/blob/master/CONTRIBUTING.md -->
### Reference Issue
Fixes #180
