### PR TITLE
[ShadyDOM] Add option for on-demand patching

### DIFF
--- a/packages/shadydom/src/link-nodes.js
+++ b/packages/shadydom/src/link-nodes.js
@@ -22,7 +22,8 @@ const hasDescriptors = utils.settings.hasDescriptors;
 function patchNode(node, type) {
   if (patchOnDemand) {
     patchNodeProto(node);
-  } else if (!hasDescriptors) {
+  }
+  if (!hasDescriptors) {
     if (type === OutsideAccessors) {
       patchOutsideElementAccessors(node);
     } else if (type === InsideAcccessors) {

--- a/packages/shadydom/src/link-nodes.js
+++ b/packages/shadydom/src/link-nodes.js
@@ -19,10 +19,6 @@ const InsideAcccessors = 2;
 const patchOnDemand = utils.settings.patchOnDemand;
 const hasDescriptors = utils.settings.hasDescriptors;
 
-/**
- *
- * @param {AccessorType} type
- */
 function patchNode(node, type) {
   if (patchOnDemand) {
     patchNodeProto(node);

--- a/packages/shadydom/src/patch-instances.js
+++ b/packages/shadydom/src/patch-instances.js
@@ -145,7 +145,7 @@ export let patchOutsideElementAccessors = noInstancePatching ?
     const sd = ensureShadyDataForNode(element);
     if (!sd.__outsideAccessors) {
       sd.__outsideAccessors = true;
-      utils.patchProperties(element, OutsideDescriptors);
+      utils.patchExistingProperties(element, OutsideDescriptors);
     }
   }
 
@@ -155,7 +155,7 @@ export let patchInsideElementAccessors = noInstancePatching ?
     const sd = ensureShadyDataForNode(element);
     if (!sd.__insideAccessors) {
       sd.__insideAccessors = true;
-      utils.patchProperties(element, InsideDescriptors);
+      utils.patchExistingProperties(element, InsideDescriptors);
       // NOTE: There are compatibility issues with patches for `textContent`
       // and `innerHTML` between CE and SD. Since SD patches are applied
       // via `ShadyDOM.patch` and CE patches are applied as the tree is walked,
@@ -170,7 +170,7 @@ export let patchInsideElementAccessors = noInstancePatching ?
       // If customElements is not loaded, then these accessors should be
       // patched so they work correctly.
       if (!window['customElements'] || utils.settings.noPatch) {
-        utils.patchProperties(element, TextContentInnerHTMLDescriptors);
+        utils.patchExistingProperties(element, TextContentInnerHTMLDescriptors);
       }
     }
   }

--- a/packages/shadydom/src/patch-instances.js
+++ b/packages/shadydom/src/patch-instances.js
@@ -137,7 +137,7 @@ makeNonEnumerable(InsideDescriptors);
 makeNonEnumerable(TextContentInnerHTMLDescriptors);
 makeNonEnumerable(OutsideDescriptors);
 
-const noInstancePatching = utils.settings.hasDescriptors || utils.settings.noPatch;
+const noInstancePatching = utils.settings.hasDescriptors || (utils.settings.noPatch === true);
 
 // ensure an element has patched "outside" accessors; no-op when not needed
 export let patchOutsideElementAccessors = noInstancePatching ?

--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -101,13 +101,14 @@ const patchedProtos = new Map();
 
 // Patch non-element prototypes up front so that we don't have to check
 // the type of Node when patching an can always assume we're patching an element.
-[window.Text, window.Comment, window.CDATASection, window.ProcessingInstruction].forEach(ctor => {
+['Text', 'Comment', 'CDATASection', 'ProcessingInstruction'].forEach(name => {
+  const ctor = window[name];
   const patchedProto = Object.create(ctor.prototype);
   patchedProto[PROTO_IS_PATCHED] = true;
   applyPatchList(patchedProto, patchMap.EventTarget);
   applyPatchList(patchedProto, patchMap.Node);
-  if (patchMap[ctor.name]) {
-    applyPatchList(patchedProto, patchMap[ctor.name]);
+  if (patchMap[name]) {
+    applyPatchList(patchedProto, patchMap[name]);
   }
   patchedProtos.set(ctor.prototype, patchedProto);
 });

--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -93,32 +93,34 @@ export const applyPatches = (prefix) => {
   }
 }
 
+const PROTO_IS_PATCHED = utils.SHADY_PREFIX + 'patchedProto';
+
 const patchedProtos = new Map();
 const TextPatchedProto = Object.create(Text.prototype);
-TextPatchedProto[utils.SHADY_PREFIX + 'patchedProto'] = true;
+TextPatchedProto[PROTO_IS_PATCHED] = true;
 applyPatchList(TextPatchedProto, patchMap.EventTarget);
 applyPatchList(TextPatchedProto, patchMap.Node);
 applyPatchList(TextPatchedProto, patchMap.Text);
 patchedProtos.set(Text.prototype, TextPatchedProto);
 
-const patchElementProto = (proto) => {
+export const patchElementProto = (proto) => {
+  proto[PROTO_IS_PATCHED] = true;
   applyPatchList(proto, patchMap.EventTarget);
   applyPatchList(proto, patchMap.Node);
   applyPatchList(proto, patchMap.Element);
   applyPatchList(proto, patchMap.HTMLElement);
   applyPatchList(proto, patchMap.HTMLSlotElement);
+  return proto;
 }
 
 export const patchNodeProto = (node) => {
-  if (!utils.settings.patchOnDemand || node[utils.SHADY_PREFIX + 'patchedProto'] ||
-    utils.isShadyRoot(node)) {
+  if (node[PROTO_IS_PATCHED] || utils.isShadyRoot(node)) {
     return;
   }
   const nativeProto = Object.getPrototypeOf(node);
   let proto = patchedProtos.get(nativeProto);
   if (!proto) {
     proto = Object.create(nativeProto);
-    proto[utils.SHADY_PREFIX + 'patchedProto'] = true;
     patchElementProto(proto);
     patchedProtos.set(nativeProto, proto);
   }

--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -101,7 +101,7 @@ const patchedProtos = new Map();
 
 // Patch non-element prototypes up front so that we don't have to check
 // the type of Node when patching an can always assume we're patching an element.
-[Text, Comment, CDATASection, ProcessingInstruction].forEach(ctor => {
+[window.Text, window.Comment, window.CDATASection, window.ProcessingInstruction].forEach(ctor => {
   const patchedProto = Object.create(ctor.prototype);
   patchedProto[PROTO_IS_PATCHED] = true;
   applyPatchList(patchedProto, patchMap.EventTarget);

--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -13,7 +13,7 @@ import {EventTargetPatches} from './patches/EventTarget.js';
 import {NodePatches} from './patches/Node.js';
 import {SlotablePatches} from './patches/Slotable.js';
 import {ParentNodePatches, ParentNodeDocumentOrFragmentPatches} from './patches/ParentNode.js';
-import {ElementPatches} from './patches/Element.js';
+import {ElementPatches, ElementShadowPatches} from './patches/Element.js';
 import {ElementOrShadowRootPatches} from './patches/ElementOrShadowRoot.js';
 import {HTMLElementPatches} from './patches/HTMLElement.js';
 import {SlotPatches} from './patches/Slot.js';
@@ -71,14 +71,62 @@ const getPatchPrototype = (name) => window[name] && window[name].prototype;
 // CustomElements polyfill *only* cares about these accessors.
 const disallowedNativePatches = utils.settings.hasDescriptors ? null : ['innerHTML', 'textContent'];
 
+/**
+ * Patch a group of accessors on an object only if it exists or if the `force`
+ * argument is true.
+ * @param {!Object} proto
+ * @param {!Array<Object>} list
+ * @param {string=} prefix
+ * @param {Array=} disallowed
+ */
+function applyPatchList(proto, list, prefix, disallowed) {
+  list.forEach(patch => proto && patch &&
+    utils.patchProperties(proto, patch, prefix, disallowed));
+}
+
 /** @param {string=} prefix */
 export const applyPatches = (prefix) => {
   const disallowed = prefix ? null : disallowedNativePatches;
   for (let p in patchMap) {
     const proto = getPatchPrototype(p);
-    patchMap[p].forEach(patch => proto && patch &&
-        utils.patchProperties(proto, patch, prefix, disallowed));
+    applyPatchList(proto, patchMap[p], prefix, disallowed);
   }
+}
+
+const patchedProtos = new Map();
+const TextPatchedProto = Object.create(Text.prototype);
+TextPatchedProto[utils.SHADY_PREFIX + 'patchedProto'] = true;
+applyPatchList(TextPatchedProto, patchMap.EventTarget);
+applyPatchList(TextPatchedProto, patchMap.Node);
+applyPatchList(TextPatchedProto, patchMap.Text);
+patchedProtos.set(Text.prototype, TextPatchedProto);
+
+const patchElementProto = (proto) => {
+  applyPatchList(proto, patchMap.EventTarget);
+  applyPatchList(proto, patchMap.Node);
+  applyPatchList(proto, patchMap.Element);
+  applyPatchList(proto, patchMap.HTMLElement);
+  applyPatchList(proto, patchMap.HTMLSlotElement);
+}
+
+export const patchNodeProto = (node) => {
+  if (!utils.settings.patchOnDemand || node[utils.SHADY_PREFIX + 'patchedProto'] ||
+    utils.isShadyRoot(node)) {
+    return;
+  }
+  const nativeProto = Object.getPrototypeOf(node);
+  let proto = patchedProtos.get(nativeProto);
+  if (!proto) {
+    proto = Object.create(nativeProto);
+    proto[utils.SHADY_PREFIX + 'patchedProto'] = true;
+    patchElementProto(proto);
+    patchedProtos.set(nativeProto, proto);
+  }
+  Object.setPrototypeOf(node, proto);
+}
+
+export const patchShadowOnElement = () => {
+  utils.patchProperties(Element.prototype, ElementShadowPatches);
 }
 
 export const addShadyPrefixedProperties = () => {

--- a/packages/shadydom/src/patches/Element.js
+++ b/packages/shadydom/src/patches/Element.js
@@ -129,10 +129,12 @@ export const ElementShadowPatches = utils.getOwnPropertyDescriptors({
    */
   attachShadow(options) {
     const root = attachShadow(this, options);
-    // TODO(sorvell): Workaround for CE not seeing shadowRoot in augmented
+    // TODO(sorvell): Workaround for CE not seeing shadowRoot in `on-demand`
     // noPatch mode. CE's attachShadow patch is overwritten by this patch
     // and cannot set its own special tracking for shadowRoot. It does this
     // to be able to see closed shadowRoots.
+    // This is necessary so that the CE polyfill can traverse into nodes
+    // with shadowRoot that will under `on-demand` have their childNodes patched.
     this['__CE_shadowRoot'] = root;
     return root;
   },

--- a/packages/shadydom/src/patches/HTMLElement.js
+++ b/packages/shadydom/src/patches/HTMLElement.js
@@ -28,25 +28,29 @@ export const HTMLElementPatches = utils.getOwnPropertyDescriptors({
 
 });
 
-eventPropertyNames.forEach(property => {
-  HTMLElementPatches[property] = {
-    /** @this {HTMLElement} */
-    set: function(fn) {
-      const shadyData = ensureShadyDataForNode(this);
-      const eventName = property.substring(2);
-      if (!shadyData.__onCallbackListeners) {
-        shadyData.__onCallbackListeners = {};
-      }
-      shadyData.__onCallbackListeners[property] && this.removeEventListener(eventName, shadyData.__onCallbackListeners[property]);
-      this[utils.SHADY_PREFIX + 'addEventListener'](eventName, fn);
-      shadyData.__onCallbackListeners[property] = fn;
-    },
-    /** @this {HTMLElement} */
-    get() {
-      const shadyData = shadyDataForNode(this);
-      return shadyData && shadyData.__onCallbackListeners && shadyData.__onCallbackListeners[property];
-    },
-    configurable: true
-  };
-});
+if (!utils.settings.preferPerformance) {
+
+  eventPropertyNames.forEach(property => {
+    HTMLElementPatches[property] = {
+      /** @this {HTMLElement} */
+      set: function(fn) {
+        const shadyData = ensureShadyDataForNode(this);
+        const eventName = property.substring(2);
+        if (!shadyData.__onCallbackListeners) {
+          shadyData.__onCallbackListeners = {};
+        }
+        shadyData.__onCallbackListeners[property] && this.removeEventListener(eventName, shadyData.__onCallbackListeners[property]);
+        this[utils.SHADY_PREFIX + 'addEventListener'](eventName, fn);
+        shadyData.__onCallbackListeners[property] = fn;
+      },
+      /** @this {HTMLElement} */
+      get() {
+        const shadyData = shadyDataForNode(this);
+        return shadyData && shadyData.__onCallbackListeners && shadyData.__onCallbackListeners[property];
+      },
+      configurable: true
+    };
+  });
+
+}
 

--- a/packages/shadydom/src/patches/Node.js
+++ b/packages/shadydom/src/patches/Node.js
@@ -80,7 +80,9 @@ function scheduleObserver(node, addedNode, removedNode) {
   if (observer) {
     if (addedNode) {
       if (addedNode.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-        observer.addedNodes.push(...addedNode.childNodes);
+        for (let i = 0, l = addedNode.childNodes.length; i < l; i++) {
+          observer.addedNodes.push(addedNode.childNodes[i]);
+        }
       } else {
         observer.addedNodes.push(addedNode);
       }

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -85,8 +85,10 @@ if (utils.settings.inUse) {
     // `insertBefore` (when the node is being moved from a location where it
     // was logically positioned in the DOM); when setting `className`/`class`;
     // when calling `querySelector|All`; when setting `textContent` or
-    // `innerHTML`.
-    'wrapIfNeeded': utils.settings.noPatch === true ? wrap : patch,
+    // `innerHTML`; `getRootNode`; `addEventListener`.
+    'wrapIfNeeded': utils.settings.noPatch === true ||
+      (utils.settings.noPatch === 'on-demand' && !utils.settings.hasDescriptors) ?
+      wrap : patch,
     'Wrapper': Wrapper,
     'composedPath': composedPath,
     // Set to true to avoid patching regular platform property names. When set,

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -78,6 +78,7 @@ if (utils.settings.inUse) {
     'handlesDynamicScoping': true,
     // Ensure the node is wrapped. This should be used when `noPatch` is set
     // to ensure Shadow DOM compatible DOM operation.
+    // Note, wrap falls back to patch so that it ensures API "always just works"
     'wrap': utils.settings.noPatch ? wrap : patch,
     // When code should be compatible with `noPatch` `true` and `on-demand`
     // settings, `wrapIfNeeded` can be used for optimal performance (v. `wrap`)
@@ -87,9 +88,9 @@ if (utils.settings.inUse) {
     // when calling `querySelector|All`; when setting `textContent` or
     // `innerHTML`; `addEventListener`; and all scope specific API's like
     // `getRootNode`, `isConnected`, `slot`, `assignedSlot`, `assignedNodes`.
-    'wrapIfNeeded': utils.settings.noPatch === true ||
-      (utils.settings.noPatch === 'on-demand' && !utils.settings.hasDescriptors) ?
-      wrap : patch,
+    // Note, `wrapIfNeeded` falls back to a pass through to preserve optimal
+    // performance.
+    'wrapIfNeeded': utils.settings.noPatch === true ? wrap : n => n,
     'Wrapper': Wrapper,
     'composedPath': composedPath,
     // Set to true to avoid patching regular platform property names. When set,

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -85,7 +85,8 @@ if (utils.settings.inUse) {
     // `insertBefore` (when the node is being moved from a location where it
     // was logically positioned in the DOM); when setting `className`/`class`;
     // when calling `querySelector|All`; when setting `textContent` or
-    // `innerHTML`; `getRootNode`; `addEventListener`.
+    // `innerHTML`; `addEventListener`; and all scope specific API's like
+    // `getRootNode`, `isConnected`, `slot`, `assignedSlot`, `assignedNodes`.
     'wrapIfNeeded': utils.settings.noPatch === true ||
       (utils.settings.noPatch === 'on-demand' && !utils.settings.hasDescriptors) ?
       wrap : patch,

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -26,7 +26,7 @@ import {patchInsideElementAccessors, patchOutsideElementAccessors} from './patch
 import {patchEvents, patchClick, composedPath} from './patch-events.js';
 import {ShadyRoot} from './attach-shadow.js';
 import {wrap, Wrapper} from './wrapper.js';
-import {addShadyPrefixedProperties, applyPatches} from './patch-prototypes.js';
+import {addShadyPrefixedProperties, applyPatches, patchShadowOnElement} from './patch-prototypes.js';
 
 
 if (utils.settings.inUse) {
@@ -121,6 +121,9 @@ if (utils.settings.inUse) {
     applyPatches();
     // Patch click event behavior only if we're patching
     patchClick()
+  } else if (utils.settings.patchOnDemand) {
+    // in noPatch, do patch `attachShadow` and `shadowRoot`
+    patchShadowOnElement();
   }
 
   // For simplicity, patch events unconditionally.

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -26,7 +26,7 @@ import {patchInsideElementAccessors, patchOutsideElementAccessors} from './patch
 import {patchEvents, patchClick, composedPath} from './patch-events.js';
 import {ShadyRoot} from './attach-shadow.js';
 import {wrap, Wrapper} from './wrapper.js';
-import {addShadyPrefixedProperties, applyPatches, patchShadowOnElement} from './patch-prototypes.js';
+import {addShadyPrefixedProperties, applyPatches, patchShadowOnElement, patchElementProto} from './patch-prototypes.js';
 
 
 if (utils.settings.inUse) {
@@ -83,8 +83,10 @@ if (utils.settings.inUse) {
     // This setting provides a small performance boost, but requires all DOM API
     // access that requires Shadow DOM behavior to be proxied via `ShadyDOM.wrap`.
     'noPatch': utils.settings.noPatch,
+    'patchOnDemand': utils.settings.patchOnDemand,
     'nativeMethods': nativeMethods,
-    'nativeTree': nativeTree
+    'nativeTree': nativeTree,
+    'patchElementProto': patchElementProto
   };
 
   window['ShadyDOM'] = ShadyDOM;

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -139,7 +139,9 @@ if (utils.settings.inUse) {
     // Patch click event behavior only if we're patching
     patchClick()
   } else if (utils.settings.patchOnDemand) {
-    // in noPatch, do patch `attachShadow` and `shadowRoot`
+    // In `on-demand` patching, do patch `attachShadow` and `shadowRoot`.
+    // These are the only patched properties in `on-demand` mode and these
+    // patches kick off patching "on-demand" for other nodes.
     patchShadowOnElement();
   }
 

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -21,7 +21,7 @@ settings.hasDescriptors = Boolean(desc && desc.configurable && desc.get);
 settings.inUse = settings['force'] || !settings.hasNativeShadowDOM;
 settings.noPatch = /** @type {string|boolean} */(settings['noPatch'] || false);
 settings.preferPerformance = settings['preferPerformance'];
-settings.patchOnDemand = (settings.noPatch === 'on-demand');
+settings.patchOnDemand = (settings.noPatch === 'on-demand') && settings.hasDescriptors;
 /* eslint-enable */
 
 const IS_IE = navigator.userAgent.match('Trident');

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -21,7 +21,7 @@ settings.hasDescriptors = Boolean(desc && desc.configurable && desc.get);
 settings.inUse = settings['force'] || !settings.hasNativeShadowDOM;
 settings.noPatch = /** @type {string|boolean} */(settings['noPatch'] || false);
 settings.preferPerformance = settings['preferPerformance'];
-settings.patchOnDemand = (settings.noPatch === 'on-demand') && settings.hasDescriptors;
+settings.patchOnDemand = (settings.noPatch === 'on-demand');
 /* eslint-enable */
 
 const IS_IE = navigator.userAgent.match('Trident');

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -19,8 +19,9 @@ const desc = Object.getOwnPropertyDescriptor(Node.prototype, 'firstChild');
 /* eslint-disable */
 settings.hasDescriptors = Boolean(desc && desc.configurable && desc.get);
 settings.inUse = settings['force'] || !settings.hasNativeShadowDOM;
-settings.noPatch = settings['noPatch'] || false;
+settings.noPatch = /** @type {string|boolean} */(settings['noPatch'] || false);
 settings.preferPerformance = settings['preferPerformance'];
+settings.patchOnDemand = (settings.noPatch === 'on-demand');
 /* eslint-enable */
 
 const IS_IE = navigator.userAgent.match('Trident');

--- a/packages/shadydom/tests/active-element.html
+++ b/packages/shadydom/tests/active-element.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     window.defineTestElement = function(name, connected) {
-      var template = ShadyDOM.wrap(document).querySelector('#' + name);
+      var template = ShadyDOM.wrapIfNeeded(document).querySelector('#' + name);
       // es5 compat class
       function Klass() {
         const self = (window.Reflect && Reflect.construct)
@@ -60,8 +60,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             connected.call(this);
           }
           if (template) {
-            ShadyDOM.wrap(this).attachShadow({mode: 'open'});
-            ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(ShadyDOM.wrap(document).importNode(template.content, true));
+            ShadyDOM.wrapIfNeeded(this).attachShadow({mode: 'open'});
+            ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(ShadyDOM.wrapIfNeeded(document).importNode(template.content, true));
           }
         }
       }
@@ -247,233 +247,233 @@ suite('activeElement', function() {
 
   suiteSetup(function() {
     // NOTE: need to patch document for `activeElement`
-    r = ShadyDOM.wrap(document).querySelector('x-shadow-host-root');
-      r_l = ShadyDOM.wrap(r).querySelector('x-shadow-host-root-light');
-      r_0 = ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).querySelector('x-shadow-host-root-0');
-        r_0_l = ShadyDOM.wrap(r_0).querySelector('x-shadow-host-root-0-light');
-        r_0_0 = ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).querySelector('x-shadow-host-root-0-0');
-          r_0_0_l = ShadyDOM.wrap(r_0_0).querySelector('x-shadow-host-root-0-0-light');
-            r_0_0_l_0 = ShadyDOM.wrap(ShadyDOM.wrap(r_0_0_l).shadowRoot).querySelector('x-shadow-host-root-0-0-light-0');
-        r_0_1 = ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).querySelector('x-shadow-host-root-0-1');
-          r_0_1_l = ShadyDOM.wrap(r_0_1).querySelector('x-shadow-host-root-0-1-light');
-      r_1 = ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).querySelector('x-shadow-host-root-1');
-        r_1_l = ShadyDOM.wrap(r_1).querySelector('x-shadow-host-root-1-light');
-          r_1_l_0 = ShadyDOM.wrap(ShadyDOM.wrap(r_1_l).shadowRoot).querySelector('x-shadow-host-root-1-light-0');
-        r_1_0 = ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).querySelector('x-shadow-host-root-1-0');
-          r_1_0_l = ShadyDOM.wrap(r_1_0).querySelector('x-shadow-host-root-1-0-light');
-        r_1_1 = ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).querySelector('x-shadow-host-root-1-1');
-          r_1_1_l = ShadyDOM.wrap(r_1_1).querySelector('x-shadow-host-root-1-1-light');
+    r = ShadyDOM.wrapIfNeeded(document).querySelector('x-shadow-host-root');
+      r_l = ShadyDOM.wrapIfNeeded(r).querySelector('x-shadow-host-root-light');
+      r_0 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).querySelector('x-shadow-host-root-0');
+        r_0_l = ShadyDOM.wrapIfNeeded(r_0).querySelector('x-shadow-host-root-0-light');
+        r_0_0 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).querySelector('x-shadow-host-root-0-0');
+          r_0_0_l = ShadyDOM.wrapIfNeeded(r_0_0).querySelector('x-shadow-host-root-0-0-light');
+            r_0_0_l_0 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0_l).shadowRoot).querySelector('x-shadow-host-root-0-0-light-0');
+        r_0_1 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).querySelector('x-shadow-host-root-0-1');
+          r_0_1_l = ShadyDOM.wrapIfNeeded(r_0_1).querySelector('x-shadow-host-root-0-1-light');
+      r_1 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).querySelector('x-shadow-host-root-1');
+        r_1_l = ShadyDOM.wrapIfNeeded(r_1).querySelector('x-shadow-host-root-1-light');
+          r_1_l_0 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_l).shadowRoot).querySelector('x-shadow-host-root-1-light-0');
+        r_1_0 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).querySelector('x-shadow-host-root-1-0');
+          r_1_0_l = ShadyDOM.wrapIfNeeded(r_1_0).querySelector('x-shadow-host-root-1-0-light');
+        r_1_1 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).querySelector('x-shadow-host-root-1-1');
+          r_1_1_l = ShadyDOM.wrapIfNeeded(r_1_1).querySelector('x-shadow-host-root-1-1-light');
   });
 
   test('r.focus()', function() {
     r.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_l.focus()', function() {
     r_l.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r_l, 'document.activeElement === r_l');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r_l, 'document.activeElement === r_l');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_0.focus()', function() {
     r_0.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_0');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_0');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_0_l.focus()', function() {
     r_0_l.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_0_l, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_0_l');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_0_l, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_0_l');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
 
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_0_0.focus()', function() {
     r_0_0.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_0');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, r_0_0, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === r_0_0');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_0');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, r_0_0, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === r_0_0');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_0_0_l.focus()', function() {
     r_0_0_l.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_0');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, r_0_0_l, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === r_0_0_l');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_0');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, r_0_0_l, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === r_0_0_l');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_0_0_l_0.focus()', function() {
     r_0_0_l_0.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_0');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, r_0_0_l, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === r_0_0_l');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0_l).shadowRoot).activeElement, r_0_0_l_0, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0_l).shadowRoot).activeElement === r_0_0_l_0');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_0');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, r_0_0_l, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === r_0_0_l');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0_l).shadowRoot).activeElement, r_0_0_l_0, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0_l).shadowRoot).activeElement === r_0_0_l_0');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_0_1.focus()', function() {
     r_0_1.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_0');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, r_0_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === r_0_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_0');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, r_0_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === r_0_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_0_1_l.focus()', function() {
     r_0_1_l.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_0');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, r_0_1_l, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === r_0_1_l');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_0, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_0');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, r_0_1_l, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === r_0_1_l');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_1.focus()', function() {
     r_1.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_1_l.focus()', function() {
     r_1_l.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_1_l, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_1_l');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_1_l, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_1_l');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_1_l_0.focus()', function() {
     r_1_l_0.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_1_l, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_1_l');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_l).shadowRoot).activeElement, r_1_l_0, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === r_1_l_0');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_1_l, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_1_l');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_l).shadowRoot).activeElement, r_1_l_0, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === r_1_l_0');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_1_0.focus()', function() {
     r_1_0.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, r_1_0, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === r_1_0');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, r_1_0, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === r_1_0');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_1_0_l.focus()', function() {
     r_1_0_l.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, r_1_0_l, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === r_1_0_l');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, r_1_0_l, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === r_1_0_l');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_1_1.focus()', function() {
     r_1_1.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, r_1_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === r_1_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, r_1_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === r_1_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('r_1_1_l.focus()', function() {
     r_1_1_l.focus();
 
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, r_1_1_l, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === r_1_1_l');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, r_1_1_l, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === r_1_1_l');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('setting activeElement on document has no effect', function() {
@@ -481,35 +481,35 @@ suite('activeElement', function() {
     try {
       document.activeElement = "abc";
     } catch(e) {}
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, r_1_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === r_1_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, r_1_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === r_1_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('setting activeElement on a shadow root has no effect', function() {
     r_1_1.focus();
     try {
-      ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement = "abc";
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement = "abc";
     } catch(e) {}
-    assert.equal(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement === r');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r).shadowRoot).activeElement === r_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_0_1).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement, r_1_1, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1).shadowRoot).activeElement === r_1_1');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_0).shadowRoot).activeElement === null');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrap(ShadyDOM.wrap(r_1_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement === r');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement, r_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).shadowRoot).activeElement === r_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_0_1).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement, r_1_1, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1).shadowRoot).activeElement === r_1_1');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_0).shadowRoot).activeElement === null');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement, null, 'ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r_1_1).shadowRoot).activeElement === null');
   });
 
   test('activeElement correctly updated after it gets removed from the document', function() {
-    ShadyDOM.wrap(r).focus();
-    ShadyDOM.wrap(ShadyDOM.wrap(r).parentNode).removeChild(r);
-    assert.notEqual(ShadyDOM.wrap(document)._activeElement, r, 'document.activeElement !== r');
+    ShadyDOM.wrapIfNeeded(r).focus();
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(r).parentNode).removeChild(r);
+    assert.notEqual(ShadyDOM.wrapIfNeeded(document)._activeElement, r, 'document.activeElement !== r');
   });
 });
 

--- a/packages/shadydom/tests/event-path.html
+++ b/packages/shadydom/tests/event-path.html
@@ -513,14 +513,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const fn = function(e) {
         path = e.composedPath();
       }
-      ShadyDOM.wrapIfNeeded(el).addEventListener('foo', fn);
+      ShadyDOM.wrap(el).addEventListener('foo', fn);
       const e = new Event('foo', {composed: true});
-      ShadyDOM.wrapIfNeeded(el).dispatchEvent(e);
+      ShadyDOM.wrap(el).dispatchEvent(e);
       assert.deepEqual([el, document.body, document.documentElement, document, window], path);
       path = null;
-      ShadyDOM.wrapIfNeeded(el).removeEventListener('foo', fn);
+      ShadyDOM.wrap(el).removeEventListener('foo', fn);
       const e2 = new Event('foo', {composed: true});
-      ShadyDOM.wrapIfNeeded(el).dispatchEvent(e2);
+      ShadyDOM.wrap(el).dispatchEvent(e2);
       assert.isNull(path);
     });
 
@@ -782,7 +782,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('capturing event listeners fire correctly for focus and blur', function() {
       let el = createEnabledElement('x-focus');
       let timeStamp;
-      ShadyDOM.wrapIfNeeded(el).addEventListener('focus', function(e) {
+      ShadyDOM.wrap(el).addEventListener('focus', function(e) {
         timeStamp = e.timeStamp;
       }, true);
       el.fireComposed();
@@ -817,7 +817,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         a.href = 'http://localhost/foo.html';
         ShadyDOM.wrapIfNeeded(a).textContent = 'link!';
         ShadyDOM.wrapIfNeeded(root).appendChild(a)
-        ShadyDOM.wrapIfNeeded(el).addEventListener('foo', function(event) {
+        ShadyDOM.wrap(el).addEventListener('foo', function(event) {
           let path = event.composedPath();
           pathCompare([a, root, el, document.body, document.documentElement, document, window], path);
         });

--- a/packages/shadydom/tests/event-path.html
+++ b/packages/shadydom/tests/event-path.html
@@ -33,7 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     window.brokenClickFn = (() => {
       let brokenComposed = false;
       const div = document.createElement('div');
-      ShadyDOM.wrap(div).addEventListener('click', (e) => {
+      ShadyDOM.wrapIfNeeded(div).addEventListener('click', (e) => {
         brokenComposed = e.composed === false;
       });
       div.click();
@@ -46,7 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     window.defineTestElement = function(name, connected, mixin) {
-      let template = ShadyDOM.wrap(document).querySelector('#' + name);
+      let template = ShadyDOM.wrapIfNeeded(document).querySelector('#' + name);
       // es5 compat class
       function Klass() {
         const self = (window.Reflect && Reflect.construct)
@@ -67,8 +67,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!this._initialized) {
           this._initialized = true;
           if (template) {
-            ShadyDOM.wrap(this).attachShadow({mode: 'open'});
-            ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(ShadyDOM.wrap(document).importNode(template.content, true));
+            ShadyDOM.wrapIfNeeded(this).attachShadow({mode: 'open'});
+            ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(ShadyDOM.wrapIfNeeded(document).importNode(template.content, true));
           }
           if (connected) {
             connected.call(this);
@@ -96,13 +96,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
     <script>
     defineTestElement('x-event-scoped', function() {
-      this.scoped = ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).querySelector('#scoped');
+      this.scoped = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).querySelector('#scoped');
       this.hostEvents = [];
       this.childEvents = [];
-      ShadyDOM.wrap(this).addEventListener('composed', this.hostHandler.bind(this));
-      ShadyDOM.wrap(this).addEventListener('scoped', this.hostHandler.bind(this));
-      ShadyDOM.wrap(this.scoped).addEventListener('composed', this.childHandler.bind(this));
-      ShadyDOM.wrap(this.scoped).addEventListener('scoped', this.childHandler.bind(this));
+      ShadyDOM.wrapIfNeeded(this).addEventListener('composed', this.hostHandler.bind(this));
+      ShadyDOM.wrapIfNeeded(this).addEventListener('scoped', this.hostHandler.bind(this));
+      ShadyDOM.wrapIfNeeded(this.scoped).addEventListener('composed', this.childHandler.bind(this));
+      ShadyDOM.wrapIfNeeded(this.scoped).addEventListener('scoped', this.childHandler.bind(this));
     }, {
       hostHandler: function(e) {
         this.hostEvents.push({
@@ -119,11 +119,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       },
       fireComposed: function() {
-        return ShadyDOM.wrap(this.scoped).dispatchEvent(
+        return ShadyDOM.wrapIfNeeded(this.scoped).dispatchEvent(
           new Event('composed', {composed: true, bubbles: true}));
       },
       fireScoped: function(){
-        return ShadyDOM.wrap(this.scoped).dispatchEvent(
+        return ShadyDOM.wrapIfNeeded(this.scoped).dispatchEvent(
           new Event('scoped', {bubbles: true}));
       }
     });
@@ -134,7 +134,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
     <script>
     defineTestElement('x-event-scoped-window', function() {
-      this.scoped = ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).querySelector('#scoped');
+      this.scoped = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).querySelector('#scoped');
       this.windowEvents = [];
       ShadyDOM.wrap(window).addEventListener('composed', this.windowHandler.bind(this));
       ShadyDOM.wrap(window).addEventListener('scoped', this.windowHandler.bind(this));
@@ -147,11 +147,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       },
       fireComposed: function() {
-        return ShadyDOM.wrap(this.scoped).dispatchEvent(
+        return ShadyDOM.wrapIfNeeded(this.scoped).dispatchEvent(
           new Event('composed', {composed: true, bubbles: true}));
       },
       fireScoped: function(){
-        return ShadyDOM.wrap(this.scoped).dispatchEvent(
+        return ShadyDOM.wrapIfNeeded(this.scoped).dispatchEvent(
           new Event('scoped', {bubbles: true}));
       }
     });
@@ -162,7 +162,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
     <script>
     defineTestElement('x-event-scoped-document', function() {
-      this.scoped = ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).querySelector('#scoped');
+      this.scoped = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).querySelector('#scoped');
       this.documentEvents = [];
       ShadyDOM.wrap(document).addEventListener('composed', this.handler.bind(this));
       ShadyDOM.wrap(document).addEventListener('scoped', this.handler.bind(this));
@@ -175,11 +175,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       },
       fireComposed: function() {
-        return ShadyDOM.wrap(this.scoped).dispatchEvent(
+        return ShadyDOM.wrapIfNeeded(this.scoped).dispatchEvent(
           new Event('composed', {composed: true, bubbles: true}));
       },
       fireScoped: function(){
-        return ShadyDOM.wrap(this.scoped).dispatchEvent(
+        return ShadyDOM.wrapIfNeeded(this.scoped).dispatchEvent(
           new Event('scoped', {bubbles: true}));
       }
     });
@@ -196,20 +196,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
   defineTestElement('x-focus', function() {
     this.events = [];
-    this.child = ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).querySelector('#child');
-    ShadyDOM.wrap(this).addEventListener('focus', this.focusHandler.bind(this));
-    ShadyDOM.wrap(this.child).addEventListener('focus', this.focusHandler.bind(this));
+    this.child = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).querySelector('#child');
+    ShadyDOM.wrapIfNeeded(this).addEventListener('focus', this.focusHandler.bind(this));
+    ShadyDOM.wrapIfNeeded(this.child).addEventListener('focus', this.focusHandler.bind(this));
   }, {
     focusHandler: function(e) {
       this.events.push(e.target);
     },
     fireComposed: function() {
       let ev = new Event('focus', {composed: true});
-      ShadyDOM.wrap(this.child).dispatchEvent(ev);
+      ShadyDOM.wrapIfNeeded(this.child).dispatchEvent(ev);
     },
     fireScoped: function() {
       let ev = new Event('focus');
-      ShadyDOM.wrap(this.child).dispatchEvent(ev);
+      ShadyDOM.wrapIfNeeded(this.child).dispatchEvent(ev);
     }
   });
   </script>
@@ -222,11 +222,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.tabIndex = -1;
       this.events = [];
       this.lastFocus = null;
-      this.child = ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).querySelector('#child');
-      ShadyDOM.wrap(this).addEventListener('focus', this.focusHandler.bind(this));
-      ShadyDOM.wrap(this).addEventListener('blur', this.focusHandler.bind(this));
-      ShadyDOM.wrap(this.child).addEventListener('focus', this.focusHandler.bind(this));
-      ShadyDOM.wrap(this.child).addEventListener('blur', this.focusHandler.bind(this));
+      this.child = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).querySelector('#child');
+      ShadyDOM.wrapIfNeeded(this).addEventListener('focus', this.focusHandler.bind(this));
+      ShadyDOM.wrapIfNeeded(this).addEventListener('blur', this.focusHandler.bind(this));
+      ShadyDOM.wrapIfNeeded(this.child).addEventListener('focus', this.focusHandler.bind(this));
+      ShadyDOM.wrapIfNeeded(this.child).addEventListener('blur', this.focusHandler.bind(this));
     }, {
       focusHandler(e) {
         this.events.push({type: e.type, target: e.target, relatedTarget: e.relatedTarget});
@@ -240,10 +240,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
   <script>
   defineTestElement('x-a', function() {
-    this.child = ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).querySelector('#child');
-    this.child2 = ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).querySelector('#child2');
-    ShadyDOM.wrap(this).addEventListener('foo', this.fooHandler.bind(this));
-    ShadyDOM.wrap(this.child).addEventListener('foo', this.childFooHandler.bind(this));
+    this.child = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).querySelector('#child');
+    this.child2 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).querySelector('#child2');
+    ShadyDOM.wrapIfNeeded(this).addEventListener('foo', this.fooHandler.bind(this));
+    ShadyDOM.wrapIfNeeded(this.child).addEventListener('foo', this.childFooHandler.bind(this));
   }, {
     fooHandler: function(e) {
       this.event = {target: e.target, relatedTarget: e.relatedTarget};
@@ -266,16 +266,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   function createEnabledElement(tag) {
     let e = document.createElement(tag);
-    ShadyDOM.wrap(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
     return e;
   }
 
   function stampNodes(selector) {
-    let t = ShadyDOM.wrap(document).querySelector(selector);
-    let dom = ShadyDOM.wrap(document).importNode(t.content, true);
+    let t = ShadyDOM.wrapIfNeeded(document).querySelector(selector);
+    let dom = ShadyDOM.wrapIfNeeded(document).importNode(t.content, true);
     let c = document.createElement('div');
-    ShadyDOM.wrap(c).appendChild(dom);
-    ShadyDOM.wrap(document.body).appendChild(c);
+    ShadyDOM.wrapIfNeeded(c).appendChild(dom);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(c);
     return c;
   }
 
@@ -293,14 +293,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       el.fireComposed();
       assert.equal(el.hostEvents[0].target, el);
       assert.equal(el.childEvents[0].target, el.scoped);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('window events retarget', function() {
       let el = createEnabledElement('x-event-scoped-window');
       el.fireComposed();
       assert.equal(el.windowEvents[0].target, el);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('window remove event listener', function() {
@@ -308,13 +308,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let listener = function() {
         el.windowListenerEvents = el.windowListenerEvents ? el.windowListenerEvents+1 : 1;
       };
-      ShadyDOM.wrap(window).addEventListener("composed", listener);
+      ShadyDOM.wrapIfNeeded(window).addEventListener("composed", listener);
       el.fireComposed();
       assert.equal(1, el.windowListenerEvents);
-      ShadyDOM.wrap(window).removeEventListener("composed", listener);
+      ShadyDOM.wrapIfNeeded(window).removeEventListener("composed", listener);
       el.fireComposed();
       assert.equal(1, el.windowListenerEvents);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('implicit window add/remove event listener', function() {
@@ -322,27 +322,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let listener = function(e) {
         el.windowListenerEvents = el.windowListenerEvents ? el.windowListenerEvents+1 : 1;
       };
-      ShadyDOM.wrap(window).addEventListener("composed", listener);
+      ShadyDOM.wrapIfNeeded(window).addEventListener("composed", listener);
       el.fireComposed();
       assert.equal(1, el.windowListenerEvents);
-      ShadyDOM.wrap(window).removeEventListener("composed", listener);
+      ShadyDOM.wrapIfNeeded(window).removeEventListener("composed", listener);
       el.fireComposed();
       assert.equal(1, el.windowListenerEvents);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('scoped event does not reach window', function() {
       let el = createEnabledElement('x-event-scoped-window');
       el.fireScoped();
       assert.equal(0, el.windowEvents.length);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('bubbling events reach shadowRoot', function() {
       // Create a div element with a shadow root
       const theDiv = document.createElement('div');
-      const root = ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
-      ShadyDOM.wrap(document.body).appendChild(theDiv);
+      const root = ShadyDOM.wrapIfNeeded(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(theDiv);
 
       const shadowChild = document.createElement('div');
       root.appendChild(shadowChild);
@@ -350,10 +350,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const spy = sinon.spy();
 
       // Add event listener to the shadow root
-      ShadyDOM.wrap(ShadyDOM.wrap(theDiv).shadowRoot).addEventListener('anEvent', spy);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(theDiv).shadowRoot).addEventListener('anEvent', spy);
 
       // Dispatch a bubbling event to the a shadowRoot child
-      ShadyDOM.wrap(shadowChild).dispatchEvent(new CustomEvent('anEvent', {bubbles: true}));
+      ShadyDOM.wrapIfNeeded(shadowChild).dispatchEvent(new CustomEvent('anEvent', {bubbles: true}));
 
       assert.isTrue(spy.called, 'Callback should be called on shadowRoot');
     });
@@ -361,16 +361,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('scoped composed does not reach shadowRoot', function() {
       // Create a div element with a shadow root
       const theDiv = document.createElement('div');
-      ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
-      ShadyDOM.wrap(document.body).appendChild(theDiv);
+      ShadyDOM.wrapIfNeeded(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(theDiv);
 
       const spy = sinon.spy();
 
       // Add event listener to the shadow root
-      ShadyDOM.wrap(ShadyDOM.wrap(theDiv).shadowRoot).addEventListener('composed', spy);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(theDiv).shadowRoot).addEventListener('composed', spy);
 
       // Dispatch a composed event to the div element (not its shadow root)
-      ShadyDOM.wrap(theDiv).dispatchEvent(new CustomEvent('composed', {bubbles: true, composed: true}));
+      ShadyDOM.wrapIfNeeded(theDiv).dispatchEvent(new CustomEvent('composed', {bubbles: true, composed: true}));
 
       assert.isFalse(spy.called, 'Callback should not be called on shadowRoot');
     });
@@ -378,18 +378,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('composed event on child lightdom does not reach shadowRoot', function() {
       // Create a div element with a shadow root
       const theDiv = document.createElement('div');
-      ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
-      ShadyDOM.wrap(document.body).appendChild(theDiv);
+      ShadyDOM.wrapIfNeeded(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(theDiv);
       const child = document.createElement('div');
-      ShadyDOM.wrap(theDiv).appendChild(child);
+      ShadyDOM.wrapIfNeeded(theDiv).appendChild(child);
 
       const spy = sinon.spy();
 
       // Add event listener to the shadow root
-      ShadyDOM.wrap(ShadyDOM.wrap(theDiv).shadowRoot).addEventListener('composed', spy);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(theDiv).shadowRoot).addEventListener('composed', spy);
 
       // Dispatch a composed event to a child of the div element (not its shadow root)
-      ShadyDOM.wrap(child).dispatchEvent(new CustomEvent('composed', {bubbles: true, composed: true}));
+      ShadyDOM.wrapIfNeeded(child).dispatchEvent(new CustomEvent('composed', {bubbles: true, composed: true}));
 
       assert.isFalse(spy.called, 'Callback should not be called on shadowRoot');
     });
@@ -397,21 +397,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('bubbling events reach <slot>', function() {
       // Create a div element with a shadow root
       const theDiv = document.createElement('div');
-      const root = ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
-      ShadyDOM.wrap(document.body).appendChild(theDiv);
+      const root = ShadyDOM.wrapIfNeeded(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(theDiv);
 
       const slot = document.createElement('slot');
       root.appendChild(slot);
       const child = document.createElement('div');
-      ShadyDOM.wrap(theDiv).appendChild(child);
+      ShadyDOM.wrapIfNeeded(theDiv).appendChild(child);
 
       const spy = sinon.spy();
 
       // Add event listener to the <slot>
-      ShadyDOM.wrap(slot).addEventListener('bubbling', spy);
+      ShadyDOM.wrapIfNeeded(slot).addEventListener('bubbling', spy);
 
       // Dispatch a bubbling event to the child distributed to the slot
-      ShadyDOM.wrap(child).dispatchEvent(new CustomEvent('bubbling', {bubbles: true}));
+      ShadyDOM.wrapIfNeeded(child).dispatchEvent(new CustomEvent('bubbling', {bubbles: true}));
 
       assert.isTrue(spy.called, 'Callback should be called on <slot>');
     });
@@ -419,8 +419,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('events on slot parent do not reach <slot>', function() {
       // Create a div element with a shadow root
       const theDiv = document.createElement('div');
-      const root = ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
-      ShadyDOM.wrap(document.body).appendChild(theDiv);
+      const root = ShadyDOM.wrapIfNeeded(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(theDiv);
 
       const slot = document.createElement('slot');
       const slotParent = document.createElement('div');
@@ -430,7 +430,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const spy = sinon.spy();
 
       // Add event listener to the shadow root
-      ShadyDOM.wrap(slot).addEventListener('bubbling', spy);
+      ShadyDOM.wrapIfNeeded(slot).addEventListener('bubbling', spy);
 
       // Dispatch a bubbling event to the slot parent
       slotParent.dispatchEvent(new CustomEvent('bubbling', {bubbles: true}));
@@ -441,8 +441,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('events bubbling to slot parent do not reach <slot>', function() {
       // Create a div element with a shadow root
       const theDiv = document.createElement('div');
-      const root = ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
-      ShadyDOM.wrap(document.body).appendChild(theDiv);
+      const root = ShadyDOM.wrapIfNeeded(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(theDiv);
 
       const slot = document.createElement('slot');
       root.appendChild(slot);
@@ -452,10 +452,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const spy = sinon.spy();
 
       // Add event listener to the <slot>
-      ShadyDOM.wrap(slot).addEventListener('bubbling', spy);
+      ShadyDOM.wrapIfNeeded(slot).addEventListener('bubbling', spy);
 
       // Dispatch a bubbling event to a sibling of the slot (not distributed to it)
-      ShadyDOM.wrap(child).dispatchEvent(new CustomEvent('bubbling', {bubbles: true}));
+      ShadyDOM.wrapIfNeeded(child).dispatchEvent(new CustomEvent('bubbling', {bubbles: true}));
 
       assert.isFalse(spy.called, 'Callback should not be called on <slot>');
     });
@@ -464,7 +464,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let el = createEnabledElement('x-event-scoped-document');
       el.fireComposed();
       assert.equal(el.documentEvents[0].target, el);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('document remove event listener', function() {
@@ -472,27 +472,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let listener = function(e) {
         el.listenerEvents = el.listenerEvents ? el.listenerEvents+1 : 1;
       };
-      ShadyDOM.wrap(document).addEventListener("composed", listener);
+      ShadyDOM.wrapIfNeeded(document).addEventListener("composed", listener);
       el.fireComposed();
       assert.equal(1, el.listenerEvents);
-      ShadyDOM.wrap(document).removeEventListener("composed", listener);
+      ShadyDOM.wrapIfNeeded(document).removeEventListener("composed", listener);
       el.fireComposed();
       assert.equal(1, el.listenerEvents);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('scoped event does not reach document', function() {
       let el = createEnabledElement('x-event-scoped-document');
       el.fireScoped();
       assert.equal(0, el.documentEvents.length);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('event.composedPath is consistent', function() {
       let el = createEnabledElement('x-event-scoped');
       el.fireComposed();
       assert.equal(el.hostEvents.length, el.childEvents.length);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('`composed` flag controls event propagation through roots', function() {
@@ -504,23 +504,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(el.childEvents.length, 2);
       assert.equal(el.childEvents[0].type, 'scoped');
       assert.equal(el.childEvents[1].type, 'composed');
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('event patching (add and remove) works on any elements', function() {
-      let el = ShadyDOM.wrap(document).querySelector('#globalpatch');
+      let el = ShadyDOM.wrapIfNeeded(document).querySelector('#globalpatch');
       let path;
       const fn = function(e) {
         path = e.composedPath();
       }
-      ShadyDOM.wrap(el).addEventListener('foo', fn);
+      ShadyDOM.wrapIfNeeded(el).addEventListener('foo', fn);
       const e = new Event('foo', {composed: true});
-      ShadyDOM.wrap(el).dispatchEvent(e);
+      ShadyDOM.wrapIfNeeded(el).dispatchEvent(e);
       assert.deepEqual([el, document.body, document.documentElement, document, window], path);
       path = null;
-      ShadyDOM.wrap(el).removeEventListener('foo', fn);
+      ShadyDOM.wrapIfNeeded(el).removeEventListener('foo', fn);
       const e2 = new Event('foo', {composed: true});
-      ShadyDOM.wrap(el).dispatchEvent(e2);
+      ShadyDOM.wrapIfNeeded(el).dispatchEvent(e2);
       assert.isNull(path);
     });
 
@@ -533,16 +533,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const scopedFn = function() {
         scoped = true;
       }
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).addEventListener('composed', composedFn);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).addEventListener('scoped', scopedFn);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).addEventListener('composed', composedFn);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).addEventListener('scoped', scopedFn);
       el.fireComposed()
       el.fireScoped();
       assert.isTrue(composed, 'composed events should fire on shadowRoot');
       assert.isTrue(scoped, 'scoped events should fire on shadowRoot');
       composed = null;
       scoped = null;
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).removeEventListener('composed', composedFn);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).removeEventListener('scoped', scopedFn);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).removeEventListener('composed', composedFn);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).removeEventListener('scoped', scopedFn);
       el.fireComposed()
       el.fireScoped();
       assert.isNull(composed, 'composed events should not fire on shadowRoot after listener removed');
@@ -553,14 +553,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const parent = document.createElement('div');
       document.body.appendChild(parent);
       const child = document.createElement('div');
-      ShadyDOM.wrap(parent).appendChild(child);
+      ShadyDOM.wrapIfNeeded(parent).appendChild(child);
       let heardEvent = false;
       function listener(e) {
         assert.equal(e.eventPhase, Event.BUBBLING_PHASE);
         heardEvent = true;
       }
-      ShadyDOM.wrap(parent).addEventListener('foo', listener);
-      ShadyDOM.wrap(child).dispatchEvent(new Event('foo', {bubbles: true}));
+      ShadyDOM.wrapIfNeeded(parent).addEventListener('foo', listener);
+      ShadyDOM.wrapIfNeeded(child).dispatchEvent(new Event('foo', {bubbles: true}));
       ShadyDOM.flush();
       assert.isTrue(heardEvent);
       document.body.removeChild(parent);
@@ -572,15 +572,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       const parent = document.createElement('div');
       parent.id = "parent";
-      ShadyDOM.wrap(document.body).appendChild(parent);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(parent);
       const child = document.createElement('div');
       child.id = "child";
-      ShadyDOM.wrap(parent).appendChild(child);
+      ShadyDOM.wrapIfNeeded(parent).appendChild(child);
       const parentMouseDownSpy = sinon.spy();
       const childMouseDownSpy = sinon.spy();
-      ShadyDOM.wrap(parent).onmousedown = parentMouseDownSpy;
-      ShadyDOM.wrap(child).onmousedown = childMouseDownSpy;
-      ShadyDOM.wrap(child).dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
+      ShadyDOM.wrapIfNeeded(parent).onmousedown = parentMouseDownSpy;
+      ShadyDOM.wrapIfNeeded(child).onmousedown = childMouseDownSpy;
+      ShadyDOM.wrapIfNeeded(child).dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
       assert.isTrue(childMouseDownSpy.calledBefore(parentMouseDownSpy), 'Event handler on child should be called first');
     });
 
@@ -590,7 +590,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(el.events.length, 2);
       assert.equal(el.events[0], el.child);
       assert.equal(el.events[1], el);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('focusin and focusout events patched to be always composed', function() {
@@ -600,23 +600,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.skip();
       }
       const theDiv = document.createElement('div');
-      ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrapIfNeeded(theDiv).attachShadow({mode: 'open'});
 
       const theInput = document.createElement('input');
-      ShadyDOM.wrap(ShadyDOM.wrap(theDiv).shadowRoot).appendChild(theInput);
-      ShadyDOM.wrap(document.body).appendChild(theDiv);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(theDiv).shadowRoot).appendChild(theInput);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(theDiv);
 
       const dispatchMockEvent = function(type, target) {
         // do not set composed to force patching needed for Firefox 61
         const e = new CustomEvent(type);
-        ShadyDOM.wrap(target).dispatchEvent(e);
+        ShadyDOM.wrapIfNeeded(target).dispatchEvent(e);
       };
 
       const focusinSpy = sinon.spy();
       const focusoutSpy = sinon.spy();
 
-      ShadyDOM.wrap(theInput).addEventListener('focusin', focusinSpy);
-      ShadyDOM.wrap(theInput).addEventListener('focusout', focusoutSpy);
+      ShadyDOM.wrapIfNeeded(theInput).addEventListener('focusin', focusinSpy);
+      ShadyDOM.wrapIfNeeded(theInput).addEventListener('focusout', focusoutSpy);
 
       dispatchMockEvent('focusin', theInput);
       dispatchMockEvent('focusout', theInput);
@@ -640,7 +640,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let input = createEnabledElement('input');
       const callback = (event) => {
         assert.isTrue(event.currentTarget === input, 'CurrentTarget should be input, not window');
-        ShadyDOM.wrap(document.body).removeChild(input);
+        ShadyDOM.wrapIfNeeded(document.body).removeChild(input);
         done();
       };
       ShadyDOM.wrap(input).onfocus = callback;
@@ -656,7 +656,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let input = createEnabledElement('input');
       const callback = (event) => {
         assert.isTrue(event.currentTarget === input, 'CurrentTarget should be input, not window');
-        ShadyDOM.wrap(document.body).removeChild(input);
+        ShadyDOM.wrapIfNeeded(document.body).removeChild(input);
         done();
       };
       ShadyDOM.wrap(input).onblur = callback;
@@ -676,7 +676,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       el.fireScoped();
       assert.equal(el.events.length, 1);
       assert.equal(el.events[0], el.child);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('focusing a shadow nested node does not blur the parent', function(done) {
@@ -687,15 +687,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.skip();
       }
       let el = createEnabledElement('x-nested-focus');
-      ShadyDOM.wrap(el).focus();
-      ShadyDOM.wrap(el.child).focus();
+      ShadyDOM.wrapIfNeeded(el).focus();
+      ShadyDOM.wrapIfNeeded(el.child).focus();
       setTimeout(function() {
         let filtered = el.events.map(ev => ({type: ev.type, target: ev.target}));
         assert.deepEqual(filtered, [
           {type: 'focus', target: el},
           {type: 'focus', target: el.child}
         ]);
-        ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+        ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
         done();
       });
     });
@@ -714,7 +714,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       }
       return Promise.resolve().then(function() {
-        ShadyDOM.wrap(el.child).focus();
+        ShadyDOM.wrapIfNeeded(el.child).focus();
         return wait();
       }).then(function() {
         assert.deepEqual(el.events, [
@@ -722,7 +722,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           {type: 'focus', target: el, relatedTarget: null},
         ]);
       }).then(function(){
-        ShadyDOM.wrap(el).focus();
+        ShadyDOM.wrapIfNeeded(el).focus();
         return wait();
       }).then(function() {
         assert.deepEqual(el.events, [
@@ -731,7 +731,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           {type: 'blur', target: el.child, relatedTarget: el}
         ]);
       }).then(function() {
-        ShadyDOM.wrap(el).blur();
+        ShadyDOM.wrapIfNeeded(el).blur();
         return wait();
       }).then(function() {
         assert.deepEqual(el.events, [
@@ -741,48 +741,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           {type: 'blur', target: el, relatedTarget: null}
         ]);
       }).then(function() {
-        ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+        ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
       });
     });
 
     test('composed relatedTarget retargets', function() {
       let container = stampNodes('#relatedtarget');
-      let a = ShadyDOM.wrap(container).children[0];
-      let b = ShadyDOM.wrap(container).children[1];
+      let a = ShadyDOM.wrapIfNeeded(container).children[0];
+      let b = ShadyDOM.wrapIfNeeded(container).children[1];
       let ev = new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: b.child});
-      ShadyDOM.wrap(a.child).dispatchEvent(ev);
+      ShadyDOM.wrapIfNeeded(a.child).dispatchEvent(ev);
       assert.property(a, 'childEvent');
       assert.deepEqual(a.childEvent, {target: a.child, relatedTarget: b});
       assert.property(a, 'event');
       assert.deepEqual(a.event, {target: a, relatedTarget: b});
-      ShadyDOM.wrap(ShadyDOM.wrap(container).parentNode).removeChild(container);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(container).parentNode).removeChild(container);
     });
 
     test('events do not fire if relatedtarget and target are the same node after retargeting', function() {
       let container = stampNodes('#relatedtarget');
-      let a = ShadyDOM.wrap(container).children[0];
+      let a = ShadyDOM.wrapIfNeeded(container).children[0];
       let ev = new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: a.child2});
-      ShadyDOM.wrap(a.child).dispatchEvent(ev);
+      ShadyDOM.wrapIfNeeded(a.child).dispatchEvent(ev);
       assert.property(a, 'childEvent');
       assert.deepEqual(a.childEvent, {target: a.child, relatedTarget: a.child2});
       assert.notProperty(a, 'event');
-      ShadyDOM.wrap(ShadyDOM.wrap(container).parentNode).removeChild(container);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(container).parentNode).removeChild(container);
     });
 
     test('events fire if relatedtarget and target are the same node without retargeting', function() {
       let container = stampNodes('#relatedtarget');
-      let a = ShadyDOM.wrap(container).children[0];
+      let a = ShadyDOM.wrapIfNeeded(container).children[0];
       let ev = new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: a});
-      ShadyDOM.wrap(a).dispatchEvent(ev);
+      ShadyDOM.wrapIfNeeded(a).dispatchEvent(ev);
       assert.property(a, 'event');
       assert.deepEqual(a.event, {target: a, relatedTarget: a});
-      ShadyDOM.wrap(ShadyDOM.wrap(container).parentNode).removeChild(container);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(container).parentNode).removeChild(container);
     });
 
     test('capturing event listeners fire correctly for focus and blur', function() {
       let el = createEnabledElement('x-focus');
       let timeStamp;
-      ShadyDOM.wrap(el).addEventListener('focus', function(e) {
+      ShadyDOM.wrapIfNeeded(el).addEventListener('focus', function(e) {
         timeStamp = e.timeStamp;
       }, true);
       el.fireComposed();
@@ -790,7 +790,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(el.events.length, 2);
       assert.equal(el.events[0], el.child);
       assert.equal(el.events[1], el);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     test('.focus() and .blur() work as expected', function() {
@@ -800,32 +800,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.skip();
       }
       let el = createEnabledElement('x-nested-focus');
-      ShadyDOM.wrap(el.child).focus();
-      assert.equal(ShadyDOM.wrap(document)._activeElement, el);
-      assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).activeElement, el.child);
-      ShadyDOM.wrap(el).blur();
-      assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).activeElement, null);
-      assert.notEqual(ShadyDOM.wrap(document)._activeElement, el);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+      ShadyDOM.wrapIfNeeded(el.child).focus();
+      assert.equal(ShadyDOM.wrapIfNeeded(document)._activeElement, el);
+      assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).activeElement, el.child);
+      ShadyDOM.wrapIfNeeded(el).blur();
+      assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).activeElement, null);
+      assert.notEqual(ShadyDOM.wrapIfNeeded(document)._activeElement, el);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
     });
 
     suite('composedPath', function() {
       test('does not confuse anchor with shadowroot', function() {
         let el = document.createElement('div');
-        let root = ShadyDOM.wrap(el).attachShadow({mode: 'open'});
+        let root = ShadyDOM.wrapIfNeeded(el).attachShadow({mode: 'open'});
         let a = document.createElement('a');
         a.href = 'http://localhost/foo.html';
-        ShadyDOM.wrap(a).textContent = 'link!';
-        ShadyDOM.wrap(root).appendChild(a)
-        ShadyDOM.wrap(el).addEventListener('foo', function(event) {
+        ShadyDOM.wrapIfNeeded(a).textContent = 'link!';
+        ShadyDOM.wrapIfNeeded(root).appendChild(a)
+        ShadyDOM.wrapIfNeeded(el).addEventListener('foo', function(event) {
           let path = event.composedPath();
           pathCompare([a, root, el, document.body, document.documentElement, document, window], path);
         });
-        ShadyDOM.wrap(document.body).appendChild(el);
+        ShadyDOM.wrapIfNeeded(document.body).appendChild(el);
         ShadyDOM.flush();
         let ev = new Event('foo', {bubbles: true, composed: true});
-        ShadyDOM.wrap(a).dispatchEvent(ev);
-        ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
+        ShadyDOM.wrapIfNeeded(a).dispatchEvent(ev);
+        ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).parentNode).removeChild(el);
       });
 
       test('focus events retarget', function() {
@@ -837,35 +837,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         let top = document.createElement('div');
         top.id = 'top';
-        ShadyDOM.wrap(top).attachShadow({mode: 'open'});
+        ShadyDOM.wrapIfNeeded(top).attachShadow({mode: 'open'});
         track(top);
-        track(ShadyDOM.wrap(top).shadowRoot);
+        track(ShadyDOM.wrapIfNeeded(top).shadowRoot);
 
         let mid = document.createElement('div');
-        ShadyDOM.wrap(mid).attachShadow({mode: 'open'});
+        ShadyDOM.wrapIfNeeded(mid).attachShadow({mode: 'open'});
         mid.id = 'mid';
         track(mid);
-        track(ShadyDOM.wrap(mid).shadowRoot);
+        track(ShadyDOM.wrapIfNeeded(mid).shadowRoot);
         let slot = document.createElement('slot');
-        ShadyDOM.wrap(ShadyDOM.wrap(mid).shadowRoot).appendChild(slot);
+        ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(mid).shadowRoot).appendChild(slot);
         track(slot);
-        ShadyDOM.wrap(ShadyDOM.wrap(top).shadowRoot).appendChild(mid);
+        ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(top).shadowRoot).appendChild(mid);
 
         let bot = document.createElement('div');
         bot.id = 'bot';
         track(bot);
-        ShadyDOM.wrap(mid).appendChild(bot);
+        ShadyDOM.wrapIfNeeded(mid).appendChild(bot);
 
-        ShadyDOM.wrap(document.body).appendChild(top);
+        ShadyDOM.wrapIfNeeded(document.body).appendChild(top);
 
         ShadyDOM.flush();
 
         let ev = new Event('focus', {composed: true});
-        ShadyDOM.wrap(bot).dispatchEvent(ev);
+        ShadyDOM.wrapIfNeeded(bot).dispatchEvent(ev);
 
         assert.equal(recv.length, 2);
         pathCompare([bot, top], recv);
-        ShadyDOM.wrap(ShadyDOM.wrap(top).parentNode).removeChild(top);
+        ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(top).parentNode).removeChild(top);
       });
 
       test('composedPath of events from non-Node subclasses works', function() {
@@ -885,16 +885,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       let sawClick = false;
       const top = document.createElement('div');
-      ShadyDOM.wrap(top).addEventListener('click', () => {
+      ShadyDOM.wrapIfNeeded(top).addEventListener('click', () => {
         sawClick = true;
       });
-      ShadyDOM.wrap(top).attachShadow({mode: 'open'});
+      ShadyDOM.wrapIfNeeded(top).attachShadow({mode: 'open'});
       const inner = document.createElement('div');
-      ShadyDOM.wrap(ShadyDOM.wrap(top).shadowRoot).appendChild(inner);
-      ShadyDOM.wrap(document.body).appendChild(top);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(top).shadowRoot).appendChild(inner);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(top);
       inner.click();
       assert.equal(sawClick, true, 'host should see click from inner node');
-      ShadyDOM.wrap(ShadyDOM.wrap(top).parentNode).removeChild(top);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(top).parentNode).removeChild(top);
     });
 
     test('delayed target does not throw', function(done) {
@@ -906,26 +906,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         });
       });
-      ShadyDOM.wrap(document.body).appendChild(button);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(button);
       button.click();
-      ShadyDOM.wrap(document.body).removeChild(button);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(button);
     });
 
     test('delayed relatedTarget does not throw', function(done) {
       const div = document.createElement('div');
-      ShadyDOM.wrap(div).addEventListener('mouseover', (e) => {
+      ShadyDOM.wrapIfNeeded(div).addEventListener('mouseover', (e) => {
         setTimeout(() => {
           assert.equal(e.relatedTarget, document);
           assert.isNotOk(e.currentTarget);
           done();
         });
       });
-      ShadyDOM.wrap(document.body).appendChild(div);
-      ShadyDOM.wrap(div).dispatchEvent(new MouseEvent('mouseover', {bubbles: true, cancelable: true, relatedTarget: document}));
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).dispatchEvent(new MouseEvent('mouseover', {bubbles: true, cancelable: true, relatedTarget: document}));
     });
 
     test('events on window', function() {
-      const w = ShadyDOM.wrap(window);
+      const w = ShadyDOM.wrapIfNeeded(window);
       let heardEvent = false;
       w.addEventListener('foo', (e) => {
         heardEvent = true;

--- a/packages/shadydom/tests/loader.js
+++ b/packages/shadydom/tests/loader.js
@@ -1,6 +1,6 @@
 ShadyDOM = {
   force: true,
-  noPatch: !!window.location.search.match('noPatch'),
+  noPatch: window.location.search.match('noPatch=on-demand') ? 'on-demand' : !!window.location.search.match('noPatch'),
   preferPerformance: !!window.location.search.match('preferPerformance')
 };
 
@@ -28,5 +28,3 @@ if (ShadyDOM.noPatch) {
   loadSD();
   loadCE();
 }
-
-

--- a/packages/shadydom/tests/observeChildren.html
+++ b/packages/shadydom/tests/observeChildren.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="wct-browser-config.js"></script>
   <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
   <script>
-    ShadyDOM = {force: true, noPatch: window.location.search.match('noPatch')};
+    ShadyDOM = {force: true, noPatch: window.location.search.match('noPatch=on-demand') ? 'on-demand' : !!window.location.search.match('noPatch')};
   </script>
   <script src="../shadydom.min.js"></script>
 
@@ -30,8 +30,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   suite('observeChildren', function() {
 
   function makeShadowRootWithSlot(element) {
-    ShadyDOM.wrap(element).attachShadow({mode: 'open'});
-    ShadyDOM.wrap(ShadyDOM.wrap(element).shadowRoot).appendChild(document.createElement('slot'));
+    ShadyDOM.wrapIfNeeded(element).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(element).shadowRoot).appendChild(document.createElement('slot'));
   }
 
   test('observeChildren on element without shadowRoot', function() {
@@ -74,25 +74,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     var observer = ShadyDOM.observeChildren(d, handler);
     var child1 = document.createElement('div');
-    ShadyDOM.wrap(d).appendChild(child1);
+    ShadyDOM.wrapIfNeeded(d).appendChild(child1);
     handler(observer.takeRecords());
     assert.equal(recorded[0].addedNodes.length, 1);
     assert.equal(recorded[0].addedNodes[0], child1);
     recorded = [];
     var child2 = document.createElement('div');
-    ShadyDOM.wrap(d).appendChild(child2);
+    ShadyDOM.wrapIfNeeded(d).appendChild(child2);
     handler(observer.takeRecords());
     assert.equal(recorded[0].addedNodes.length, 1);
     assert.equal(recorded[0].addedNodes[0], child2);
     recorded = [];
-    ShadyDOM.wrap(d).removeChild(child1);
-    ShadyDOM.wrap(d).removeChild(child2);
+    ShadyDOM.wrapIfNeeded(d).removeChild(child1);
+    ShadyDOM.wrapIfNeeded(d).removeChild(child2);
     handler(observer.takeRecords());
     assert.equal(recorded[0].removedNodes.length, 2);
     assert.deepEqual(recorded[0].removedNodes, [child1, child2]);
     recorded = [];
     ShadyDOM.unobserveChildren(observer);
-    ShadyDOM.wrap(d).appendChild(child1);
+    ShadyDOM.wrapIfNeeded(d).appendChild(child1);
     handler(observer.takeRecords());
     assert.deepEqual(recorded, []);
   });
@@ -105,7 +105,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       recorded = info;
     });
     var child1 = document.createElement('div');
-    ShadyDOM.wrap(d).appendChild(child1);
+    ShadyDOM.wrapIfNeeded(d).appendChild(child1);
     observer.takeRecords();
     assert.equal(recorded, null);
   });
@@ -118,25 +118,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       recorded = info;
     });
     var child1 = document.createElement('div');
-    ShadyDOM.wrap(d).appendChild(child1);
+    ShadyDOM.wrapIfNeeded(d).appendChild(child1);
     setTimeout(function() {
       assert.equal(recorded[0].addedNodes.length, 1);
       assert.equal(recorded[0].addedNodes[0], child1);
       recorded = null;
       var child2 = document.createElement('div');
-      ShadyDOM.wrap(d).appendChild(child2);
+      ShadyDOM.wrapIfNeeded(d).appendChild(child2);
       setTimeout(function() {
         assert.equal(recorded[0].addedNodes.length, 1);
         assert.equal(recorded[0].addedNodes[0], child2);
         recorded = null;
-        ShadyDOM.wrap(d).removeChild(child1);
-        ShadyDOM.wrap(d).removeChild(child2);
+        ShadyDOM.wrapIfNeeded(d).removeChild(child1);
+        ShadyDOM.wrapIfNeeded(d).removeChild(child2);
         setTimeout(function() {
           assert.equal(recorded[0].removedNodes.length, 2);
           assert.deepEqual(recorded[0].removedNodes, [child1, child2]);
           recorded = null;
           ShadyDOM.unobserveChildren(observer);
-          ShadyDOM.wrap(d).appendChild(child1);
+          ShadyDOM.wrapIfNeeded(d).appendChild(child1);
           setTimeout(function() {
             assert.equal(recorded, null);
             done();

--- a/packages/shadydom/tests/runner.html
+++ b/packages/shadydom/tests/runner.html
@@ -18,42 +18,57 @@
   var suites = [
     'shady.html',
     'shady.html?noPatch=true',
+    'shady.html?noPatch=on-demand',
 
     'shady-dynamic.html',
     'shady-dynamic.html?noPatch=true',
+    'shady-dynamic.html?noPatch=on-demand',
     'shady-dynamic.html?forceCustomElements=true',
     'shady-dynamic.html?noPatch=true&forceCustomElements=true',
+    'shady-dynamic.html?noPatch=on-demand&forceCustomElements=true',
 
     'shady-content.html',
     'shady-content.html?noPatch=true',
+    'shady-content.html?noPatch=on-demand',
     'shady-content.html?forceCustomElements=true',
     'shady-content.html?noPatch=true&forceCustomElements=true',
+    'shady-content.html?noPatch=on-demand&forceCustomElements=true',
 
     'slotchange.html',
     'slotchange.html?noPatch=true',
+    'slotchange.html?noPatch=on-demand',
 
     'observeChildren.html',
     'observeChildren.html?noPatch=true',
+    'observeChildren.html?noPatch=on-demand',
 
     'event-path.html',
     'event-path.html?noPatch=true',
+    'event-path.html?noPatch=on-demand',
     'event-path.html?forceCustomElements=true',
     'event-path.html?noPatch=true&forceCustomElements=true',
+    'event-path.html?noPatch=on-demand&forceCustomElements=true',
 
     'slot-scenarios.html?forceCustomElements=true',
     'slot-scenarios.html?noPatch=true&forceCustomElements=true',
+    'slot-scenarios.html?noPatch=on-demand&forceCustomElements=true',
 
     'sync-style-scoping.html',
     'sync-style-scoping.html?preferPerformance=true',
     'sync-style-scoping.html?noPatch=true',
+    'sync-style-scoping.html?noPatch=on-demand',
     'sync-style-scoping.html?noPatch=true&preferPerformance=true',
+    'sync-style-scoping.html?noPatch=on-demand&preferPerformance=true',
     'sync-style-scoping.html?forceCustomElements=true',
     'sync-style-scoping.html?noPatch=true&forceCustomElements=true',
+    'sync-style-scoping.html?noPatch=on-demand&forceCustomElements=true',
 
     'active-element.html',
     'active-element.html?noPatch=true',
+    'active-element.html?noPatch=on-demand',
     'active-element.html?forceCustomElements=true',
     'active-element.html?noPatch=true&forceCustomElements=true',
+    'active-element.html?noPatch=on-demand&forceCustomElements=true',
 
     'attach-while-loading.html',
     'filter-mutations.html',

--- a/packages/shadydom/tests/shady-content.html
+++ b/packages/shadydom/tests/shady-content.html
@@ -32,14 +32,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     window.defineTestElement = function(name, connected, shadowRootInConstrutor) {
-      var template = ShadyDOM.wrap(document).querySelector('#' + name);
+      var template = ShadyDOM.wrapIfNeeded(document).querySelector('#' + name);
       // es5 compat class
       function Klass() {
         const self = (window.Reflect && Reflect.construct)
           ? Reflect.construct(HTMLElement, [], this.constructor || Klass)
           : HTMLElement.call(this);
         if (shadowRootInConstrutor) {
-          ShadyDOM.wrap(self).attachShadow({mode: 'open'});
+          ShadyDOM.wrapIfNeeded(self).attachShadow({mode: 'open'});
         }
         return self;
       }
@@ -56,15 +56,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (!this._initialized) {
           this._initialized = true;
           if (!shadowRootInConstrutor) {
-            ShadyDOM.wrap(this).attachShadow({mode: 'open'});
+            ShadyDOM.wrapIfNeeded(this).attachShadow({mode: 'open'});
           }
           if (connected) {
             connected.call(this);
           }
           if (template) {
-            ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(ShadyDOM.wrap(document).importNode(template.content, true));
+            ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(ShadyDOM.wrapIfNeeded(document).importNode(template.content, true));
           }
-          var idEls = ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).querySelectorAll('[id]');
+          var idEls = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).querySelectorAll('[id]');
           this.$ = {};
           for (var i=0; i < idEls.length; i++) {
             var el = idEls[i];
@@ -186,13 +186,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
   defineTestElement('inner-html', function() {
-    ShadyDOM.wrap(this).attachShadow({mode: 'open'});
-    ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).innerHTML = '[<slot></slot>]';
+    ShadyDOM.wrapIfNeeded(this).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).innerHTML = '[<slot></slot>]';
   });
 
   defineTestElement('use-inner-html', function() {
-    ShadyDOM.wrap(this).attachShadow({mode: 'open'});
-    ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).innerHTML = '<inner-html>I</inner-html>[<slot></slot>]';
+    ShadyDOM.wrapIfNeeded(this).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).innerHTML = '<inner-html>I</inner-html>[<slot></slot>]';
   });
 </script>
 
@@ -208,743 +208,743 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('assignedSlot with render pending', function() {
       var el = document.createElement('x-compose-lazy-no-dist');
       var c = document.createElement('div');
-      ShadyDOM.wrap(document.body).appendChild(el);
-      var slot = ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).querySelector('slot');
-      ShadyDOM.wrap(el).appendChild(c);
-      assert.equal(ShadyDOM.wrap(c).assignedSlot, slot);
-      ShadyDOM.wrap(document.body).removeChild(el);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(el);
+      var slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).querySelector('slot');
+      ShadyDOM.wrapIfNeeded(el).appendChild(c);
+      assert.equal(ShadyDOM.wrapIfNeeded(c).assignedSlot, slot);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(el);
     });
 
     test('append div to distributing element', function() {
       var dist = document.createElement('x-dist');
-      ShadyDOM.wrap(document.body).appendChild(dist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(dist);
       // Distribute div
       var div = document.createElement('div');
-      ShadyDOM.wrap(dist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(dist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, ShadyDOM.wrap(ShadyDOM.wrap(dist).shadowRoot).querySelector('#content'));
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(dist).shadowRoot).querySelector('#content'));
       // Append to distributed div
       var div2 = document.createElement('div');
-      ShadyDOM.wrap(div).appendChild(div2);
+      ShadyDOM.wrapIfNeeded(div).appendChild(div2);
       ShadyDOM.flush();
       // Remove
-      ShadyDOM.wrap(dist).removeChild(div);
+      ShadyDOM.wrapIfNeeded(dist).removeChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(dist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(dist);
     });
 
     test('append div to non-distributing element', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Distribute div
       var div = document.createElement('div');
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
       // Append to distributed div
       var div2 = document.createElement('div');
-      ShadyDOM.wrap(div).appendChild(div2);
+      ShadyDOM.wrapIfNeeded(div).appendChild(div2);
       ShadyDOM.flush();
       // Remove
-      ShadyDOM.wrap(noDist).removeChild(div);
+      ShadyDOM.wrapIfNeeded(noDist).removeChild(div);
       ShadyDOM.flush();
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append div to shady root of distributing element', function() {
       var dist = document.createElement('x-dist');
-      ShadyDOM.wrap(document.body).appendChild(dist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(dist);
       // Append div to root
       var div = document.createElement('div');
-      ShadyDOM.wrap(ShadyDOM.wrap(dist).shadowRoot).appendChild(div);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(dist).shadowRoot).appendChild(div);
       ShadyDOM.flush();
       // Append to div in root
       var div2 = document.createElement('div');
-      ShadyDOM.wrap(div).appendChild(div2);
+      ShadyDOM.wrapIfNeeded(div).appendChild(div2);
       ShadyDOM.flush();
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(dist).shadowRoot).removeChild(div);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(dist).shadowRoot).removeChild(div);
       ShadyDOM.flush();
-      ShadyDOM.wrap(document.body).removeChild(dist);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(dist);
     });
 
     test('append div to shady root of non-distributing element', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to root
       var div = document.createElement('div');
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).appendChild(div);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(div);
       ShadyDOM.flush();
       // Append to div in root
       var div2 = document.createElement('div');
-      ShadyDOM.wrap(div).appendChild(div2);
+      ShadyDOM.wrapIfNeeded(div).appendChild(div2);
       ShadyDOM.flush();
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).removeChild(div);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(div);
       ShadyDOM.flush();
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append div to distributing element in root', function() {
       var compose = document.createElement('x-compose-dist');
-      ShadyDOM.wrap(document.body).appendChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Distribute div
       var div = document.createElement('div');
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#dist')).appendChild(div);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).appendChild(div);
       ShadyDOM.flush();
       // Append to distributed div
       var div2 = document.createElement('div');
-      ShadyDOM.wrap(div).appendChild(div2);
+      ShadyDOM.wrapIfNeeded(div).appendChild(div2);
       ShadyDOM.flush();
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#dist')).removeChild(div);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).removeChild(div);
       ShadyDOM.flush();
-      ShadyDOM.wrap(document.body).removeChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
     test('append div to non-distributing element in root', function() {
       var compose = document.createElement('x-compose-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append div to root
       var div = document.createElement('div');
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#noDist')).appendChild(div);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).appendChild(div);
       ShadyDOM.flush();
       // Append to div in root
       var div2 = document.createElement('div');
-      ShadyDOM.wrap(div).appendChild(div2);
+      ShadyDOM.wrapIfNeeded(div).appendChild(div2);
       ShadyDOM.flush();
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#noDist')).removeChild(div);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).removeChild(div);
       ShadyDOM.flush();
-      ShadyDOM.wrap(document.body).removeChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
     test('append slot to shady root of element (div first)', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
       // Append slot to shady root
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).removeChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append slot to shady root of element (slot first)', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append slot to shady root
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(slot);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).removeChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append slot to div in shady root of element (div first)', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
       // Append slot to shady root
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).querySelector('#static')).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).appendChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).querySelector('#static')).removeChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append slot to div in shady root of element (slot first)', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append slot to shady root
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).querySelector('#static')).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).appendChild(slot);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).querySelector('#static')).removeChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append slot in fragment to shady root of element (div first)', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(frag).appendChild(slot);
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(frag).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(frag);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).removeChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append slot in fragment to shady root of element (slot first)', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(frag).appendChild(slot);
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(frag).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(frag);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).removeChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append wrapped slot to shady root of element (div first)', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(wrapper).appendChild(slot);
-      ShadyDOM.wrap(frag).appendChild(wrapper);
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(wrapper).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(frag);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).removeChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append wrapped slot to shady root of element (slot first)', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(wrapper).appendChild(slot);
-      ShadyDOM.wrap(frag).appendChild(wrapper);
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(wrapper).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(frag);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).removeChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append wrapped slot to div in shady root of element (div first)', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(wrapper).appendChild(slot);
-      ShadyDOM.wrap(frag).appendChild(wrapper);
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).querySelector('#static')).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(wrapper).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).appendChild(frag);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      var s = ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).querySelector('#static');
-      ShadyDOM.wrap(s).removeChild(wrapper);
+      var s = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static');
+      ShadyDOM.wrapIfNeeded(s).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append wrapped slot to div in shady root of element (slot first)', function() {
       var noDist = document.createElement('x-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(noDist);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(wrapper).appendChild(slot);
-      ShadyDOM.wrap(frag).appendChild(wrapper);
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).querySelector('#static')).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(wrapper).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).appendChild(frag);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(noDist).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(noDist).shadowRoot).querySelector('#static')).removeChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(noDist);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
     test('append slot to non-distributing element in shady root of composed element (div first)', function() {
       var compose = document.createElement('x-compose-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append slot to light DOM of non-distributing element
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(compose).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
       // Append slot to non-distributing element
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#noDist')).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).appendChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#noDist')).removeChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(compose);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
     test('append slot to non-distributing element in shady root of composed element (slot first)', function() {
       var compose = document.createElement('x-compose-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append slot to light DOM of non-distributing element
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#noDist')).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).appendChild(slot);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(compose).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#noDist')).removeChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(compose);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
     test('append wrapped slot to non-distributing element in shady root of composed element (div first)', function() {
       var compose = document.createElement('x-compose-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(compose).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(wrapper).appendChild(slot);
-      ShadyDOM.wrap(frag).appendChild(wrapper);
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#noDist')).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(wrapper).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).appendChild(frag);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#noDist')).removeChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(compose);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
     test('append wrapped slot to non-distributing element in shady root of composed element (slot first)', function() {
       var compose = document.createElement('x-compose-no-dist');
-      ShadyDOM.wrap(document.body).appendChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(wrapper).appendChild(slot);
-      ShadyDOM.wrap(frag).appendChild(wrapper);
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#noDist')).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(wrapper).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).appendChild(frag);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(compose).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#noDist')).removeChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(compose);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
     test('append slot to distributing element in shady root of composed element (div first)', function() {
       var compose = document.createElement('x-compose-dist');
-      ShadyDOM.wrap(document.body).appendChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append slot to light DOM of non-distributing element
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(compose).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
       // Append slot to non-distributing element
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#dist')).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).appendChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#dist')).removeChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(compose);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
     test('append slot to distributing element in shady root of composed element (slot first)', function() {
       var compose = document.createElement('x-compose-dist');
-      ShadyDOM.wrap(document.body).appendChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append slot to non-distributing element
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#dist')).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).appendChild(slot);
       // Append slot to light DOM of non-distributing element
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(compose).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#dist')).removeChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(compose);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
     test('append wrapped slot to distributing element in shady root of composed element (div first)', function() {
       var compose = document.createElement('x-compose-dist');
-      ShadyDOM.wrap(document.body).appendChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(compose).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(wrapper).appendChild(slot);
-      ShadyDOM.wrap(frag).appendChild(wrapper);
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#dist')).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(wrapper).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).appendChild(frag);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#dist')).removeChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(compose);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
     test('append wrapped slot to distributing element in shady root of composed element (slot first)', function() {
       var compose = document.createElement('x-compose-dist');
-      ShadyDOM.wrap(document.body).appendChild(compose);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'insert');
-      ShadyDOM.wrap(wrapper).appendChild(slot);
-      ShadyDOM.wrap(frag).appendChild(wrapper);
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#dist')).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
+      ShadyDOM.wrapIfNeeded(wrapper).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).appendChild(frag);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).slot = 'insert';
-      ShadyDOM.wrap(compose).appendChild(div);
+      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
       // Remove
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(compose).shadowRoot).querySelector('#dist')).removeChild(wrapper);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-      ShadyDOM.wrap(document.body).removeChild(compose);
+      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
     test('append slot to initially un-upgraded element', function() {
-      var lazyContainer = ShadyDOM.wrap(document).querySelector('x-compose-lazy-no-dist');
-      var child = ShadyDOM.wrap(lazyContainer).firstElementChild;
+      var lazyContainer = ShadyDOM.wrapIfNeeded(document).querySelector('x-compose-lazy-no-dist');
+      var child = ShadyDOM.wrapIfNeeded(lazyContainer).firstElementChild;
       defineTestElement('x-lazy-no-dist');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(lazyContainer).shadowRoot).querySelector('#lazy')).shadowRoot).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(lazyContainer).shadowRoot).querySelector('#lazy')).shadowRoot).appendChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(slot).assignedNodes({flatten: true})[1], child);
+      assert.equal(ShadyDOM.wrapIfNeeded(slot).assignedNodes({flatten: true})[1], child);
 
     });
 
     test('append/remove multiple slots with same name (catchall) to element', function() {
       var el = document.createElement('x-dist');
-      ShadyDOM.wrap(document.body).appendChild(el);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(el);
       var frag = document.createDocumentFragment();
       var s1 = document.createElement('slot');
-      ShadyDOM.wrap(s1).innerHTML = 'fallback1';
+      ShadyDOM.wrapIfNeeded(s1).innerHTML = 'fallback1';
       var s2 = document.createElement('slot');
-      ShadyDOM.wrap(s2).innerHTML = 'fallback2';
+      ShadyDOM.wrapIfNeeded(s2).innerHTML = 'fallback2';
       var s3 = document.createElement('slot');
-      ShadyDOM.wrap(s3).innerHTML = 'fallback3';
-      ShadyDOM.wrap(frag).appendChild(s1);
-      ShadyDOM.wrap(frag).appendChild(s2);
-      ShadyDOM.wrap(frag).appendChild(s3);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(s3).innerHTML = 'fallback3';
+      ShadyDOM.wrapIfNeeded(frag).appendChild(s1);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(s2);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(s3);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(frag);
       var span = document.createElement('span');
-      ShadyDOM.wrap(span).textContent = 'hi';
-      ShadyDOM.wrap(el).appendChild(span);
+      ShadyDOM.wrapIfNeeded(span).textContent = 'hi';
+      ShadyDOM.wrapIfNeeded(el).appendChild(span);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el), 'x-disthifallback1fallback2fallback3', 'composed textContent incorrect');
-      var origSlot = ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).querySelector('slot');
-      ShadyDOM.wrap(origSlot).innerHTML = 'fallbackOrig';
+      var origSlot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).querySelector('slot');
+      ShadyDOM.wrapIfNeeded(origSlot).innerHTML = 'fallbackOrig';
       var s0 = document.createElement('slot');
-      ShadyDOM.wrap(s0).innerHTML = 'fallback0';
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).insertBefore(s0, ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).firstChild);
+      ShadyDOM.wrapIfNeeded(s0).innerHTML = 'fallback0';
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).insertBefore(s0, ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).firstChild);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el), 'hix-distfallbackOrigfallback1fallback2fallback3', 'composed textContent incorrect');
       var s4 = document.createElement('slot');
-      ShadyDOM.wrap(s4).innerHTML = 'fallback4';
+      ShadyDOM.wrapIfNeeded(s4).innerHTML = 'fallback4';
       var s5 = document.createElement('slot');
-      ShadyDOM.wrap(s5).innerHTML = 'fallback5';
+      ShadyDOM.wrapIfNeeded(s5).innerHTML = 'fallback5';
       var slotContainer = document.createElement('span');
-      ShadyDOM.wrap(slotContainer).appendChild(s4);
-      ShadyDOM.wrap(slotContainer).appendChild(s5);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).insertBefore(slotContainer, s2);
+      ShadyDOM.wrapIfNeeded(slotContainer).appendChild(s4);
+      ShadyDOM.wrapIfNeeded(slotContainer).appendChild(s5);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).insertBefore(slotContainer, s2);
       var s6 = document.createElement('slot');
-      ShadyDOM.wrap(s6).innerHTML = 'fallback6';
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(s6);
+      ShadyDOM.wrapIfNeeded(s6).innerHTML = 'fallback6';
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(s6);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el), 'hix-distfallbackOrigfallback1fallback4fallback5fallback2fallback3fallback6', 'composed textContent incorrect');
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).removeChild(slotContainer);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).removeChild(slotContainer);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el), 'hix-distfallbackOrigfallback1fallback2fallback3fallback6', 'composed textContent incorrect');
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).removeChild(s0);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).removeChild(s1);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).removeChild(s2);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).removeChild(s3);
-      ShadyDOM.wrap(ShadyDOM.wrap(origSlot).parentNode).removeChild(origSlot);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).removeChild(s0);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).removeChild(s1);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).removeChild(s2);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).removeChild(s3);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(origSlot).parentNode).removeChild(origSlot);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el), 'x-disthi', 'composed textContent incorrect');
-      ShadyDOM.wrap(document.body).removeChild(el);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(el);
     });
 
     test('append/remove multiple slots with same name to element', function() {
       var el = document.createElement('x-dist');
-      ShadyDOM.wrap(document.body).appendChild(el);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(el);
       var frag = document.createDocumentFragment();
       var s1 = document.createElement('slot');
-      ShadyDOM.wrap(s1).setAttribute('name', 'foo');
-      ShadyDOM.wrap(s1).innerHTML = 'fallback1';
+      ShadyDOM.wrapIfNeeded(s1).setAttribute('name', 'foo');
+      ShadyDOM.wrapIfNeeded(s1).innerHTML = 'fallback1';
       var s2 = document.createElement('slot');
-      ShadyDOM.wrap(s2).setAttribute('name', 'foo');
-      ShadyDOM.wrap(s2).innerHTML = 'fallback2';
+      ShadyDOM.wrapIfNeeded(s2).setAttribute('name', 'foo');
+      ShadyDOM.wrapIfNeeded(s2).innerHTML = 'fallback2';
       var s3 = document.createElement('slot');
-      ShadyDOM.wrap(s3).setAttribute('name', 'foo');
-      ShadyDOM.wrap(s3).innerHTML = 'fallback3';
-      ShadyDOM.wrap(frag).appendChild(s1);
-      ShadyDOM.wrap(frag).appendChild(s2);
-      ShadyDOM.wrap(frag).appendChild(s3);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(s3).setAttribute('name', 'foo');
+      ShadyDOM.wrapIfNeeded(s3).innerHTML = 'fallback3';
+      ShadyDOM.wrapIfNeeded(frag).appendChild(s1);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(s2);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(s3);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(frag);
       var span = document.createElement('span');
-      ShadyDOM.wrap(span).textContent = 'hi';
-      ShadyDOM.wrap(el).appendChild(span);
+      ShadyDOM.wrapIfNeeded(span).textContent = 'hi';
+      ShadyDOM.wrapIfNeeded(el).appendChild(span);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el), 'x-disthifallback1fallback2fallback3', 'composed textContent incorrect');
-      var origSlot = ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).querySelector('slot');
-      ShadyDOM.wrap(origSlot).innerHTML = 'fallbackOrig';
+      var origSlot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).querySelector('slot');
+      ShadyDOM.wrapIfNeeded(origSlot).innerHTML = 'fallbackOrig';
       var s0 = document.createElement('slot');
       s0.setAttribute('name', 'foo');
-      ShadyDOM.wrap(s0).innerHTML = 'fallback0';
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).insertBefore(s0, ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).firstChild);
+      ShadyDOM.wrapIfNeeded(s0).innerHTML = 'fallback0';
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).insertBefore(s0, ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).firstChild);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el), 'fallback0x-disthifallback1fallback2fallback3', 'composed textContent incorrect');
       var s4 = document.createElement('slot');
       s4.setAttribute('name', 'foo');
-      ShadyDOM.wrap(s4).innerHTML = 'fallback4';
+      ShadyDOM.wrapIfNeeded(s4).innerHTML = 'fallback4';
       var s5 = document.createElement('slot');
       s5.setAttribute('name', 'foo');
-      ShadyDOM.wrap(s5).innerHTML = 'fallback5';
+      ShadyDOM.wrapIfNeeded(s5).innerHTML = 'fallback5';
       var slotContainer = document.createElement('span');
-      ShadyDOM.wrap(slotContainer).appendChild(s4);
-      ShadyDOM.wrap(slotContainer).appendChild(s5);
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).insertBefore(slotContainer, s2);
+      ShadyDOM.wrapIfNeeded(slotContainer).appendChild(s4);
+      ShadyDOM.wrapIfNeeded(slotContainer).appendChild(s5);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).insertBefore(slotContainer, s2);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el), 'fallback0x-disthifallback1fallback4fallback5fallback2fallback3', 'composed textContent incorrect');
-      ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).removeChild(slotContainer);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).removeChild(slotContainer);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el), 'fallback0x-disthifallback1fallback2fallback3', 'composed textContent incorrect');
-      ShadyDOM.wrap(span).slot = 'foo';
+      ShadyDOM.wrapIfNeeded(span).slot = 'foo';
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el), 'hix-distfallbackOrigfallback1fallback2fallback3', 'composed textContent incorrect');
-      ShadyDOM.wrap(document.body).removeChild(el);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(el);
     });
 
     test('change slot name duplicating existing slot names', function() {
       var el = document.createElement('x-dist-slot-name-change');
-      ShadyDOM.wrap(document.body).appendChild(el);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(el);
       var foo = document.createElement('div');
-      ShadyDOM.wrap(foo).setAttribute('slot', 'foo');
-      ShadyDOM.wrap(foo).textContent = 'fooChild';
+      ShadyDOM.wrapIfNeeded(foo).setAttribute('slot', 'foo');
+      ShadyDOM.wrapIfNeeded(foo).textContent = 'fooChild';
       var bar = document.createElement('div');
-      ShadyDOM.wrap(bar).setAttribute('slot', 'bar');
-      ShadyDOM.wrap(bar).textContent = 'barChild';
-      ShadyDOM.wrap(el).appendChild(foo);
-      ShadyDOM.wrap(el).appendChild(bar);
+      ShadyDOM.wrapIfNeeded(bar).setAttribute('slot', 'bar');
+      ShadyDOM.wrapIfNeeded(bar).textContent = 'barChild';
+      ShadyDOM.wrapIfNeeded(el).appendChild(foo);
+      ShadyDOM.wrapIfNeeded(el).appendChild(bar);
       ShadyDOM.flush();
-      assert.deepEqual(ShadyDOM.wrap(el.$.f1).assignedNodes(), [foo]);
-      assert.deepEqual(ShadyDOM.wrap(el.$.b1).assignedNodes(), [bar]);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(el.$.f1).assignedNodes(), [foo]);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(el.$.b1).assignedNodes(), [bar]);
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'fooChildfoo2');
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c2), 'barChildbar2');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'foo');
-      ShadyDOM.wrap(slot).appendChild(document.createTextNode('test'));
-      ShadyDOM.wrap(el.$.c1).appendChild(slot);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'foo');
+      ShadyDOM.wrapIfNeeded(slot).appendChild(document.createTextNode('test'));
+      ShadyDOM.wrapIfNeeded(el.$.c1).appendChild(slot);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'fooChildfoo2test');
-      ShadyDOM.wrap(slot).setAttribute('name', 'bar');
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'bar');
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'fooChildfoo2barChild');
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c2), 'bar1bar2');
-      ShadyDOM.wrap(el.$.f1).setAttribute('name', 'bar');
+      ShadyDOM.wrapIfNeeded(el.$.f1).setAttribute('name', 'bar');
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'barChildfooChildtest');
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c2), 'bar1bar2');
-      ShadyDOM.wrap(el.$.f2).setAttribute('name', 'bar');
+      ShadyDOM.wrapIfNeeded(el.$.f2).setAttribute('name', 'bar');
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'barChildfoo2test');
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c2), 'bar1bar2');
-      ShadyDOM.wrap(slot).setAttribute('name', 'foo');
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'foo');
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'barChildfoo2fooChild');
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c2), 'bar1bar2');
-      ShadyDOM.wrap(el.$.f2).setAttribute('name', 'foo');
+      ShadyDOM.wrapIfNeeded(el.$.f2).setAttribute('name', 'foo');
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'barChildfooChildtest');
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c2), 'bar1bar2');
-      ShadyDOM.wrap(el.$.f1).setAttribute('name', 'foo');
+      ShadyDOM.wrapIfNeeded(el.$.f1).setAttribute('name', 'foo');
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'fooChildfoo2test');
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c2), 'barChildbar2');
-      ShadyDOM.wrap(document.body).removeChild(el);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(el);
     });
 
     test('composition around slots', function() {
       var el = document.createElement('x-dist-slot-name-change');
-      ShadyDOM.wrap(document.body).appendChild(el);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(el);
       ShadyDOM.flush();
       var a = document.createElement('div');
-      ShadyDOM.wrap(a).textContent = 'a';
-      ShadyDOM.wrap(el.$.c1).appendChild(a);
+      ShadyDOM.wrapIfNeeded(a).textContent = 'a';
+      ShadyDOM.wrapIfNeeded(el.$.c1).appendChild(a);
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'foo1foo2a');
-      ShadyDOM.wrap(el.$.c1).insertBefore(a, el.$.f2);
+      ShadyDOM.wrapIfNeeded(el.$.c1).insertBefore(a, el.$.f2);
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'foo1afoo2');
-      ShadyDOM.wrap(el.$.c1).insertBefore(a, el.$.f1);
+      ShadyDOM.wrapIfNeeded(el.$.c1).insertBefore(a, el.$.f1);
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'afoo1foo2');
       var slot = document.createElement('slot');
-      ShadyDOM.wrap(slot).setAttribute('name', 'foo');
-      ShadyDOM.wrap(el.$.c1).insertBefore(slot, el.$.f2);
+      ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'foo');
+      ShadyDOM.wrapIfNeeded(el.$.c1).insertBefore(slot, el.$.f2);
       var slot2 = document.createElement('slot');
-      ShadyDOM.wrap(slot2).setAttribute('name', 'foo');
-      ShadyDOM.wrap(el.$.c1).insertBefore(slot2, el.$.f2);
+      ShadyDOM.wrapIfNeeded(slot2).setAttribute('name', 'foo');
+      ShadyDOM.wrapIfNeeded(el.$.c1).insertBefore(slot2, el.$.f2);
       ShadyDOM.flush();
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'afoo1foo2');
-      ShadyDOM.wrap(el.$.c1).insertBefore(a, slot2);
+      ShadyDOM.wrapIfNeeded(el.$.c1).insertBefore(a, slot2);
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'foo1afoo2');
-      ShadyDOM.wrap(el.$.c1).insertBefore(a, slot);
+      ShadyDOM.wrapIfNeeded(el.$.c1).insertBefore(a, slot);
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'foo1afoo2');
-      ShadyDOM.wrap(el.$.c1).insertBefore(a, el.$.f1);
+      ShadyDOM.wrapIfNeeded(el.$.c1).insertBefore(a, el.$.f1);
       assert.equal(ShadyDOM.nativeTree.textContent(el.$.c1), 'afoo1foo2');
     });
 
     test('composed children distributed', function() {
       var host = document.createElement('x-dist');
-      ShadyDOM.wrap(document.body).appendChild(host);
-      var target = ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelector('#distWrapper');
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(host);
+      var target = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).querySelector('#distWrapper');
       var s0 = document.createElement('span');
       var frag = document.createDocumentFragment();
       var s1 = document.createElement('span');
       var s2 = document.createElement('span');
       var s3 = document.createElement('span');
-      ShadyDOM.wrap(frag).appendChild(s1);
-      ShadyDOM.wrap(frag).appendChild(s2);
-      ShadyDOM.wrap(frag).appendChild(s3);
-      ShadyDOM.wrap(host).appendChild(s0);
-      ShadyDOM.wrap(host).insertBefore(frag, s0);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(s1);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(s2);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(s3);
+      ShadyDOM.wrapIfNeeded(host).appendChild(s0);
+      ShadyDOM.wrapIfNeeded(host).insertBefore(frag, s0);
       ShadyDOM.flush();
       var c$ = Array.from(getComposedChildNodes(target));
       assert.deepEqual(c$, [s1, s2, s3, s0]);
-      ShadyDOM.wrap(host).removeChild(s1);
-      ShadyDOM.wrap(host).removeChild(s2);
-      ShadyDOM.wrap(host).removeChild(s3);
+      ShadyDOM.wrapIfNeeded(host).removeChild(s1);
+      ShadyDOM.wrapIfNeeded(host).removeChild(s2);
+      ShadyDOM.wrapIfNeeded(host).removeChild(s3);
       ShadyDOM.flush();
       c$ = Array.from(getComposedChildNodes(target));
       assert.deepEqual(c$, [s0]);
@@ -954,421 +954,421 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     test('moving children between distributing hosts', function() {
       var h1 = document.createElement('x-dist');
       var h2 = document.createElement('x-dist');
-      ShadyDOM.wrap(document.body).appendChild(h1);
-      ShadyDOM.wrap(document.body).appendChild(h2);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h1);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h2);
       ShadyDOM.flush();
       var d = document.createElement('div');
-      ShadyDOM.wrap(h1).appendChild(d);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h2).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h2).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h1).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h2).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h2).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(document.body).removeChild(h1);
-      ShadyDOM.wrap(document.body).removeChild(h2);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h1);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h2);
     });
 
     test('moving children between distributing hosts (parsed child)', function() {
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).innerHTML = '<x-dist><div></div></x-dist>';
-      var h1 = ShadyDOM.wrap(div).firstChild;
+      ShadyDOM.wrapIfNeeded(div).innerHTML = '<x-dist><div></div></x-dist>';
+      var h1 = ShadyDOM.wrapIfNeeded(div).firstChild;
       var h2 = document.createElement('x-dist');
-      ShadyDOM.wrap(document.body).appendChild(div);
-      ShadyDOM.wrap(document.body).appendChild(h2);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(div);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h2);
       ShadyDOM.flush();
-      var d = ShadyDOM.wrap(h1).firstElementChild;
+      var d = ShadyDOM.wrapIfNeeded(h1).firstElementChild;
       assert.equal(d.localName, 'div');
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h2).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h2).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h1).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h2).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h2).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(document.body).removeChild(div);
-      ShadyDOM.wrap(document.body).removeChild(h2);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(div);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h2);
     });
 
     test('moving children between distributing host and fragment', function() {
       var h1 = document.createElement('x-dist');
       var h2 = createPatchedDocumentFragment();
-      ShadyDOM.wrap(document.body).appendChild(h1);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h1);
       ShadyDOM.flush();
       var d = document.createElement('div');
-      ShadyDOM.wrap(h1).appendChild(d);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h1).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(document.body).removeChild(h1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h1);
     });
 
     test('moving children between distributing host and fragment (parsed child)', function() {
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).innerHTML = '<x-dist><div></div></x-dist>';
-      var h1 = ShadyDOM.wrap(div).firstChild;
+      ShadyDOM.wrapIfNeeded(div).innerHTML = '<x-dist><div></div></x-dist>';
+      var h1 = ShadyDOM.wrapIfNeeded(div).firstChild;
       var h2 = createPatchedDocumentFragment();;
-      ShadyDOM.wrap(document.body).appendChild(h1);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h1);
       ShadyDOM.flush();
-      var d = ShadyDOM.wrap(h1).firstElementChild;
+      var d = ShadyDOM.wrapIfNeeded(h1).firstElementChild;
       assert.equal(d.localName, 'div');
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
       ShadyDOM.wrap(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(document.body).removeChild(h1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h1);
     });
 
     test('moving children between distributing hosts with deep insertion points', function() {
       var h1 = document.createElement('x-dist-inside-deep-tree');
       var h2 = document.createElement('x-dist-inside-deep-tree');
-      ShadyDOM.wrap(document.body).appendChild(h1);
-      ShadyDOM.wrap(document.body).appendChild(h2);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h1);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h2);
       ShadyDOM.flush();
       var d = document.createElement('div');
-      ShadyDOM.wrap(h1).appendChild(d);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h2).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h2).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h1).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h2).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h2).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(document.body).removeChild(h1);
-      ShadyDOM.wrap(document.body).removeChild(h2);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h1);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h2);
     });
 
     test('moving children between distributing hosts with deep insertion points (parsed child)', function() {
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).innerHTML = '<x-dist-inside-deep-tree><div></div></x-dist-inside-deep-tree>';
-      var h1 = ShadyDOM.wrap(div).firstChild;
+      ShadyDOM.wrapIfNeeded(div).innerHTML = '<x-dist-inside-deep-tree><div></div></x-dist-inside-deep-tree>';
+      var h1 = ShadyDOM.wrapIfNeeded(div).firstChild;
       var h2 = document.createElement('x-dist-inside-deep-tree');
-      ShadyDOM.wrap(document.body).appendChild(div);
-      ShadyDOM.wrap(document.body).appendChild(h2);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(div);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h2);
       ShadyDOM.flush();
-      var d = ShadyDOM.wrap(h1).firstElementChild;
+      var d = ShadyDOM.wrapIfNeeded(h1).firstElementChild;
       assert.equal(d.localName, 'div');
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h2).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h2).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h1).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h2).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h2).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(document.body).removeChild(div);
-      ShadyDOM.wrap(document.body).removeChild(h2);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h2).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(div);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h2);
     });
 
     test('moving children between distributing host with deep insertion and fragment', function() {
       var h1 = document.createElement('x-dist-inside-deep-tree');
       var h2 = createPatchedDocumentFragment();
-      ShadyDOM.wrap(document.body).appendChild(h1);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h1);
       ShadyDOM.flush();
       var d = document.createElement('div');
-      ShadyDOM.wrap(h1).appendChild(d);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h1).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(document.body).removeChild(h1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h1);
     });
 
     test('moving children between distributing host with deep insertion and fragment (parsed child)', function() {
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).innerHTML = '<x-dist-inside-deep-tree><div></div></x-dist-inside-deep-tree>';
-      var h1 = ShadyDOM.wrap(div).firstChild;
+      ShadyDOM.wrapIfNeeded(div).innerHTML = '<x-dist-inside-deep-tree><div></div></x-dist-inside-deep-tree>';
+      var h1 = ShadyDOM.wrapIfNeeded(div).firstChild;
       var h2 = createPatchedDocumentFragment();
-      ShadyDOM.wrap(document.body).appendChild(h1);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h1);
       ShadyDOM.flush();
-      var d = ShadyDOM.wrap(h1).firstElementChild;
+      var d = ShadyDOM.wrapIfNeeded(h1).firstElementChild;
       assert.equal(d.localName, 'div');
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h1).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(document.body).removeChild(h1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h1);
     });
 
     test('moving children between distributing host with shallow insertion and fragment', function() {
       var h1 = document.createElement('x-dist-simple');
       var h2 = createPatchedDocumentFragment();
-      ShadyDOM.wrap(document.body).appendChild(h1);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h1);
       ShadyDOM.flush();
       var d = document.createElement('div');
-      ShadyDOM.wrap(h1).appendChild(d);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h1).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(document.body).removeChild(h1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h1);
     });
 
     test('moving children between distributing host with shallow insertion and fragment (parsed child)', function() {
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).innerHTML = '<x-dist-simple><div></div></x-dist-simple>';
-      var h1 = ShadyDOM.wrap(div).firstChild;
+      ShadyDOM.wrapIfNeeded(div).innerHTML = '<x-dist-simple><div></div></x-dist-simple>';
+      var h1 = ShadyDOM.wrapIfNeeded(div).firstChild;
       var h2 = createPatchedDocumentFragment();
-      ShadyDOM.wrap(document.body).appendChild(h1);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(h1);
       ShadyDOM.flush();
-      var d = ShadyDOM.wrap(h1).firstElementChild;
+      var d = ShadyDOM.wrapIfNeeded(h1).firstElementChild;
       assert.equal(d.localName, 'div');
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(h1).appendChild(d);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(h1).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 1);
-      assert.equal(ShadyDOM.wrap(h1).firstElementChild, d);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 0);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).firstElementChild, d);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}), [d]);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 0);
       ShadyDOM.wrap(h2).appendChild(d);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrap(h2).childNodes.length, 1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h2).childNodes.length, 1);
       assert.equal(h2.firstChild, d);
-      assert.equal(ShadyDOM.wrap(h1).childNodes.length, 0);
-      assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
-      ShadyDOM.wrap(document.body).removeChild(h1);
+      assert.equal(ShadyDOM.wrapIfNeeded(h1).childNodes.length, 0);
+      assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(h1).shadowRoot).querySelector('#content')).assignedNodes({flatten: true}).length, 0);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(h1);
     });
 
     test('adding a document fragment clears nodes in the fragment', function() {
       var x = document.createElement('x-dist-star');
-      ShadyDOM.wrap(document.body).appendChild(x);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(x);
       var frag = document.createDocumentFragment();
       var t = document.createTextNode('hi');
       var d = document.createElement('div');
-      ShadyDOM.wrap(frag).appendChild(t);
-      ShadyDOM.wrap(frag).appendChild(d);
-      ShadyDOM.wrap(x).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(t);
+      ShadyDOM.wrapIfNeeded(frag).appendChild(d);
+      ShadyDOM.wrapIfNeeded(x).appendChild(frag);
       ShadyDOM.flush();
       assert.equal(t.parentNode, x, 'logical parent wrong');
       assert.equal(d.parentNode, x, 'logical parent wrong');
       assert.equal(frag.childNodes.length, 0, 'fragment not empty');
-      ShadyDOM.wrap(document.body).removeChild(x);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(x);
     });
 
     test('adding a non-distributing node removes the node from its current location', function() {
       var x = document.createElement('x-dist-star');
       var t = document.createTextNode('hi');
-      ShadyDOM.wrap(document.body).appendChild(t);
-      ShadyDOM.wrap(x).appendChild(t);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(t);
+      ShadyDOM.wrapIfNeeded(x).appendChild(t);
       ShadyDOM.flush();
       assert.equal(t.parentNode, x);
     });
 
     test('shadowRoot set via innerHTML that contains a <slot> and a custom element that also sets shadowRoot content via innerHTML', function() {
-      var el = ShadyDOM.wrap(document).querySelector('use-inner-html');
+      var el = ShadyDOM.wrapIfNeeded(document).querySelector('use-inner-html');
       assert.equal(ShadyDOM.nativeTree.textContent(el), '[I][A]');
     });
 
     test('elements created in inert documents correctly upgrade when added to shadow hosts with shadowRoots containing slots', function() {
       var t = document.createElement('template');
-      ShadyDOM.wrap(t).innerHTML = '<x-simple></x-simple>';
-      var clone = ShadyDOM.wrap(ShadyDOM.wrap(t.content).cloneNode(true)).firstChild;
+      ShadyDOM.wrapIfNeeded(t).innerHTML = '<x-simple></x-simple>';
+      var clone = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(t.content).cloneNode(true)).firstChild;
       var host = document.createElement('x-dist');
-      ShadyDOM.wrap(document.body).appendChild(host);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(host);
       ShadyDOM.flush();
-      ShadyDOM.wrap(host).appendChild(clone);
+      ShadyDOM.wrapIfNeeded(host).appendChild(clone);
       // NOTE: flush needed when noPatch is true since upgrade happens only then the element hits the dom via distribution.
       ShadyDOM.flush();
       assert.equal(clone._initialized, true);
       assert.equal(ShadyDOM.nativeTree.textContent(clone), 'simple');
-      ShadyDOM.wrap(document.body).removeChild(host);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(host);
     });
 
     test('creating redistribution tree asynchronously (simulated) in elements with constructor created shadowRoots', function() {
       // render an element with a shadowRoot
       var x = document.createElement('x-ctor');
       var t = document.createTextNode('hi');
-      ShadyDOM.wrap(x).appendChild(t);
-      ShadyDOM.wrap(document.body).appendChild(x);
+      ShadyDOM.wrapIfNeeded(x).appendChild(t);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(x);
       ShadyDOM.flush();
       // later attach an element that makes a shadowRoot in its constructor and a slot
       var inner = document.createElement('x-ctor');
-      ShadyDOM.wrap(inner).appendChild(document.createElement('slot'));
-      ShadyDOM.wrap(ShadyDOM.wrap(x).shadowRoot).appendChild(inner);
+      ShadyDOM.wrapIfNeeded(inner).appendChild(document.createElement('slot'));
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(x).shadowRoot).appendChild(inner);
       ShadyDOM.flush();
       // later attach a slot to that element...
-      ShadyDOM.wrap(ShadyDOM.wrap(inner).shadowRoot).appendChild(document.createElement('slot'));
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(inner).shadowRoot).appendChild(document.createElement('slot'));
       ShadyDOM.flush();
       // check rendering
       assert.deepEqual(getComposedChildNodes(inner), [t]);
@@ -1376,23 +1376,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     test('initial distribution can be flushed with `ShadyDOM.flushInitial`', function() {
       const el = document.createElement('x-dist-four');
-      ShadyDOM.wrap(document.body).appendChild(el);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(el);
       const d = document.createElement('div');
-      ShadyDOM.wrap(el).appendChild(d);
+      ShadyDOM.wrapIfNeeded(el).appendChild(d);
       assert.equal(ShadyDOM.nativeTree.innerHTML(el), '<x-dist-three><slot></slot><x-dist-two><slot></slot><x-dist-simple><slot></slot><slot id="content"></slot></x-dist-simple></x-dist-two></x-dist-three>');
-      ShadyDOM.flushInitial(ShadyDOM.wrap(el).shadowRoot);
+      ShadyDOM.flushInitial(ShadyDOM.wrapIfNeeded(el).shadowRoot);
       assert.equal(ShadyDOM.nativeTree.innerHTML(el), '<x-dist-three><x-dist-two><x-dist-simple><div></div></x-dist-simple></x-dist-two></x-dist-three>');
       document.body.removeChild(el);
     });
 
-    test('events dispatch correctly with `ShadyDOM.wrap().dispatchEvent`', function() {
+    test('events dispatch correctly with `ShadyDOM.wrapIfNeeded().dispatchEvent`', function() {
       const el = document.createElement('x-dist-four');
-      ShadyDOM.wrap(document.body).appendChild(el);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(el);
       const d = document.createElement('div');
-      ShadyDOM.wrap(el).appendChild(d);
+      ShadyDOM.wrapIfNeeded(el).appendChild(d);
       let heardEvent = false;
       el.addEventListener('foo', function() { heardEvent = true});
-      ShadyDOM.wrap(d).dispatchEvent(new Event('foo', {bubbles: true}));
+      ShadyDOM.wrapIfNeeded(d).dispatchEvent(new Event('foo', {bubbles: true}));
       assert.isTrue(heardEvent);
       document.body.removeChild(el);
     });

--- a/packages/shadydom/tests/shady-content.html
+++ b/packages/shadydom/tests/shady-content.html
@@ -222,7 +222,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var div = document.createElement('div');
       ShadyDOM.wrapIfNeeded(dist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(dist).shadowRoot).querySelector('#content'));
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(dist).shadowRoot).querySelector('#content'));
       // Append to distributed div
       var div2 = document.createElement('div');
       ShadyDOM.wrapIfNeeded(div).appendChild(div2);
@@ -230,7 +230,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Remove
       ShadyDOM.wrapIfNeeded(dist).removeChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(dist);
     });
 
@@ -241,7 +241,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var div = document.createElement('div');
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       // Append to distributed div
       var div2 = document.createElement('div');
       ShadyDOM.wrapIfNeeded(div).appendChild(div2);
@@ -325,7 +325,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
       // Append slot to shady root
@@ -333,11 +333,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
@@ -350,14 +350,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(slot);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
@@ -366,20 +366,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       // Append slot to shady root
       var slot = document.createElement('slot');
       ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).appendChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
@@ -392,14 +392,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).appendChild(slot);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
@@ -408,10 +408,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var slot = document.createElement('slot');
@@ -419,11 +419,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(frag).appendChild(slot);
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(frag);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
@@ -438,14 +438,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(frag);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
@@ -454,10 +454,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
@@ -467,11 +467,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(frag);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
@@ -488,14 +488,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).appendChild(frag);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
@@ -504,10 +504,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(document.body).appendChild(noDist);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
@@ -517,12 +517,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).appendChild(frag);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       var s = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static');
       ShadyDOM.wrapIfNeeded(s).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
@@ -539,14 +539,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).appendChild(frag);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(noDist).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(noDist).shadowRoot).querySelector('#static')).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(noDist);
     });
 
@@ -555,20 +555,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append slot to light DOM of non-distributing element
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       // Append slot to non-distributing element
       var slot = document.createElement('slot');
       ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).appendChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
@@ -581,14 +581,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).appendChild(slot);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
@@ -597,10 +597,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
@@ -610,11 +610,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).appendChild(frag);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
@@ -631,14 +631,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).appendChild(frag);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#noDist')).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
@@ -647,20 +647,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append slot to light DOM of non-distributing element
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       // Append slot to non-distributing element
       var slot = document.createElement('slot');
       ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'insert');
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).appendChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
@@ -673,14 +673,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).appendChild(slot);
       // Append slot to light DOM of non-distributing element
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).removeChild(slot);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
@@ -689,10 +689,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(document.body).appendChild(compose);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       // Append slot to shady root
       var frag = document.createDocumentFragment();
       var wrapper = document.createElement('div');
@@ -702,11 +702,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(frag).appendChild(wrapper);
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).appendChild(frag);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 
@@ -723,14 +723,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).appendChild(frag);
       // Append div to light dom
       var div = document.createElement('div');
-      ShadyDOM.wrapIfNeeded(div).slot = 'insert';
+      ShadyDOM.wrap(div).slot = 'insert';
       ShadyDOM.wrapIfNeeded(compose).appendChild(div);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, slot);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, slot);
       // Remove
       ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(compose).shadowRoot).querySelector('#dist')).removeChild(wrapper);
       ShadyDOM.flush();
-      assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+      assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
       ShadyDOM.wrapIfNeeded(document.body).removeChild(compose);
     });
 

--- a/packages/shadydom/tests/shady-dynamic.html
+++ b/packages/shadydom/tests/shady-dynamic.html
@@ -82,7 +82,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     window.defineTestElement = function(name, connected) {
-      var template = ShadyDOM.wrap(document).querySelector('#' + name);
+      var template = ShadyDOM.wrapIfNeeded(document).querySelector('#' + name);
       // es5 compat class
       function Klass() {
         const self = (window.Reflect && Reflect.construct)
@@ -108,8 +108,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             connected.call(this);
           }
           if (template) {
-            ShadyDOM.wrap(this).attachShadow({mode: 'open'});
-            ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(ShadyDOM.wrap(document).importNode(template.content, true));
+            ShadyDOM.wrapIfNeeded(this).attachShadow({mode: 'open'});
+            ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(ShadyDOM.wrapIfNeeded(document).importNode(template.content, true));
           }
         }
       }
@@ -122,7 +122,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     window.makeFocusable = function() {
-      ShadyDOM.wrap(this).setAttribute('tabIndex', -1);
+      ShadyDOM.wrapIfNeeded(this).setAttribute('tabIndex', -1);
     }
   </script>
 
@@ -214,7 +214,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template id="x-attr">Attr1</template>
   <script>
     defineTestElement('x-attr', function() {
-      ShadyDOM.wrap(this).setAttribute('slot', 'bar');
+      ShadyDOM.wrapIfNeeded(this).setAttribute('slot', 'bar');
     });
   </script>
 
@@ -222,7 +222,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template id="x-attr2">Attr2</template>
   <script>
     defineTestElement('x-attr2', function() {
-      ShadyDOM.wrap(this).slot = 'foo';
+      ShadyDOM.wrapIfNeeded(this).slot = 'foo';
     });
   </script>
 
@@ -260,11 +260,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     defineTestElement('x-deep-contains', function() {
       var e = document.createElement('div');
-      ShadyDOM.wrap(e).setAttribute('slot', 'light');
-      ShadyDOM.wrap(this).appendChild(e);
+      ShadyDOM.wrapIfNeeded(e).setAttribute('slot', 'light');
+      ShadyDOM.wrapIfNeeded(this).appendChild(e);
       e = document.createElement('div');
-      ShadyDOM.wrap(e).setAttribute('slot', 'notdistributed');
-      ShadyDOM.wrap(this).appendChild(e);
+      ShadyDOM.wrapIfNeeded(e).setAttribute('slot', 'notdistributed');
+      ShadyDOM.wrapIfNeeded(this).appendChild(e);
     });
   </script>
 
@@ -276,18 +276,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   (function() {
     class InnerElement extends HTMLElement {
       connectedCallback() {
-        const clone = ShadyDOM.wrap(document).importNode(window.innerTemplate.content, true);
-        ShadyDOM.wrap(this).attachShadow({ mode: 'open' });
-        ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(clone);
+        const clone = ShadyDOM.wrapIfNeeded(document).importNode(window.innerTemplate.content, true);
+        ShadyDOM.wrapIfNeeded(this).attachShadow({ mode: 'open' });
+        ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(clone);
       }
     }
     customElements.define('inner-element', InnerElement);
 
     class OuterElement extends HTMLElement {
       connectedCallback() {
-        const clone = ShadyDOM.wrap(document).importNode(window.outerTemplate.content, true);
-        ShadyDOM.wrap(this).attachShadow({ mode: 'open' });
-        ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(clone);
+        const clone = ShadyDOM.wrapIfNeeded(document).importNode(window.outerTemplate.content, true);
+        ShadyDOM.wrapIfNeeded(this).attachShadow({ mode: 'open' });
+        ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(clone);
       }
     }
     customElements.define('outer-element', OuterElement);
@@ -304,8 +304,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   defineTestElement('x-stamps-peer', function() {
     var span = document.createElement('span');
-    ShadyDOM.wrap(span).setAttribute('id', 'peer');
-    ShadyDOM.wrap(ShadyDOM.wrap(this).parentNode).appendChild(span);
+    ShadyDOM.wrapIfNeeded(span).setAttribute('id', 'peer');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).parentNode).appendChild(span);
   });
 </script>
 
@@ -321,15 +321,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   function createEnabledElement(tag) {
     var e = document.createElement(tag);
-    ShadyDOM.wrap(document.body).appendChild(e);
-    ShadyDOM.wrap(document.body).removeChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(e);
     return e;
   }
 
   function allInsertionPoints(e) {
     var r = [];
     while (e) {
-      e = ShadyDOM.wrap(e).assignedSlot;
+      e = ShadyDOM.wrapIfNeeded(e).assignedSlot;
       if (e) {
         r.push(e);
       }
@@ -343,81 +343,81 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   var testElementEsc;
 
   suiteSetup(function() {
-    testElement = ShadyDOM.wrap(document).querySelector('x-test');
-    testElementEsc = ShadyDOM.wrap(document).querySelector('x-test-esc');
+    testElement = ShadyDOM.wrapIfNeeded(document).querySelector('x-test');
+    testElementEsc = ShadyDOM.wrapIfNeeded(document).querySelector('x-test-esc');
   });
 
   test('mode `open` exposes `.shadowRoot`', function() {
     let div = document.createElement('div');
-    ShadyDOM.wrap(div).attachShadow({mode: 'open'});
-    assert.ok(ShadyDOM.wrap(div).shadowRoot);
+    ShadyDOM.wrapIfNeeded(div).attachShadow({mode: 'open'});
+    assert.ok(ShadyDOM.wrapIfNeeded(div).shadowRoot);
   });
 
   test('mode `closed` hides `.shadowRoot`', function() {
     let div = document.createElement('div');
-    ShadyDOM.wrap(div).attachShadow({mode: 'closed'});
-    assert.notOk(ShadyDOM.wrap(div).shadowRoot);
+    ShadyDOM.wrapIfNeeded(div).attachShadow({mode: 'closed'});
+    assert.notOk(ShadyDOM.wrapIfNeeded(div).shadowRoot);
   });
 
   test('shadowRoot.querySelector', function() {
-    var projected = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#projected');
-    assert.equal(ShadyDOM.wrap(projected).textContent, 'projected');
-    var p2 = ShadyDOM.wrap(testElement).querySelector('#projected');
+    var projected = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#projected');
+    assert.equal(ShadyDOM.wrapIfNeeded(projected).textContent, 'projected');
+    var p2 = ShadyDOM.wrapIfNeeded(testElement).querySelector('#projected');
     assert.isNull(p2);
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
     assert.equal(rere.localName, 'x-rereproject');
-    var re = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('x-reproject');
+    var re = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('x-reproject');
     assert.equal(re.localName, 'x-reproject');
-    var p = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelector('x-project');
+    var p = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelector('x-project');
     assert.equal(p.localName, 'x-project');
   });
 
   test('shadowRoot.querySelectorAll', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    var re = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('x-reproject');
-    var p = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelector('x-project');
-    var rereList = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelectorAll('*');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    var re = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('x-reproject');
+    var p = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelector('x-project');
+    var rereList = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelectorAll('*');
     assert.include(rereList, re);
     assert.equal(rereList.length, 2);
-    var reList = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelectorAll('*');
+    var reList = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelectorAll('*');
     assert.include(reList, p);
     assert.equal(reList.length, 2);
-    var pList = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).querySelectorAll('*');
+    var pList = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot).querySelectorAll('*');
     assert.equal(pList.length, 1);
   });
 
   test('shadowRoot.getElementById', function() {
-    var projected = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).getElementById('projected');
-    assert.equal(ShadyDOM.wrap(projected).textContent, 'projected');
+    var projected = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).getElementById('projected');
+    assert.equal(ShadyDOM.wrapIfNeeded(projected).textContent, 'projected');
   });
 
   test('shadowRoot.getElementByIdEscStr', function() {
-    var projected = ShadyDOM.wrap(ShadyDOM.wrap(testElementEsc).shadowRoot).getElementById('projected/escape');
-    assert.equal(ShadyDOM.wrap(projected).textContent, 'projected with id that needs escaping');
+    var projected = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElementEsc).shadowRoot).getElementById('projected/escape');
+    assert.equal(ShadyDOM.wrapIfNeeded(projected).textContent, 'projected with id that needs escaping');
   });
 
   test('element.querySelector', function() {
-    var projected = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#projected');
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    var re = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('x-reproject');
-    var p = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelector('x-project');
-    assert.equal(ShadyDOM.wrap(rere).querySelector('#projected'), projected);
-    assert(ShadyDOM.wrap(re).querySelector('slot'));
-    assert(ShadyDOM.wrap(p).querySelector('slot'));
+    var projected = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#projected');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    var re = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('x-reproject');
+    var p = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelector('x-project');
+    assert.equal(ShadyDOM.wrapIfNeeded(rere).querySelector('#projected'), projected);
+    assert(ShadyDOM.wrapIfNeeded(re).querySelector('slot'));
+    assert(ShadyDOM.wrapIfNeeded(p).querySelector('slot'));
   });
 
   test('element.querySelectorAll', function() {
-    var projected = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#projected');
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    var re = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('x-reproject');
-    var p = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelector('x-project');
-    assert.equal(ShadyDOM.wrap(rere).querySelectorAll('#projected')[0], projected);
-    assert(ShadyDOM.wrap(re).querySelectorAll('slot').length, 1);
-    assert(ShadyDOM.wrap(p).querySelectorAll('slot').length, 1);
+    var projected = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#projected');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    var re = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('x-reproject');
+    var p = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelector('x-project');
+    assert.equal(ShadyDOM.wrapIfNeeded(rere).querySelectorAll('#projected')[0], projected);
+    assert(ShadyDOM.wrapIfNeeded(re).querySelectorAll('slot').length, 1);
+    assert(ShadyDOM.wrapIfNeeded(p).querySelectorAll('slot').length, 1);
   });
 
-  test('ShadyDOM.wrap(document).querySelector', function() {
-    assert.ok(ShadyDOM.wrap(document).querySelector('body'));
+  test('ShadyDOM.wrapIfNeeded(document).querySelector', function() {
+    assert.ok(ShadyDOM.wrapIfNeeded(document).querySelector('body'));
   });
 
   test('document.getElementById', function() {
@@ -431,272 +431,272 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   })
 
   test('projection', function() {
-    var projected = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#projected');
-    assert.equal(ShadyDOM.wrap(projected).textContent, 'projected');
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
+    var projected = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#projected');
+    assert.equal(ShadyDOM.wrapIfNeeded(projected).textContent, 'projected');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
     assert.equal(rere.localName, 'x-rereproject');
-    var re = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('x-reproject');
+    var re = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('x-reproject');
     assert.equal(re.localName, 'x-reproject');
-    var p = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelector('x-project');
+    var p = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelector('x-project');
     assert.equal(p.localName, 'x-project');
     ShadyDOM.flush();
-    var c1 = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('slot');
-    assert.include(ShadyDOM.wrap(c1).assignedNodes({flatten: true}), projected);
-    var c2 = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelector('slot');
-    assert.include(ShadyDOM.wrap(c2).assignedNodes({flatten: true}), projected);
-    var c3 = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).querySelector('slot');
-    assert.include(ShadyDOM.wrap(c3).assignedNodes({flatten: true}), projected);
+    var c1 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('slot');
+    assert.include(ShadyDOM.wrapIfNeeded(c1).assignedNodes({flatten: true}), projected);
+    var c2 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelector('slot');
+    assert.include(ShadyDOM.wrapIfNeeded(c2).assignedNodes({flatten: true}), projected);
+    var c3 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot).querySelector('slot');
+    assert.include(ShadyDOM.wrapIfNeeded(c3).assignedNodes({flatten: true}), projected);
     var ip$ = [c1, c2, c3];
     var as$ = allInsertionPoints(projected);
     assert.deepEqual(as$, ip$);
   });
 
   test('shadyRoot.update', function() {
-    var projected = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#projected');
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    var c1 = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('slot');
-    var re = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('x-reproject');
-    var c2 = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelector('slot');
-    var p = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelector('x-project');
-    var c3 = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).querySelector('slot');
+    var projected = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#projected');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    var c1 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('slot');
+    var re = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('x-reproject');
+    var c2 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelector('slot');
+    var p = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelector('x-project');
+    var c3 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot).querySelector('slot');
     var ip$ = [c1, c2, c3];
     if (testElement.shadyRoot) {
       testElement.shadyRoot.update();
     }
     ShadyDOM.flush();
     assert.deepEqual(allInsertionPoints(projected), ip$);
-    rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
+    rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
     assert.equal(rere.localName, 'x-rereproject');
     if (rere.shadyRoot) {
       rere.shadyRoot.update();
     }
     ShadyDOM.flush();
     assert.deepEqual(allInsertionPoints(projected), ip$);
-    re = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('x-reproject');
+    re = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('x-reproject');
     assert.equal(re.localName, 'x-reproject');
     if (re.shadyRoot) {
       re.shadyRoot.update();
     }
     ShadyDOM.flush();
     assert.deepEqual(allInsertionPoints(projected), ip$);
-    p = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelector('x-project');
+    p = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelector('x-project');
     assert.equal(p.localName, 'x-project');
   });
 
 
   test('without a host setting host attributes/reflecting properties provokes distribution', function() {
-    var e = ShadyDOM.wrap(document).querySelector('x-select-attr');
-    var ip$ = ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).querySelectorAll('slot');
-    var c = ShadyDOM.wrap(e).firstElementChild;
+    var e = ShadyDOM.wrapIfNeeded(document).querySelector('x-select-attr');
+    var ip$ = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).querySelectorAll('slot');
+    var c = ShadyDOM.wrapIfNeeded(e).firstElementChild;
     ShadyDOM.flush();
     assert.equal(allInsertionPoints(c)[0], ip$[1], 'child not distributed based on host attribute');
-    ShadyDOM.wrap(c).slot = 'foo';
+    ShadyDOM.wrapIfNeeded(c).slot = 'foo';
     ShadyDOM.flush();
     assert.equal(allInsertionPoints(c)[0], ip$[0], 'child not distributed based on reflecting attribute');
-    ShadyDOM.wrap(c).slot = '';
+    ShadyDOM.wrapIfNeeded(c).slot = '';
     ShadyDOM.flush();
     assert.equal(allInsertionPoints(c).length, 0, 'child not distributed based on reflecting attribute');
   });
 
   test('within a host setting host attributes/reflecting properties provokes distribution', function() {
-    var e = ShadyDOM.wrap(document).querySelector('x-compose-select-attr');
-    var ip$ = ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).querySelector('#select')).shadowRoot).querySelectorAll('slot');
-    var c1 = ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).querySelector('#attr1');
+    var e = ShadyDOM.wrapIfNeeded(document).querySelector('x-compose-select-attr');
+    var ip$ = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).querySelector('#select')).shadowRoot).querySelectorAll('slot');
+    var c1 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).querySelector('#attr1');
     ShadyDOM.flush();
     assert.equal(allInsertionPoints(c1)[0], ip$[1], 'child not distributed based on host attribute');
-    ShadyDOM.wrap(c1).slot = 'foo';
+    ShadyDOM.wrapIfNeeded(c1).slot = 'foo';
     ShadyDOM.flush();
     assert.equal(allInsertionPoints(c1)[0], ip$[0], 'child not distributed based on reflecting attribute');
-    ShadyDOM.wrap(c1).slot = 'bar';
+    ShadyDOM.wrapIfNeeded(c1).slot = 'bar';
     ShadyDOM.flush();
     assert.equal(allInsertionPoints(c1)[0], ip$[1], 'child not distributed based on reflecting attribute');
-    var c2 = ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).querySelector('#attr2');
+    var c2 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).querySelector('#attr2');
     ShadyDOM.flush();
     assert.equal(allInsertionPoints(c2)[0], ip$[0], 'child not distributed based on default value');
   });
 
   test('appendChild (light)', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
     var s = document.createElement('span');
     s.id = 'added';
-    ShadyDOM.wrap(s).textContent = 'Added';
-    ShadyDOM.wrap(rere).appendChild(s);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#added'), s);
+    ShadyDOM.wrapIfNeeded(s).textContent = 'Added';
+    ShadyDOM.wrapIfNeeded(rere).appendChild(s);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#added'), s);
   });
 
   test('insertBefore (light)', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    var ref = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#added');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    var ref = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#added');
     var s = document.createElement('span');
     s.id = 'added2';
-    ShadyDOM.wrap(s).textContent = 'Added2';
-    ShadyDOM.wrap(rere).insertBefore(s, ref);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#added2'), s);
+    ShadyDOM.wrapIfNeeded(s).textContent = 'Added2';
+    ShadyDOM.wrapIfNeeded(rere).insertBefore(s, ref);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#added2'), s);
   });
 
   test('insertBefore before a <slot> in light', function() {
-    var template = ShadyDOM.wrap(document).querySelector('template#insertBeforeSlot');
-    var frag = ShadyDOM.wrap(template.content).cloneNode(true);
-    var div = ShadyDOM.wrap(frag).querySelector('div#slotHost');
-    var slot = ShadyDOM.wrap(div).firstElementChild;
-    ShadyDOM.wrap(document.body).appendChild(frag);
+    var template = ShadyDOM.wrapIfNeeded(document).querySelector('template#insertBeforeSlot');
+    var frag = ShadyDOM.wrapIfNeeded(template.content).cloneNode(true);
+    var div = ShadyDOM.wrapIfNeeded(frag).querySelector('div#slotHost');
+    var slot = ShadyDOM.wrapIfNeeded(div).firstElementChild;
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(frag);
     var el = document.createElement('span');
-    ShadyDOM.wrap(div).insertBefore(el, slot);
-    ShadyDOM.wrap(ShadyDOM.wrap(div).parentNode).removeChild(div);
+    ShadyDOM.wrapIfNeeded(div).insertBefore(el, slot);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(div).parentNode).removeChild(div);
   });
 
   test('removeChild (light)', function() {
-    var added = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#added');
-    var added2 = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#added2');
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelectorAll('*').length, 4);
-    ShadyDOM.wrap(rere).removeChild(added);
-    ShadyDOM.wrap(rere).removeChild(added2);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelectorAll('*').length, 2);
+    var added = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#added');
+    var added2 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#added2');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelectorAll('*').length, 4);
+    ShadyDOM.wrapIfNeeded(rere).removeChild(added);
+    ShadyDOM.wrapIfNeeded(rere).removeChild(added2);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelectorAll('*').length, 2);
   });
 
   test('appendChild (local)', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
     var s = document.createElement('span');
     s.id = 'local';
-    ShadyDOM.wrap(s).textContent = 'Local';
-    ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).appendChild(s);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('#local'), s);
+    ShadyDOM.wrapIfNeeded(s).textContent = 'Local';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).appendChild(s);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('#local'), s);
   });
 
   test('insertBefore (local)', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    var ref = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#local');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    var ref = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#local');
     var s = document.createElement('span');
     s.id = 'local2';
-    ShadyDOM.wrap(s).textContent = 'Local2';
-    ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).insertBefore(s, ref);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('#local2'), s);
+    ShadyDOM.wrapIfNeeded(s).textContent = 'Local2';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).insertBefore(s, ref);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('#local2'), s);
   });
 
   test('removeChild (local)', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    var local = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('#local');
-    var local2 = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('#local2');
-    ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).removeChild(local);
-    ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).removeChild(local2);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelectorAll('#local').length, 0);
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    var local = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('#local');
+    var local2 = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('#local2');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).removeChild(local);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).removeChild(local2);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelectorAll('#local').length, 0);
   });
 
   test('localDom.insertBefore first element results in minimal change', function() {
-    var children = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).childNodes;
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
+    var children = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).childNodes;
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
     assert.equal(rere.attachedCount, 1);
     var s = document.createElement('span');
     s.id = 'local-first';
-    ShadyDOM.wrap(s).textContent = 'Local First';
-    ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).insertBefore(s, children[0]);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#local-first'), s);
+    ShadyDOM.wrapIfNeeded(s).textContent = 'Local First';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).insertBefore(s, children[0]);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#local-first'), s);
     assert.equal(rere.attachedCount, 1);
-    ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).removeChild(s);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).removeChild(s);
     assert.equal(rere.attachedCount, 1);
   });
 
   test('appendChild (fragment, local)', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
     var fragment = document.createDocumentFragment();
     var childCount = 5;
     for (var i=0; i < childCount; i++) {
       var s = document.createElement('span');
-      ShadyDOM.wrap(s).textContent = i;
-      ShadyDOM.wrap(fragment).appendChild(s);
+      ShadyDOM.wrapIfNeeded(s).textContent = i;
+      ShadyDOM.wrapIfNeeded(fragment).appendChild(s);
     }
-    ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).appendChild(fragment);
-    var added = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelectorAll('span');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).appendChild(fragment);
+    var added = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelectorAll('span');
     assert.equal(added.length, childCount);
     for (i=0; i < added.length; i++) {
-      ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).removeChild(added[i]);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).removeChild(added[i]);
     }
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelectorAll('span').length, 0);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelectorAll('span').length, 0);
   });
 
   test('insertBefore (fragment, local)', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
     var fragment = document.createDocumentFragment();
     var childCount = 5;
     for (var i=0; i < childCount; i++) {
       var s = document.createElement('span');
-      ShadyDOM.wrap(s).textContent = i;
-      ShadyDOM.wrap(fragment).appendChild(s);
+      ShadyDOM.wrapIfNeeded(s).textContent = i;
+      ShadyDOM.wrapIfNeeded(fragment).appendChild(s);
     }
     var l = document.createElement('span');
-    ShadyDOM.wrap(l).textContent = 'last';
-    ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).appendChild(l);
-    ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).insertBefore(fragment, l);
-    var added = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelectorAll('span');
+    ShadyDOM.wrapIfNeeded(l).textContent = 'last';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).appendChild(l);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).insertBefore(fragment, l);
+    var added = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelectorAll('span');
     assert.equal(added.length, childCount+1);
     assert.equal(added[added.length-1], l);
     for (i=0; i < added.length; i++) {
-      ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).removeChild(added[i]);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).removeChild(added[i]);
     }
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelectorAll('span').length, 0);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelectorAll('span').length, 0);
   });
 
   test('mutations using fragments without logical dom', function() {
     var d = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(d);
-    assert.equal(ShadyDOM.wrap(d).childNodes.length, 0);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(d);
+    assert.equal(ShadyDOM.wrapIfNeeded(d).childNodes.length, 0);
     var frag = document.createDocumentFragment();
     var c = document.createElement('div');
-    ShadyDOM.wrap(frag).appendChild(c);
-    ShadyDOM.wrap(d).appendChild(frag);
-    assert.equal(ShadyDOM.wrap(d).childNodes.length, 1);
-    assert.equal(ShadyDOM.wrap(d).firstChild, c);
+    ShadyDOM.wrapIfNeeded(frag).appendChild(c);
+    ShadyDOM.wrapIfNeeded(d).appendChild(frag);
+    assert.equal(ShadyDOM.wrapIfNeeded(d).childNodes.length, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(d).firstChild, c);
     var c1 = document.createElement('div');
-    ShadyDOM.wrap(frag).appendChild(c1);
-    ShadyDOM.wrap(d).appendChild(frag);
-    assert.equal(ShadyDOM.wrap(d).childNodes.length, 2);
-    assert.equal(ShadyDOM.wrap(d).firstChild, c);
-    assert.equal(ShadyDOM.wrap(d).lastChild, c1);
+    ShadyDOM.wrapIfNeeded(frag).appendChild(c1);
+    ShadyDOM.wrapIfNeeded(d).appendChild(frag);
+    assert.equal(ShadyDOM.wrapIfNeeded(d).childNodes.length, 2);
+    assert.equal(ShadyDOM.wrapIfNeeded(d).firstChild, c);
+    assert.equal(ShadyDOM.wrapIfNeeded(d).lastChild, c1);
   });
 
   test('appendChild interacts with unmanaged parent tree', function() {
-    var container = ShadyDOM.wrap(document).querySelector('#container');
-    var echo = ShadyDOM.wrap(container).firstElementChild;
+    var container = ShadyDOM.wrapIfNeeded(document).querySelector('#container');
+    var echo = ShadyDOM.wrapIfNeeded(container).firstElementChild;
     assert.equal(echo.localName, 'x-echo');
-    var s1 = ShadyDOM.wrap(echo).nextElementSibling;
-    assert.equal(ShadyDOM.wrap(s1).textContent, '1');
-    var s2 = ShadyDOM.wrap(s1).nextElementSibling;
-    assert.equal(ShadyDOM.wrap(s2).textContent, '2');
-    assert.equal(ShadyDOM.wrap(container).children.length, 3);
-    ShadyDOM.wrap(echo).appendChild(s1);
+    var s1 = ShadyDOM.wrapIfNeeded(echo).nextElementSibling;
+    assert.equal(ShadyDOM.wrapIfNeeded(s1).textContent, '1');
+    var s2 = ShadyDOM.wrapIfNeeded(s1).nextElementSibling;
+    assert.equal(ShadyDOM.wrapIfNeeded(s2).textContent, '2');
+    assert.equal(ShadyDOM.wrapIfNeeded(container).children.length, 3);
+    ShadyDOM.wrapIfNeeded(echo).appendChild(s1);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(container).children.length, 2);
-    assert.equal(ShadyDOM.wrap(echo).nextElementSibling, s2);
-    ShadyDOM.wrap(echo).appendChild(s2);
+    assert.equal(ShadyDOM.wrapIfNeeded(container).children.length, 2);
+    assert.equal(ShadyDOM.wrapIfNeeded(echo).nextElementSibling, s2);
+    ShadyDOM.wrapIfNeeded(echo).appendChild(s2);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(container).children.length, 1);
-    assert.equal(ShadyDOM.wrap(echo).nextElementSibling, null);
-    ShadyDOM.wrap(container).appendChild(s1);
+    assert.equal(ShadyDOM.wrapIfNeeded(container).children.length, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(echo).nextElementSibling, null);
+    ShadyDOM.wrapIfNeeded(container).appendChild(s1);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(container).children.length, 2);
-    assert.equal(ShadyDOM.wrap(echo).nextElementSibling, s1);
-    ShadyDOM.wrap(container).appendChild(s2);
+    assert.equal(ShadyDOM.wrapIfNeeded(container).children.length, 2);
+    assert.equal(ShadyDOM.wrapIfNeeded(echo).nextElementSibling, s1);
+    ShadyDOM.wrapIfNeeded(container).appendChild(s2);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(container).children.length, 3);
-    assert.equal(ShadyDOM.wrap(echo).nextElementSibling, s1);
-    assert.equal(ShadyDOM.wrap(s1).nextElementSibling, s2);
+    assert.equal(ShadyDOM.wrapIfNeeded(container).children.length, 3);
+    assert.equal(ShadyDOM.wrapIfNeeded(echo).nextElementSibling, s1);
+    assert.equal(ShadyDOM.wrapIfNeeded(s1).nextElementSibling, s2);
   });
 
   test('distribute (forced)', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    var re = ShadyDOM.wrap(ShadyDOM.wrap(rere).shadowRoot).querySelector('x-reproject');
-    var p = ShadyDOM.wrap(ShadyDOM.wrap(re).shadowRoot).querySelector('x-project');
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    var re = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(rere).shadowRoot).querySelector('x-reproject');
+    var p = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(re).shadowRoot).querySelector('x-project');
     var s = document.createElement('span');
     s.id = 'light';
-    ShadyDOM.wrap(s).textContent = 'Light';
-    ShadyDOM.wrap(rere).appendChild(s);
-    assert.equal(ShadyDOM.wrap(rere).querySelector('#light'), s);
-    assert.equal(ShadyDOM.wrap(s).parentNode, rere);
+    ShadyDOM.wrapIfNeeded(s).textContent = 'Light';
+    ShadyDOM.wrapIfNeeded(rere).appendChild(s);
+    assert.equal(ShadyDOM.wrapIfNeeded(rere).querySelector('#light'), s);
+    assert.equal(ShadyDOM.wrapIfNeeded(s).parentNode, rere);
     assert.notEqual(ShadyDOM.nativeTree.parentNode(s), rere);
     ShadyDOM.flush();
     assert.equal(ShadyDOM.nativeTree.parentNode(s), p);
-    ShadyDOM.wrap(rere).removeChild(s);
+    ShadyDOM.wrapIfNeeded(rere).removeChild(s);
     assert.equal(ShadyDOM.nativeTree.parentNode(s), p);
     ShadyDOM.flush();
     assert.equal(ShadyDOM.nativeTree.parentNode(s), null);
@@ -713,97 +713,97 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   test('disconnected node: isConnected, getRootNode', function() {
     let div = document.createElement('div');
-    assert.isFalse(ShadyDOM.wrap(div).isConnected);
-    assert.equal(ShadyDOM.wrap(div).getRootNode(), div);
+    assert.isFalse(ShadyDOM.wrapIfNeeded(div).isConnected);
+    assert.equal(ShadyDOM.wrapIfNeeded(div).getRootNode(), div);
   });
 
   test('slot, assignedSlot accessor', function() {
     let div = document.createElement('div');
-    ShadyDOM.wrap(div).slot = 'slot';
-    assert.equal(ShadyDOM.wrap(div).slot, 'slot');
+    ShadyDOM.wrapIfNeeded(div).slot = 'slot';
+    assert.equal(ShadyDOM.wrapIfNeeded(div).slot, 'slot');
     assert.equal(div.getAttribute('slot'), 'slot');
-    assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+    assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
   });
 
   test('parentNode', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    var projected = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#projected');
-    assert.equal(ShadyDOM.wrap(testElement).parentNode, document.body);
-    assert.equal(ShadyDOM.wrap(projected).parentNode, rere);
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    var projected = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#projected');
+    assert.equal(ShadyDOM.wrapIfNeeded(testElement).parentNode, document.body);
+    assert.equal(ShadyDOM.wrapIfNeeded(projected).parentNode, rere);
   });
 
   test('parentElement', function() {
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
-    var projected = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#projected');
-    assert.equal(ShadyDOM.wrap(testElement).parentElement, document.body);
-    assert.equal(ShadyDOM.wrap(projected).parentElement, rere);
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('x-rereproject');
+    var projected = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#projected');
+    assert.equal(ShadyDOM.wrapIfNeeded(testElement).parentElement, document.body);
+    assert.equal(ShadyDOM.wrapIfNeeded(projected).parentElement, rere);
   });
 
   test('childNodes is an array', function() {
-    var test = ShadyDOM.wrap(document).querySelector('x-test');
-    assert.isTrue(Array.isArray(ShadyDOM.wrap(test).childNodes));
+    var test = ShadyDOM.wrapIfNeeded(document).querySelector('x-test');
+    assert.isTrue(Array.isArray(ShadyDOM.wrapIfNeeded(test).childNodes));
   });
 
   test('childNodes.item(index)', function() {
     var el = createEnabledElement('x-echo');
     var d1 = document.createElement('div');
     var t1 = document.createTextNode('');
-    ShadyDOM.wrap(el).appendChild(d1);
-    ShadyDOM.wrap(el).insertBefore(t1, d1);
-    assert.equal(ShadyDOM.wrap(el).childNodes.item(0), t1);
-    assert.equal(ShadyDOM.wrap(el).childNodes.item(1), d1);
+    ShadyDOM.wrapIfNeeded(el).appendChild(d1);
+    ShadyDOM.wrapIfNeeded(el).insertBefore(t1, d1);
+    assert.equal(ShadyDOM.wrapIfNeeded(el).childNodes.item(0), t1);
+    assert.equal(ShadyDOM.wrapIfNeeded(el).childNodes.item(1), d1);
   });
 
   test('children.item(index)', function() {
     var el = createEnabledElement('x-echo');
     var d1 = document.createElement('div');
     var d2 = document.createElement('div');
-    ShadyDOM.wrap(el).appendChild(d1);
-    ShadyDOM.wrap(el).insertBefore(d2, d1);
-    assert.equal(ShadyDOM.wrap(el).children.item(0), d2);
-    assert.equal(ShadyDOM.wrap(el).children.item(1), d1);
+    ShadyDOM.wrapIfNeeded(el).appendChild(d1);
+    ShadyDOM.wrapIfNeeded(el).insertBefore(d2, d1);
+    assert.equal(ShadyDOM.wrapIfNeeded(el).children.item(0), d2);
+    assert.equal(ShadyDOM.wrapIfNeeded(el).children.item(1), d1);
   });
 
   test('childElementCount', function() {
-    var test = ShadyDOM.wrap(document).querySelector('x-test');
-    assert.equal(ShadyDOM.wrap(test).childElementCount, 0);
-    var rere = ShadyDOM.wrap(ShadyDOM.wrap(test).shadowRoot).querySelector('x-rereproject');
-    assert.equal(ShadyDOM.wrap(rere).childElementCount, 1);
-    var projected = ShadyDOM.wrap(ShadyDOM.wrap(test).shadowRoot).querySelector('#projected');
-    assert.equal(ShadyDOM.wrap(projected).childElementCount, 0);
-    var emptySvg = ShadyDOM.wrap(document).querySelector('#emptySvg');
-    assert.equal(ShadyDOM.wrap(emptySvg).childElementCount, 0);
+    var test = ShadyDOM.wrapIfNeeded(document).querySelector('x-test');
+    assert.equal(ShadyDOM.wrapIfNeeded(test).childElementCount, 0);
+    var rere = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(test).shadowRoot).querySelector('x-rereproject');
+    assert.equal(ShadyDOM.wrapIfNeeded(rere).childElementCount, 1);
+    var projected = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(test).shadowRoot).querySelector('#projected');
+    assert.equal(ShadyDOM.wrapIfNeeded(projected).childElementCount, 0);
+    var emptySvg = ShadyDOM.wrapIfNeeded(document).querySelector('#emptySvg');
+    assert.equal(ShadyDOM.wrapIfNeeded(emptySvg).childElementCount, 0);
   });
 
   test('cloneNode shallow', function() {
     var a = document.createElement('div');
-    ShadyDOM.wrap(a).innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
-    ShadyDOM.wrap(document.body).appendChild(a);
+    ShadyDOM.wrapIfNeeded(a).innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(a);
     ShadyDOM.flush();
-    var b = ShadyDOM.wrap(ShadyDOM.wrap(a).firstElementChild).cloneNode();
-    ShadyDOM.wrap(document.body).appendChild(b);
+    var b = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(a).firstElementChild).cloneNode();
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(b);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(b).childNodes.length, 0, 'shallow copy has incorrect children');
+    assert.equal(ShadyDOM.wrapIfNeeded(b).childNodes.length, 0, 'shallow copy has incorrect children');
     assert.equal(ShadyDOM.nativeTree.children(b).length, 2, 'shallow copy has incorrect composed children');
   });
 
   test('cloneNode deep', function() {
     var a = document.createElement('div');
-    ShadyDOM.wrap(a).innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
-    ShadyDOM.wrap(document.body).appendChild(a);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(a).firstElementChild).childNodes.length, 2, 'deep copy has incorrect children');
+    ShadyDOM.wrapIfNeeded(a).innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(a);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(a).firstElementChild).childNodes.length, 2, 'deep copy has incorrect children');
     ShadyDOM.flush();
     var b = ShadyDOM.wrap(a).cloneNode(true);
-    ShadyDOM.wrap(document.body).appendChild(b);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(b);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(b).firstElementChild).childNodes.length, 2, 'deep copy has incorrect children');
-    assert.equal(ShadyDOM.nativeTree.children(ShadyDOM.wrap(b).firstElementChild).length, 4, 'deep copy has incorrect composed children');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(b).firstElementChild).childNodes.length, 2, 'deep copy has incorrect children');
+    assert.equal(ShadyDOM.nativeTree.children(ShadyDOM.wrapIfNeeded(b).firstElementChild).length, 4, 'deep copy has incorrect composed children');
   });
 
   test('cloneNode attribute', function() {
     var div = document.createElement('div');
     div.setAttribute('id', 'test');
-    ShadyDOM.wrap(document.body).appendChild(div);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(div);
     ShadyDOM.flush();
     var attr = div.getAttributeNode('id').cloneNode(true);
     assert.equal(attr.name, 'id');
@@ -812,40 +812,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   test('importNode shallow', function() {
     var a = document.createElement('div');
-    ShadyDOM.wrap(a).innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
-    ShadyDOM.wrap(document.body).appendChild(a);
+    ShadyDOM.wrapIfNeeded(a).innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(a);
     ShadyDOM.flush();
     // NOTE: Safari defaults do `deep` true for importNode so be explicit here.
-    var b = ShadyDOM.wrap(document).importNode(ShadyDOM.wrap(a).firstElementChild, false);
-    ShadyDOM.wrap(document.body).appendChild(b);
+    var b = ShadyDOM.wrapIfNeeded(document).importNode(ShadyDOM.wrapIfNeeded(a).firstElementChild, false);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(b);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(b).childNodes.length, 0, 'shallow import has incorrect children');
+    assert.equal(ShadyDOM.wrapIfNeeded(b).childNodes.length, 0, 'shallow import has incorrect children');
     assert.equal(ShadyDOM.nativeTree.children(b).length, 2, 'shallow import has incorrect composed children');
   });
 
   test('importNode deep', function() {
     var a = document.createElement('div');
-    ShadyDOM.wrap(a).innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
-    ShadyDOM.wrap(document.body).appendChild(a);
+    ShadyDOM.wrapIfNeeded(a).innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(a);
     ShadyDOM.flush();
     var b = ShadyDOM.wrap(document).importNode(a, true);
-    ShadyDOM.wrap(document.body).appendChild(b);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(b);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(b).firstElementChild).childNodes.length, 2, 'deep copy has incorrect children');
-    assert.equal(ShadyDOM.nativeTree.children(ShadyDOM.wrap(b).firstElementChild).length, 4, 'deep copy has incorrect composed children');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(b).firstElementChild).childNodes.length, 2, 'deep copy has incorrect children');
+    assert.equal(ShadyDOM.nativeTree.children(ShadyDOM.wrapIfNeeded(b).firstElementChild).length, 4, 'deep copy has incorrect composed children');
   });
 
   test('importNode template deep', function() {
     var template = document.createElement('template');
-    ShadyDOM.wrap(template).innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
-    ShadyDOM.wrap(document.body).appendChild(template);
+    ShadyDOM.wrapIfNeeded(template).innerHTML = '<x-clonate><span>1</span><span>2</span></x-clonate>';
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(template);
     ShadyDOM.flush();
-    var templateCopy = ShadyDOM.wrap(document).importNode(template, true);
-    ShadyDOM.wrap(document.body).appendChild(templateCopy);
+    var templateCopy = ShadyDOM.wrapIfNeeded(document).importNode(template, true);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(templateCopy);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(templateCopy.content).childNodes.length, 1, 'deep copy has incorrect children');
-    var contentCopy = ShadyDOM.wrap(templateCopy.content).cloneNode(true);
-    assert.equal(ShadyDOM.wrap(contentCopy).firstChild.localName, 'x-clonate');
+    assert.equal(ShadyDOM.wrapIfNeeded(templateCopy.content).childNodes.length, 1, 'deep copy has incorrect children');
+    var contentCopy = ShadyDOM.wrapIfNeeded(templateCopy.content).cloneNode(true);
+    assert.equal(ShadyDOM.wrapIfNeeded(contentCopy).firstChild.localName, 'x-clonate');
   });
 
   test('flush reentrancy', function() {
@@ -878,45 +878,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   test('event.composedPath correctly calculated for when slots are assigned to slots', function(done) {
     let re = document.createElement('x-reproject');
-    ShadyDOM.wrap(document.body).appendChild(re);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(re);
     ShadyDOM.flush();
     let child = document.createElement('p');
-    ShadyDOM.wrap(child).innerHTML = "hello";
+    ShadyDOM.wrapIfNeeded(child).innerHTML = "hello";
     // child will be inserted into p after distributeContent is performed.
-    ShadyDOM.wrap(re).appendChild(child);
+    ShadyDOM.wrapIfNeeded(re).appendChild(child);
     ShadyDOM.flush();
-    let s1 = ShadyDOM.wrap(child).assignedSlot;
-    let s2 = ShadyDOM.wrap(s1).assignedSlot;
-    let r1 = ShadyDOM.wrap(s2).getRootNode();
-    let h1 = ShadyDOM.wrap(r1).host;
-    let r2 = ShadyDOM.wrap(h1).getRootNode();
-    let h2 = ShadyDOM.wrap(r2).host;
+    let s1 = ShadyDOM.wrapIfNeeded(child).assignedSlot;
+    let s2 = ShadyDOM.wrapIfNeeded(s1).assignedSlot;
+    let r1 = ShadyDOM.wrapIfNeeded(s2).getRootNode();
+    let h1 = ShadyDOM.wrapIfNeeded(r1).host;
+    let r2 = ShadyDOM.wrapIfNeeded(h1).getRootNode();
+    let h2 = ShadyDOM.wrapIfNeeded(r2).host;
     const path = [child, s1, s2, r1, h1, r2, h2, document.body, document.documentElement, document, window];
-    ShadyDOM.wrap(child).addEventListener('child-event', function(e){
+    ShadyDOM.wrapIfNeeded(child).addEventListener('child-event', function(e){
       const composedPath = e.composedPath();
       assert.deepEqual(composedPath, path);
       done();
     });
     let evt = new CustomEvent('child-event');
-    ShadyDOM.wrap(child).dispatchEvent(evt);
-    ShadyDOM.wrap(document.body).removeChild(re);
+    ShadyDOM.wrapIfNeeded(child).dispatchEvent(evt);
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(re);
   });
 
   test('ShadyDOM.composedPath correctly calculated', function(done) {
     let re = document.createElement('x-reproject');
-    ShadyDOM.wrap(document.body).appendChild(re);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(re);
     ShadyDOM.flush();
     let child = document.createElement('p');
-    ShadyDOM.wrap(child).innerHTML = "hello";
+    ShadyDOM.wrapIfNeeded(child).innerHTML = "hello";
     // child will be inserted into p after distributeContent is performed.
-    ShadyDOM.wrap(re).appendChild(child);
+    ShadyDOM.wrapIfNeeded(re).appendChild(child);
     ShadyDOM.flush();
-    let s1 = ShadyDOM.wrap(child).assignedSlot;
-    let s2 = ShadyDOM.wrap(s1).assignedSlot;
-    let r1 = ShadyDOM.wrap(s2).getRootNode();
-    let h1 = ShadyDOM.wrap(r1).host;
-    let r2 = ShadyDOM.wrap(h1).getRootNode();
-    let h2 = ShadyDOM.wrap(r2).host;
+    let s1 = ShadyDOM.wrapIfNeeded(child).assignedSlot;
+    let s2 = ShadyDOM.wrapIfNeeded(s1).assignedSlot;
+    let r1 = ShadyDOM.wrapIfNeeded(s2).getRootNode();
+    let h1 = ShadyDOM.wrapIfNeeded(r1).host;
+    let r2 = ShadyDOM.wrapIfNeeded(h1).getRootNode();
+    let h2 = ShadyDOM.wrapIfNeeded(r2).host;
     const path = [child, s1, s2, r1, h1, r2, h2, document.body, document.documentElement, document, window];
     // specifically test without wrapping
     child.addEventListener('child-event', function(e){
@@ -927,65 +927,65 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     let evt = new CustomEvent('child-event');
     // specifically test without wrapping
     child.dispatchEvent(evt);
-    ShadyDOM.wrap(document.body).removeChild(re);
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(re);
   });
 
   test('synchronous append during distribution', function() {
     var echo = document.createElement('x-echo');
-    ShadyDOM.wrap(document.body).appendChild(echo);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(echo);
     // When connected will cause span#peer to be added after it,
     // which should also be distributed
-    ShadyDOM.wrap(echo).appendChild(document.createElement('x-stamps-peer'));
+    ShadyDOM.wrapIfNeeded(echo).appendChild(document.createElement('x-stamps-peer'));
     ShadyDOM.flush();
-    var assignedNodes = ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(echo).shadowRoot).firstElementChild).assignedNodes();
+    var assignedNodes = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(echo).shadowRoot).firstElementChild).assignedNodes();
     assert.equal(assignedNodes[0].localName, 'x-stamps-peer');
     assert.equal(assignedNodes[1].id, 'peer');
   });
 
   test('dispatchEvent on element forces distribution', function() {
     var e = document.createElement('x-echo');
-    ShadyDOM.wrap(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
     var html = '<div id="added"></div>';
-    ShadyDOM.wrap(e).innerHTML = html;
-    ShadyDOM.wrap(e).dispatchEvent(new Event('foo'));
+    ShadyDOM.wrapIfNeeded(e).innerHTML = html;
+    ShadyDOM.wrapIfNeeded(e).dispatchEvent(new Event('foo'));
     assert.equal(ShadyDOM.nativeTree.innerHTML(e), html);
-    ShadyDOM.wrap(document.body).removeChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(e);
   });
 
   test('dispatchEvent on text forces distribution', function() {
     var e = document.createElement('x-echo');
-    ShadyDOM.wrap(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
     var html = 'some text';
-    ShadyDOM.wrap(e).innerHTML = html;
-    assert.isTrue(ShadyDOM.wrap(e).firstChild.nodeType == Node.TEXT_NODE);
-    ShadyDOM.wrap(ShadyDOM.wrap(e).firstChild).dispatchEvent(new Event('foo'));
+    ShadyDOM.wrapIfNeeded(e).innerHTML = html;
+    assert.isTrue(ShadyDOM.wrapIfNeeded(e).firstChild.nodeType == Node.TEXT_NODE);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).firstChild).dispatchEvent(new Event('foo'));
     assert.equal(ShadyDOM.nativeTree.innerHTML(e), html);
-    ShadyDOM.wrap(document.body).removeChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(e);
   });
 
   test('dispatchEvent on element pending distribution bubbles correctly', function() {
     var e = document.createElement('x-distribute');
-    ShadyDOM.wrap(document.body).appendChild(e);
-    var c = ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).getElementById('notTestContainer');
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
+    var c = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).getElementById('notTestContainer');
     var eventCount = 0;
-    ShadyDOM.wrap(e).addEventListener('foo', function() { eventCount++ });
-    ShadyDOM.wrap(c).addEventListener('foo', function() { eventCount++ });
+    ShadyDOM.wrapIfNeeded(e).addEventListener('foo', function() { eventCount++ });
+    ShadyDOM.wrapIfNeeded(c).addEventListener('foo', function() { eventCount++ });
     var div = document.createElement('div');
-    ShadyDOM.wrap(e).appendChild(div);
-    ShadyDOM.wrap(div).dispatchEvent(new Event('foo', {bubbles: true}));
+    ShadyDOM.wrapIfNeeded(e).appendChild(div);
+    ShadyDOM.wrapIfNeeded(div).dispatchEvent(new Event('foo', {bubbles: true}));
     assert.equal(eventCount, 2, 'event did not bubble through root and to target');
-    ShadyDOM.wrap(document.body).removeChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(e);
   });
 
   test('shadowRoot.appendChild element with slot child and shadowRoot with slot pending distribution', function() {
-    var outerElement = ShadyDOM.wrap(document).querySelector('outer-element');
+    var outerElement = ShadyDOM.wrapIfNeeded(document).querySelector('outer-element');
     assert.equal(ShadyDOM.nativeTree.innerHTML(outerElement), '<inner-element>hello</inner-element>');
-    var test = ShadyDOM.wrap(outerElement).firstChild;
-    var outerSlot = ShadyDOM.wrap(ShadyDOM.wrap(outerElement).shadowRoot).querySelector('slot');
-    var innerElement = ShadyDOM.wrap(ShadyDOM.wrap(outerElement).shadowRoot).querySelector('inner-element');
-    var innerSlot = ShadyDOM.wrap(ShadyDOM.wrap(innerElement).shadowRoot).querySelector('slot');
-    assert.deepEqual(ShadyDOM.wrap(outerSlot).assignedNodes(), [test]);
-    assert.deepEqual(ShadyDOM.wrap(innerSlot).assignedNodes(), [outerSlot]);
+    var test = ShadyDOM.wrapIfNeeded(outerElement).firstChild;
+    var outerSlot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(outerElement).shadowRoot).querySelector('slot');
+    var innerElement = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(outerElement).shadowRoot).querySelector('inner-element');
+    var innerSlot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(innerElement).shadowRoot).querySelector('slot');
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(outerSlot).assignedNodes(), [test]);
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(innerSlot).assignedNodes(), [outerSlot]);
   });
 
 });
@@ -993,34 +993,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 suite('insertBefore', function() {
   test('insertBefore while ref_node in shadowRoot not yet distributed', function() {
     var e = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(e);
-    ShadyDOM.wrap(e).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(e).attachShadow({mode: 'open'});
     ShadyDOM.flush();
     var frag = document.createDocumentFragment();
     var s = document.createElement('slot');
     var a = document.createElement('div');
-    ShadyDOM.wrap(frag).appendChild(s);
-    ShadyDOM.wrap(frag).appendChild(a);
+    ShadyDOM.wrapIfNeeded(frag).appendChild(s);
+    ShadyDOM.wrapIfNeeded(frag).appendChild(a);
     // 1. append fragment with <slot> and ref_node a
     // 2. because of the <slot>, the root will distribute and not do fast path insertion
     // 3. this leaves node a in outer space until distribution.
-    ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).appendChild(frag);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).appendChild(frag);
     var b = document.createElement('div');
     // insertBefore ref_node a when it is not yet distributed.
-    ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).insertBefore(b, a);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).insertBefore(b, a);
     ShadyDOM.flush();
-    assert.sameMembers(ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).childNodes, [s, b, a])
+    assert.sameMembers(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).childNodes, [s, b, a])
   });
 
   test('insertBefore multiple elements at different spots', function() {
     var e = document.createElement('x-echo');
-    ShadyDOM.wrap(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
     var d1 = document.createElement('div');
     d1.id = 'd1';
     var d2 = document.createElement('div');
     d2.id = 'd2';
-    ShadyDOM.wrap(e).appendChild(d1);
-    ShadyDOM.wrap(e).appendChild(d2);
+    ShadyDOM.wrapIfNeeded(e).appendChild(d1);
+    ShadyDOM.wrapIfNeeded(e).appendChild(d2);
     ShadyDOM.flush();
     assert.equal(ShadyDOM.nativeTree.innerHTML(e), '<div id="d1"></div><div id="d2"></div>')
     var d3 = document.createElement('div');
@@ -1029,98 +1029,98 @@ suite('insertBefore', function() {
     d4.id = 'd4';
     var d5 = document.createElement('div');
     d5.id = 'd5';
-    ShadyDOM.wrap(e).insertBefore(d3, d1);
-    ShadyDOM.wrap(e).insertBefore(d4, d2);
-    ShadyDOM.wrap(e).appendChild(d5);
+    ShadyDOM.wrapIfNeeded(e).insertBefore(d3, d1);
+    ShadyDOM.wrapIfNeeded(e).insertBefore(d4, d2);
+    ShadyDOM.wrapIfNeeded(e).appendChild(d5);
     ShadyDOM.flush();
     assert.equal(ShadyDOM.nativeTree.innerHTML(e),
       '<div id="d3"></div><div id="d1"></div><div id="d4"></div><div id="d2"></div><div id="d5"></div>')
-    ShadyDOM.wrap(document.body).removeChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(e);
   });
 
   test('insertBefore while ref_node undistributed', function() {
     var e = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(e);
-    ShadyDOM.wrap(e).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(e).attachShadow({mode: 'open'});
     ShadyDOM.flush();
     var a = document.createElement('div');
-    ShadyDOM.wrap(e).appendChild(a);
+    ShadyDOM.wrapIfNeeded(e).appendChild(a);
     var b = document.createElement('div');
     // insertBefore ref_node a when it is not yet distributed.
-    ShadyDOM.wrap(e).insertBefore(b, a);
+    ShadyDOM.wrapIfNeeded(e).insertBefore(b, a);
     ShadyDOM.flush();
-    assert.sameMembers(ShadyDOM.wrap(e).childNodes, [b, a])
+    assert.sameMembers(ShadyDOM.wrapIfNeeded(e).childNodes, [b, a])
   });
 
   test('insertBefore while ref_node in host not yet distributed', function() {
     var e = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
     var frag = document.createDocumentFragment();
-    ShadyDOM.wrap(frag).appendChild(document.createElement('div'));
+    ShadyDOM.wrapIfNeeded(frag).appendChild(document.createElement('div'));
     var slot = document.createElement('slot');
-    ShadyDOM.wrap(ShadyDOM.wrap(frag).firstChild).appendChild(slot);
-    ShadyDOM.wrap(e).attachShadow({mode: 'open'});
-    ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).appendChild(frag);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(frag).firstChild).appendChild(slot);
+    ShadyDOM.wrapIfNeeded(e).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).appendChild(frag);
     ShadyDOM.flush();
     var a = document.createElement('div');
-    ShadyDOM.wrap(e).appendChild(a);
+    ShadyDOM.wrapIfNeeded(e).appendChild(a);
     var b = document.createElement('div');
     // insertBefore ref_node a when it is not yet distributed.
-    ShadyDOM.wrap(e).insertBefore(b, a);
+    ShadyDOM.wrapIfNeeded(e).insertBefore(b, a);
     ShadyDOM.flush();
-    assert.sameMembers(ShadyDOM.wrap(e).childNodes, [b, a])
-    assert.sameMembers(ShadyDOM.wrap(slot).assignedNodes(), [b, a]);
+    assert.sameMembers(ShadyDOM.wrapIfNeeded(e).childNodes, [b, a])
+    assert.sameMembers(ShadyDOM.wrapIfNeeded(slot).assignedNodes(), [b, a]);
   });
 
   test('insertBefore while ref_node in container not yet distributed', function() {
     var e = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
     var frag = document.createDocumentFragment();
     var container = document.createElement('div');
-    ShadyDOM.wrap(frag).appendChild(container);
+    ShadyDOM.wrapIfNeeded(frag).appendChild(container);
     var slot = document.createElement('slot');
-    ShadyDOM.wrap(container).appendChild(slot);
+    ShadyDOM.wrapIfNeeded(container).appendChild(slot);
     var before = document.createElement('div');
-    ShadyDOM.wrap(container).appendChild(before);
-    ShadyDOM.wrap(e).attachShadow({mode: 'open'});
-    ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).appendChild(frag);
+    ShadyDOM.wrapIfNeeded(container).appendChild(before);
+    ShadyDOM.wrapIfNeeded(e).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).appendChild(frag);
     ShadyDOM.flush();
     // inserting into container that includes a slot before distribution
     var b = document.createElement('div');
     // insertBefore ref_node a when it is not yet distributed.
-    ShadyDOM.wrap(container).insertBefore(b, before);
+    ShadyDOM.wrapIfNeeded(container).insertBefore(b, before);
     ShadyDOM.flush();
-    assert.sameMembers(ShadyDOM.wrap(container).childNodes, [slot, b, before]);
+    assert.sameMembers(ShadyDOM.wrapIfNeeded(container).childNodes, [slot, b, before]);
   });
 
   test('insertBefore no-ops when ref_node and node are the same', function() {
     var e = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
     var div = document.createElement('div');
-    ShadyDOM.wrap(e).appendChild(div);
-    ShadyDOM.wrap(e).insertBefore(div, div);
-    assert.sameMembers(Array.from(ShadyDOM.wrap(e).childNodes), [div]);
+    ShadyDOM.wrapIfNeeded(e).appendChild(div);
+    ShadyDOM.wrapIfNeeded(e).insertBefore(div, div);
+    assert.sameMembers(Array.from(ShadyDOM.wrapIfNeeded(e).childNodes), [div]);
   });
 
   test('insertBefore throws when ref_node is not in parent', function() {
     var e = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
     var div1 = document.createElement('div');
     var div2 = document.createElement('div');
     assert.throws(function() {
-      ShadyDOM.wrap(e).insertBefore(div1, div2);
+      ShadyDOM.wrapIfNeeded(e).insertBefore(div1, div2);
     });
   });
 
   test('contains', function() {
     var e = document.createElement('x-simple');
-    ShadyDOM.wrap(document.body).appendChild(e);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
     assert.isTrue(ShadyDOM.wrap(document).contains(e));
-    assert.isFalse(ShadyDOM.wrap(document).contains(ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).firstChild));
-    assert.isFalse(ShadyDOM.wrap(e).contains(ShadyDOM.wrap(e).firstChild));
-    assert.isTrue(ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).contains(ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).firstChild));
-    assert.isFalse(ShadyDOM.wrap(ShadyDOM.wrap(e).shadowRoot).contains(document));
-    ShadyDOM.wrap(document.body).removeChild(e);
+    assert.isFalse(ShadyDOM.wrap(document).contains(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).firstChild));
+    assert.isFalse(ShadyDOM.wrap(e).contains(ShadyDOM.wrapIfNeeded(e).firstChild));
+    assert.isTrue(ShadyDOM.wrap(ShadyDOM.wrapIfNeeded(e).shadowRoot).contains(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(e).shadowRoot).firstChild));
+    assert.isFalse(ShadyDOM.wrap(ShadyDOM.wrapIfNeeded(e).shadowRoot).contains(document));
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(e);
   });
 
 });
@@ -1129,58 +1129,58 @@ suite('Accessors', function() {
   var noDistribute, distribute;
 
   suiteSetup(function() {
-    noDistribute = ShadyDOM.wrap(document).querySelector('.accessors x-test-no-distribute');
-    distribute = ShadyDOM.wrap(document).querySelector('.accessors x-project');
+    noDistribute = ShadyDOM.wrapIfNeeded(document).querySelector('.accessors x-test-no-distribute');
+    distribute = ShadyDOM.wrapIfNeeded(document).querySelector('.accessors x-project');
   });
 
   test('node accessors (no distribute)', function() {
-    var child = ShadyDOM.wrap(noDistribute).children[0];
+    var child = ShadyDOM.wrapIfNeeded(noDistribute).children[0];
     assert.isTrue(child.classList.contains('child'), 'test node could not be found');
     var before = document.createElement('div');
     var after = document.createElement('div');
-    ShadyDOM.wrap(noDistribute).insertBefore(before, child);
-    ShadyDOM.wrap(noDistribute).appendChild(after);
+    ShadyDOM.wrapIfNeeded(noDistribute).insertBefore(before, child);
+    ShadyDOM.wrapIfNeeded(noDistribute).appendChild(after);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(noDistribute).firstChild, before, 'firstChild incorrect');
-    assert.equal(ShadyDOM.wrap(noDistribute).lastChild, after, 'lastChild incorrect');
-    assert.equal(ShadyDOM.wrap(before).nextSibling, child, 'nextSibling incorrect');
-    assert.equal(ShadyDOM.wrap(child).nextSibling, after, 'nextSibling incorrect');
-    assert.equal(ShadyDOM.wrap(after).previousSibling, child, 'previousSibling incorrect');
-    assert.equal(ShadyDOM.wrap(after).nextSibling, null, 'nextSibling incorrect');
-    assert.equal(ShadyDOM.wrap(child).previousSibling, before, 'previousSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(noDistribute).firstChild, before, 'firstChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(noDistribute).lastChild, after, 'lastChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(before).nextSibling, child, 'nextSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(child).nextSibling, after, 'nextSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(after).previousSibling, child, 'previousSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(after).nextSibling, null, 'nextSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(child).previousSibling, before, 'previousSibling incorrect');
   });
 
   test('node accessors (distribute)', function() {
-    var child = ShadyDOM.wrap(distribute).children[0];
+    var child = ShadyDOM.wrapIfNeeded(distribute).children[0];
     assert.isTrue(child.classList.contains('child'), 'test node could not be found');
     var before = document.createElement('div');
     var after = document.createElement('div');
-    ShadyDOM.wrap(distribute).insertBefore(before, child);
-    ShadyDOM.wrap(distribute).appendChild(after);
+    ShadyDOM.wrapIfNeeded(distribute).insertBefore(before, child);
+    ShadyDOM.wrapIfNeeded(distribute).appendChild(after);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(distribute).firstChild, before, 'firstChild incorrect');
-    assert.equal(ShadyDOM.wrap(distribute).lastChild, after, 'lastChild incorrect');
-    assert.equal(ShadyDOM.wrap(before).nextSibling, child, 'nextSibling incorrect');
-    assert.equal(ShadyDOM.wrap(child).nextSibling, after, 'nextSibling incorrect');
-    assert.equal(ShadyDOM.wrap(after).previousSibling, child, 'previousSibling incorrect');
-    assert.equal(ShadyDOM.wrap(after).nextSibling, null, 'nextSibling incorrect');
-    assert.equal(ShadyDOM.wrap(child).previousSibling, before, 'previousSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(distribute).firstChild, before, 'firstChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(distribute).lastChild, after, 'lastChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(before).nextSibling, child, 'nextSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(child).nextSibling, after, 'nextSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(after).previousSibling, child, 'previousSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(after).nextSibling, null, 'nextSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(child).previousSibling, before, 'previousSibling incorrect');
   });
 
   test('element accessors (no distribute)', function() {
     var parent = createEnabledElement('x-test-no-distribute');
     var child = document.createElement('div');
-    ShadyDOM.wrap(parent).appendChild(child);
+    ShadyDOM.wrapIfNeeded(parent).appendChild(child);
     var before = document.createElement('div');
     var after = document.createElement('div');
-    ShadyDOM.wrap(parent).insertBefore(before, child);
-    ShadyDOM.wrap(parent).appendChild(after);
-    assert.equal(ShadyDOM.wrap(parent).firstElementChild, before, 'firstElementChild incorrect');
-    assert.equal(ShadyDOM.wrap(parent).lastElementChild, after, 'lastElementChild incorrect');
-    assert.equal(ShadyDOM.wrap(before).nextElementSibling, child, 'nextElementSibling incorrect');
-    assert.equal(ShadyDOM.wrap(child).nextElementSibling, after, 'nextElementSibling incorrect');
-    assert.equal(ShadyDOM.wrap(after).previousElementSibling, child, 'previousElementSibling incorrect');
-    assert.equal(ShadyDOM.wrap(child).previousElementSibling, before, 'previousElementSibling incorrect');
+    ShadyDOM.wrapIfNeeded(parent).insertBefore(before, child);
+    ShadyDOM.wrapIfNeeded(parent).appendChild(after);
+    assert.equal(ShadyDOM.wrapIfNeeded(parent).firstElementChild, before, 'firstElementChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(parent).lastElementChild, after, 'lastElementChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(before).nextElementSibling, child, 'nextElementSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(child).nextElementSibling, after, 'nextElementSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(after).previousElementSibling, child, 'previousElementSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(child).previousElementSibling, before, 'previousElementSibling incorrect');
   });
 
   test('element.children includes references to elements with name attribute', function() {
@@ -1200,14 +1200,14 @@ suite('Accessors', function() {
     firstDuplicate.setAttribute('id', 'duplicate');
     const secondDuplicate = document.createElement('div');
     secondDuplicate.setAttribute('id', 'duplicate');
-    ShadyDOM.wrap(container).appendChild(a);
-    ShadyDOM.wrap(container).appendChild(b);
-    ShadyDOM.wrap(container).appendChild(c);
-    ShadyDOM.wrap(container).appendChild(lengthId);
-    ShadyDOM.wrap(container).appendChild(numericId);
-    ShadyDOM.wrap(container).appendChild(firstDuplicate);
-    ShadyDOM.wrap(container).appendChild(secondDuplicate);
-    const children = ShadyDOM.wrap(container).children;
+    ShadyDOM.wrapIfNeeded(container).appendChild(a);
+    ShadyDOM.wrapIfNeeded(container).appendChild(b);
+    ShadyDOM.wrapIfNeeded(container).appendChild(c);
+    ShadyDOM.wrapIfNeeded(container).appendChild(lengthId);
+    ShadyDOM.wrapIfNeeded(container).appendChild(numericId);
+    ShadyDOM.wrapIfNeeded(container).appendChild(firstDuplicate);
+    ShadyDOM.wrapIfNeeded(container).appendChild(secondDuplicate);
+    const children = ShadyDOM.wrapIfNeeded(container).children;
     // References by the name attribute do not work in Edge and IE11
     if (!window.NATIVE.children || !window.NATIVE.children.get || window.NATIVE.children.get.call(container).a) {
       assert.equal(children.a, a);
@@ -1227,54 +1227,54 @@ suite('Accessors', function() {
   test('element accessors (distribute)', function() {
     var parent = createEnabledElement('x-project');
     var child = document.createElement('div');
-    ShadyDOM.wrap(parent).appendChild(child);
+    ShadyDOM.wrapIfNeeded(parent).appendChild(child);
     var before = document.createElement('div');
     var after = document.createElement('div');
-    ShadyDOM.wrap(parent).insertBefore(before, child);
-    ShadyDOM.wrap(parent).appendChild(after);
-    assert.equal(ShadyDOM.wrap(parent).firstElementChild, before, 'firstElementChild incorrect');
-    assert.equal(ShadyDOM.wrap(parent).lastElementChild, after, 'lastElementChild incorrect');
-    assert.equal(ShadyDOM.wrap(before).nextElementSibling, child, 'nextElementSibling incorrect');
-    assert.equal(ShadyDOM.wrap(child).nextElementSibling, after, 'nextElementSibling incorrect');
-    assert.equal(ShadyDOM.wrap(after).previousElementSibling, child, 'previousElementSibling incorrect');
-    assert.equal(ShadyDOM.wrap(child).previousElementSibling, before, 'previousElementSibling incorrect');
+    ShadyDOM.wrapIfNeeded(parent).insertBefore(before, child);
+    ShadyDOM.wrapIfNeeded(parent).appendChild(after);
+    assert.equal(ShadyDOM.wrapIfNeeded(parent).firstElementChild, before, 'firstElementChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(parent).lastElementChild, after, 'lastElementChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(before).nextElementSibling, child, 'nextElementSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(child).nextElementSibling, after, 'nextElementSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(after).previousElementSibling, child, 'previousElementSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(child).previousElementSibling, before, 'previousElementSibling incorrect');
   });
 
   test('node accessors (empty logical tree)', function() {
     var element = createEnabledElement('x-simple');
-    assert.equal(ShadyDOM.wrap(element).parentNode, null, 'parentNode incorrect');
-    assert.equal(ShadyDOM.wrap(element).firstChild, null, 'firstChild incorrect');
-    assert.equal(ShadyDOM.wrap(element).lastChild, null, 'lastChild incorrect');
-    assert.equal(ShadyDOM.wrap(element).nextSibling, null, 'nextSibling incorrect');
-    assert.equal(ShadyDOM.wrap(element).previousSibling, null, 'previousSibling incorrect');
-    assert.equal(ShadyDOM.wrap(element).firstElementChild, null, 'firstElementChild incorrect');
-    assert.equal(ShadyDOM.wrap(element).lastElementChild, null, 'lastElementChild incorrect');
-    assert.equal(ShadyDOM.wrap(element).nextElementSibling, null, 'nextElementSibling incorrect');
-    assert.equal(ShadyDOM.wrap(element).previousElementSibling, null, 'previousElementSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).parentNode, null, 'parentNode incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).firstChild, null, 'firstChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).lastChild, null, 'lastChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).nextSibling, null, 'nextSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).previousSibling, null, 'previousSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).firstElementChild, null, 'firstElementChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).lastElementChild, null, 'lastElementChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).nextElementSibling, null, 'nextElementSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).previousElementSibling, null, 'previousElementSibling incorrect');
   });
 
   test('node accessors (unmanaged logical tree)', function() {
     var element = document.createElement('div');
     var child1 = document.createElement('div');
     var child2 = document.createElement('div');
-    ShadyDOM.wrap(element).appendChild(child1);
-    ShadyDOM.wrap(element).appendChild(child2);
-    assert.equal(ShadyDOM.wrap(element).parentNode, null, 'parentNode incorrect');
-    assert.equal(ShadyDOM.wrap(element).firstChild, child1, 'firstChild incorrect');
-    assert.equal(ShadyDOM.wrap(element).lastChild, child2, 'lastChild incorrect');
-    assert.equal(ShadyDOM.wrap(element).nextSibling, null, 'nextSibling incorrect');
-    assert.equal(ShadyDOM.wrap(element).previousSibling, null, 'previousSibling incorrect');
-    assert.equal(ShadyDOM.wrap(element).firstElementChild, child1, 'firstElementChild incorrect');
-    assert.equal(ShadyDOM.wrap(element).lastElementChild, child2, 'lastElementChild incorrect');
-    assert.equal(ShadyDOM.wrap(element).nextElementSibling, null, 'nextElementSibling incorrect');
-    assert.equal(ShadyDOM.wrap(element).previousElementSibling, null, 'previousElementSibling incorrect');
+    ShadyDOM.wrapIfNeeded(element).appendChild(child1);
+    ShadyDOM.wrapIfNeeded(element).appendChild(child2);
+    assert.equal(ShadyDOM.wrapIfNeeded(element).parentNode, null, 'parentNode incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).firstChild, child1, 'firstChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).lastChild, child2, 'lastChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).nextSibling, null, 'nextSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).previousSibling, null, 'previousSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).firstElementChild, child1, 'firstElementChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).lastElementChild, child2, 'lastElementChild incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).nextElementSibling, null, 'nextElementSibling incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(element).previousElementSibling, null, 'previousElementSibling incorrect');
   });
 
   test('document ParentNode accessors', function() {
     if (!window.NATIVE.documentHasParentNodeAccessors) {
       this.skip();
     }
-    const doc = ShadyDOM.wrap(document);
+    const doc = ShadyDOM.wrapIfNeeded(document);
     assert.ok(doc.firstChild);
     assert.ok(doc.lastChild);
     assert.equal(doc.firstElementChild, document.documentElement);
@@ -1286,10 +1286,10 @@ suite('Accessors', function() {
 
   test('template accessors (innerHTML)', function() {
     var template = document.createElement('template');
-    ShadyDOM.wrap(template).innerHTML = '<div></div>';
-    assert.notOk(ShadyDOM.wrap(template).firstChild);
-    assert.ok(ShadyDOM.wrap(template.content).firstChild);
-    assert.equal(ShadyDOM.wrap(template).innerHTML, '<div></div>');
+    ShadyDOM.wrapIfNeeded(template).innerHTML = '<div></div>';
+    assert.notOk(ShadyDOM.wrapIfNeeded(template).firstChild);
+    assert.ok(ShadyDOM.wrapIfNeeded(template.content).firstChild);
+    assert.equal(ShadyDOM.wrapIfNeeded(template).innerHTML, '<div></div>');
   });
 
   const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
@@ -1299,55 +1299,55 @@ suite('Accessors', function() {
       this.skip();
     }
     const svg = ShadyDOM.patch(document.createElementNS(SVG_NAMESPACE, 'svg'));
-    ShadyDOM.wrap(svg).innerHTML = '<circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />';
-    const circle = ShadyDOM.wrap(svg).querySelector('circle');
+    ShadyDOM.wrapIfNeeded(svg).innerHTML = '<circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />';
+    const circle = ShadyDOM.wrapIfNeeded(svg).querySelector('circle');
     assert.isTrue(circle instanceof SVGCircleElement, `Expected ${circle} to be a circle, but was "${typeof circle}" instead`);
   });
 
   test('textContent', function() {
     var testElement = createEnabledElement('x-project');
-    ShadyDOM.wrap(testElement).textContent = 'Hello World';
-    assert.equal(ShadyDOM.wrap(testElement).textContent, 'Hello World', 'textContent getter incorrect');
-    ShadyDOM.wrap(document.body).appendChild(testElement);
+    ShadyDOM.wrapIfNeeded(testElement).textContent = 'Hello World';
+    assert.equal(ShadyDOM.wrapIfNeeded(testElement).textContent, 'Hello World', 'textContent getter incorrect');
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(testElement);
     ShadyDOM.flush();
     assert.equal(ShadyDOM.nativeTree.childNodes(testElement)[1].textContent, 'Hello World', 'text content setter incorrect');
     testElement = createEnabledElement('x-commented');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).textContent, '[]', 'text content getter with comment incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).textContent, '[]', 'text content getter with comment incorrect');
 
     var textNode = document.createTextNode('foo');
-    assert.equal(ShadyDOM.wrap(textNode).textContent, 'foo', 'text content getter on textnode incorrect');
-    ShadyDOM.wrap(textNode).textContent = 'bar';
-    assert.equal(ShadyDOM.wrap(textNode).textContent, 'bar', 'text content setter on textnode incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(textNode).textContent, 'foo', 'text content getter on textnode incorrect');
+    ShadyDOM.wrapIfNeeded(textNode).textContent = 'bar';
+    assert.equal(ShadyDOM.wrapIfNeeded(textNode).textContent, 'bar', 'text content setter on textnode incorrect');
 
     var commentNode = document.createComment('foo');
-    assert.equal(ShadyDOM.wrap(commentNode).textContent, 'foo', 'text content getter on commentnode incorrect');
-    ShadyDOM.wrap(commentNode).textContent = 'bar';
-    assert.equal(ShadyDOM.wrap(commentNode).textContent, 'bar', 'text content setter on commentnode incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(commentNode).textContent, 'foo', 'text content getter on commentnode incorrect');
+    ShadyDOM.wrapIfNeeded(commentNode).textContent = 'bar';
+    assert.equal(ShadyDOM.wrapIfNeeded(commentNode).textContent, 'bar', 'text content setter on commentnode incorrect');
   });
 
   test('setting textContent to an empty string removes existing content', function() {
     var fragment = document.createDocumentFragment();
     var d = document.createElement('div');
-    ShadyDOM.wrap(fragment).appendChild(d);
+    ShadyDOM.wrapIfNeeded(fragment).appendChild(d);
     ShadyDOM.flush();
     assert.equal(ShadyDOM.nativeTree.childNodes(fragment).length, 1, 'documentFragment.appendChild is incorrect');
-    ShadyDOM.wrap(fragment).textContent = "";
+    ShadyDOM.wrapIfNeeded(fragment).textContent = "";
     ShadyDOM.flush();
     assert.equal(ShadyDOM.nativeTree.childNodes(fragment).length, 0, 'textContent setter on document fragment is incorrect');
   });
 
   test('setting textContent to null should set it to the empty string', function() {
     var testElement = createEnabledElement('x-project');
-    ShadyDOM.wrap(testElement).textContent = null;
+    ShadyDOM.wrapIfNeeded(testElement).textContent = null;
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(testElement).textContent, '', 'text content should be set to empty string in case of setting it to null');
+    assert.equal(ShadyDOM.wrapIfNeeded(testElement).textContent, '', 'text content should be set to empty string in case of setting it to null');
   });
 
   test('setting textContent to undefined should set it to the empty string', function() {
     var testElement = createEnabledElement('x-project');
-    ShadyDOM.wrap(testElement).textContent = undefined;
+    ShadyDOM.wrapIfNeeded(testElement).textContent = undefined;
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(testElement).textContent, '', 'text content should be set to empty string in case of setting it to undefined');
+    assert.equal(ShadyDOM.wrapIfNeeded(testElement).textContent, '', 'text content should be set to empty string in case of setting it to undefined');
   });
 
   test('textContent on document fragment', function() {
@@ -1359,24 +1359,24 @@ suite('Accessors', function() {
     i.innerText = 'World'
     documentFragment.appendChild(i);
 
-    assert.equal(ShadyDOM.wrap(documentFragment).textContent, 'HelloWorld', 'textContent getter on document fragment incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(documentFragment).textContent, 'HelloWorld', 'textContent getter on document fragment incorrect');
 
-    ShadyDOM.wrap(documentFragment).textContent = 'HelloWorld';
-    assert.equal(ShadyDOM.wrap(documentFragment).childNodes.length, 1, 'textContent setter on document fragment incorrect');
-    assert.equal(ShadyDOM.wrap(documentFragment).textContent, 'HelloWorld', 'textContent setter on document fragment incorrect');
+    ShadyDOM.wrapIfNeeded(documentFragment).textContent = 'HelloWorld';
+    assert.equal(ShadyDOM.wrapIfNeeded(documentFragment).childNodes.length, 1, 'textContent setter on document fragment incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(documentFragment).textContent, 'HelloWorld', 'textContent setter on document fragment incorrect');
 
-    ShadyDOM.wrap(documentFragment).textContent = '';
-    assert.equal(ShadyDOM.wrap(documentFragment).childNodes.length, 0, 'textContent setter on document fragment incorrect');
-    assert.equal(ShadyDOM.wrap(documentFragment).textContent, '', 'textContent setter on document fragment incorrect');
+    ShadyDOM.wrapIfNeeded(documentFragment).textContent = '';
+    assert.equal(ShadyDOM.wrapIfNeeded(documentFragment).childNodes.length, 0, 'textContent setter on document fragment incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(documentFragment).textContent, '', 'textContent setter on document fragment incorrect');
   });
 
   test('innerHTML', function() {
     var testElement = createEnabledElement('x-project');
-    ShadyDOM.wrap(testElement).innerHTML = '<div>Hello World</div><div>2</div><div>3</div>';
-    var added = ShadyDOM.wrap(testElement).firstChild;
-    assert.equal(ShadyDOM.wrap(added).textContent , 'Hello World', 'innerHTML setter incorrect');
-    assert.equal(ShadyDOM.wrap(testElement).innerHTML , '<div>Hello World</div><div>2</div><div>3</div>', 'innerHTML getter incorrect');
-    ShadyDOM.wrap(document.body).appendChild(testElement);
+    ShadyDOM.wrapIfNeeded(testElement).innerHTML = '<div>Hello World</div><div>2</div><div>3</div>';
+    var added = ShadyDOM.wrapIfNeeded(testElement).firstChild;
+    assert.equal(ShadyDOM.wrapIfNeeded(added).textContent , 'Hello World', 'innerHTML setter incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(testElement).innerHTML , '<div>Hello World</div><div>2</div><div>3</div>', 'innerHTML getter incorrect');
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(testElement);
     ShadyDOM.flush();
     var children = ShadyDOM.nativeTree.childNodes(testElement);
     assert.equal(children[1], added, 'innerHTML setter composed incorrectly');
@@ -1386,56 +1386,56 @@ suite('Accessors', function() {
 
   test('innerHTML (non-composed)', function() {
     var testElement = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(testElement);
-    ShadyDOM.wrap(testElement).innerHTML = '<div>Hello World</div><div>2</div><div>3</div>';
-    var added = ShadyDOM.wrap(testElement).firstChild;
-    assert.equal(ShadyDOM.wrap(added).textContent , 'Hello World', 'innerHTML setter incorrect');
-    assert.equal(ShadyDOM.wrap(testElement).innerHTML , '<div>Hello World</div><div>2</div><div>3</div>', 'innerHTML getter incorrect');
-    assert.equal(ShadyDOM.wrap(testElement).children.length, 3);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(testElement);
+    ShadyDOM.wrapIfNeeded(testElement).innerHTML = '<div>Hello World</div><div>2</div><div>3</div>';
+    var added = ShadyDOM.wrapIfNeeded(testElement).firstChild;
+    assert.equal(ShadyDOM.wrapIfNeeded(added).textContent , 'Hello World', 'innerHTML setter incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(testElement).innerHTML , '<div>Hello World</div><div>2</div><div>3</div>', 'innerHTML getter incorrect');
+    assert.equal(ShadyDOM.wrapIfNeeded(testElement).children.length, 3);
   });
 
   test('innerHTML on table elements', function() {
     var element = document.createElement('table');
-    ShadyDOM.wrap(element).innerHTML = '<tbody></tbody>';
-    var tb = ShadyDOM.wrap(element).childNodes[0];
+    ShadyDOM.wrapIfNeeded(element).innerHTML = '<tbody></tbody>';
+    var tb = ShadyDOM.wrapIfNeeded(element).childNodes[0];
     assert.equal(tb.localName, 'tbody');
-    ShadyDOM.wrap(tb).innerHTML = '<tr></tr>';
-    var tr = ShadyDOM.wrap(tb).childNodes[0];
+    ShadyDOM.wrapIfNeeded(tb).innerHTML = '<tr></tr>';
+    var tr = ShadyDOM.wrapIfNeeded(tb).childNodes[0];
     assert.equal(tr.localName, 'tr');
-    ShadyDOM.wrap(tr).innerHTML = '<td></td>';
-    var td = ShadyDOM.wrap(tr).childNodes[0];
+    ShadyDOM.wrapIfNeeded(tr).innerHTML = '<td></td>';
+    var td = ShadyDOM.wrapIfNeeded(tr).childNodes[0];
     assert.equal(td.localName, 'td');
   });
 
   test('innerHTML on template element', function() {
     var element = document.createElement('template');
-    ShadyDOM.wrap(element).innerHTML = '<div>A</div><div>B</div>';
-    assert.equal(ShadyDOM.wrap(element).childNodes.length, 0);
-    assert.equal(ShadyDOM.wrap(element.content).childNodes.length, 2);
+    ShadyDOM.wrapIfNeeded(element).innerHTML = '<div>A</div><div>B</div>';
+    assert.equal(ShadyDOM.wrapIfNeeded(element).childNodes.length, 0);
+    assert.equal(ShadyDOM.wrapIfNeeded(element.content).childNodes.length, 2);
   });
 
   test('innerHTML removing a custom element', function() {
     var testElement = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(testElement);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(testElement);
     const simple = document.createElement('x-simple');
     testElement.appendChild(simple);
-    ShadyDOM.wrap(testElement).innerHTML = '';
+    ShadyDOM.wrapIfNeeded(testElement).innerHTML = '';
     assert.isTrue(simple._isDisconnected);
   });
 
   test('innerHTML containing custom element', function() {
     var testElement = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(testElement);
-    ShadyDOM.wrap(testElement).innerHTML = '<x-simple></x-simple>';
-    assert.isTrue(ShadyDOM.wrap(testElement).firstChild._initialized);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(testElement);
+    ShadyDOM.wrapIfNeeded(testElement).innerHTML = '<x-simple></x-simple>';
+    assert.isTrue(ShadyDOM.wrapIfNeeded(testElement).firstChild._initialized);
   });
 
   test('textContent that removes custom element', function() {
     var testElement = document.createElement('div');
-    ShadyDOM.wrap(document.body).appendChild(testElement);
-    ShadyDOM.wrap(testElement).innerHTML = '<x-simple></x-simple>';
-    const el = ShadyDOM.wrap(testElement).firstChild;
-    ShadyDOM.wrap(testElement).textContent = '';
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(testElement);
+    ShadyDOM.wrapIfNeeded(testElement).innerHTML = '<x-simple></x-simple>';
+    const el = ShadyDOM.wrapIfNeeded(testElement).firstChild;
+    ShadyDOM.wrapIfNeeded(testElement).textContent = '';
     assert.isTrue(el._isDisconnected);
   });
 
@@ -1443,28 +1443,28 @@ suite('Accessors', function() {
     test('innerHTML removing a custom element', function() {
       var testElement = document.createElement('div');
       ShadyDOM.patch(testElement);
-      ShadyDOM.wrap(document.body).appendChild(testElement);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(testElement);
       const simple = document.createElement('x-simple');
       testElement.appendChild(simple);
-      ShadyDOM.wrap(testElement).innerHTML = '';
+      ShadyDOM.wrapIfNeeded(testElement).innerHTML = '';
       assert.isTrue(simple._isDisconnected);
     });
 
     test('innerHTML containing custom element', function() {
       var testElement = document.createElement('div');
       ShadyDOM.patch(testElement);
-      ShadyDOM.wrap(document.body).appendChild(testElement);
-      ShadyDOM.wrap(testElement).innerHTML = '<x-simple></x-simple>';
-      assert.isTrue(ShadyDOM.wrap(testElement).firstChild._initialized);
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(testElement);
+      ShadyDOM.wrapIfNeeded(testElement).innerHTML = '<x-simple></x-simple>';
+      assert.isTrue(ShadyDOM.wrapIfNeeded(testElement).firstChild._initialized);
     });
 
     test('textContent that removes custom element', function() {
       var testElement = document.createElement('div');
       ShadyDOM.patch(testElement);
-      ShadyDOM.wrap(document.body).appendChild(testElement);
-      ShadyDOM.wrap(testElement).innerHTML = '<x-simple></x-simple>';
-      const el = ShadyDOM.wrap(testElement).firstChild;
-      ShadyDOM.wrap(testElement).textContent = '';
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(testElement);
+      ShadyDOM.wrapIfNeeded(testElement).innerHTML = '<x-simple></x-simple>';
+      const el = ShadyDOM.wrapIfNeeded(testElement).firstChild;
+      ShadyDOM.wrapIfNeeded(testElement).textContent = '';
       assert.isTrue(el._isDisconnected);
     });
   });
@@ -1476,72 +1476,72 @@ suite('non-distributed elements', function() {
   var nd;
 
   suiteSetup(function() {
-    nd = ShadyDOM.wrap(document).querySelector('#noDistribute');
+    nd = ShadyDOM.wrapIfNeeded(document).querySelector('#noDistribute');
   });
 
   test('finds undistributed child', function() {
-    assert.ok(ShadyDOM.wrap(nd).children.length, 2, 'light children includes distributed and non-distributed nodes');
+    assert.ok(ShadyDOM.wrapIfNeeded(nd).children.length, 2, 'light children includes distributed and non-distributed nodes');
   });
 
   test('removes/adds undistributed child', function() {
-    var b = ShadyDOM.wrap(nd).children[0];
+    var b = ShadyDOM.wrapIfNeeded(nd).children[0];
     assert.equal(allInsertionPoints(b).length, 0, 'element improperly distributed');
-    ShadyDOM.wrap(nd).removeChild(b);
+    ShadyDOM.wrapIfNeeded(nd).removeChild(b);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(nd).children.length, 1, 'children length not decremented due to element removal');
-    ShadyDOM.wrap(nd).appendChild(b);
+    assert.equal(ShadyDOM.wrapIfNeeded(nd).children.length, 1, 'children length not decremented due to element removal');
+    ShadyDOM.wrapIfNeeded(nd).appendChild(b);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(nd).children.length, 2, 'children length not incremented due to element addition');
+    assert.equal(ShadyDOM.wrapIfNeeded(nd).children.length, 2, 'children length not incremented due to element addition');
     var d = document.createElement('div');
     d.innerHTML = 'added';
-    ShadyDOM.wrap(nd).insertBefore(d, b);
+    ShadyDOM.wrapIfNeeded(nd).insertBefore(d, b);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(nd).children.length, 3, 'children length not incremented due to element addition');
-    ShadyDOM.wrap(nd).removeChild(d);
+    assert.equal(ShadyDOM.wrapIfNeeded(nd).children.length, 3, 'children length not incremented due to element addition');
+    ShadyDOM.wrapIfNeeded(nd).removeChild(d);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(nd).children.length, 2, 'children length not decremented due to element removal');
+    assert.equal(ShadyDOM.wrapIfNeeded(nd).children.length, 2, 'children length not decremented due to element removal');
   });
 
   test('removes/adds between light and local dom', function() {
-    var b = ShadyDOM.wrap(nd).children[1];
+    var b = ShadyDOM.wrapIfNeeded(nd).children[1];
     assert.equal(allInsertionPoints(b).length, 0, 'element improperly distributed');
-    ShadyDOM.wrap(ShadyDOM.wrap(nd).shadowRoot).appendChild(b);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(nd).shadowRoot).appendChild(b);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(nd).children.length, 1, 'children length not decremented due to element removal');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(nd).shadowRoot).children.length, 2, 'root children length not incremented due to element addition');
-    ShadyDOM.wrap(nd).appendChild(b);
+    assert.equal(ShadyDOM.wrapIfNeeded(nd).children.length, 1, 'children length not decremented due to element removal');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(nd).shadowRoot).children.length, 2, 'root children length not incremented due to element addition');
+    ShadyDOM.wrapIfNeeded(nd).appendChild(b);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(nd).children.length, 2, 'children length not incremented due to element addition');
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(nd).shadowRoot).children.length, 1, 'root children length not decremented due to element removal');
+    assert.equal(ShadyDOM.wrapIfNeeded(nd).children.length, 2, 'children length not incremented due to element addition');
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(nd).shadowRoot).children.length, 1, 'root children length not decremented due to element removal');
   });
 
   test('correctly distributes changes to light dom', function() {
     function testNoAttr() {
-      assert.equal(allInsertionPoints(child)[0], ShadyDOM.wrap(ShadyDOM.wrap(d).shadowRoot).querySelector('#notTestContent'), 'child not distributed logically');
+      assert.equal(allInsertionPoints(child)[0], ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(d).shadowRoot).querySelector('#notTestContent'), 'child not distributed logically');
     }
     function testWithAttr() {
-      assert.equal(allInsertionPoints(child)[0], ShadyDOM.wrap(ShadyDOM.wrap(d).shadowRoot).querySelector('#testContent'), 'child not distributed logically');
+      assert.equal(allInsertionPoints(child)[0], ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(d).shadowRoot).querySelector('#testContent'), 'child not distributed logically');
     }
     // test with x-distribute
     var d = document.createElement('x-distribute');
-    ShadyDOM.wrap(document.body).appendChild(d);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(d);
     var child = document.createElement('div');
     child.classList.add('child');
-    ShadyDOM.wrap(child).textContent = 'Child';
-    ShadyDOM.wrap(d).appendChild(child);
+    ShadyDOM.wrapIfNeeded(child).textContent = 'Child';
+    ShadyDOM.wrapIfNeeded(d).appendChild(child);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(d).children[0], child, 'child not added to logical dom');
+    assert.equal(ShadyDOM.wrapIfNeeded(d).children[0], child, 'child not added to logical dom');
     testNoAttr();
     // set / unset `test` attr and see if it distributes properly
-    ShadyDOM.wrap(child).setAttribute('slot', 'test');
+    ShadyDOM.wrapIfNeeded(child).setAttribute('slot', 'test');
     ShadyDOM.flush();
     testWithAttr();
     //
-    ShadyDOM.wrap(child).removeAttribute('slot');
+    ShadyDOM.wrapIfNeeded(child).removeAttribute('slot');
     ShadyDOM.flush();
     testNoAttr();
     //
-    ShadyDOM.wrap(child).setAttribute('slot', 'test');
+    ShadyDOM.wrapIfNeeded(child).setAttribute('slot', 'test');
     ShadyDOM.flush();
     testWithAttr();
   });
@@ -1550,109 +1550,109 @@ suite('non-distributed elements', function() {
     var test = document.createElement('div');
     var c1 = createEnabledElement('x-compose');
     var c2 = createEnabledElement('x-compose');
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(c1).shadowRoot).querySelector('#project')).appendChild(test);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project')).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(c2).shadowRoot).querySelector('#project')).appendChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c2).shadowRoot).querySelector('#project')).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c2).shadowRoot, 'getOwnerRoot not correctly reset when element moved to different root');
-    ShadyDOM.wrap(c1).appendChild(test);
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c2).shadowRoot, 'getOwnerRoot not correctly reset when element moved to different root');
+    ShadyDOM.wrapIfNeeded(c1).appendChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
   });
 
   test('getRootNode into/out of shadowRoot', function() {
     var test = document.createElement('div');
     var c1 = createEnabledElement('x-compose');
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(c1).shadowRoot).querySelector('#project')).appendChild(test);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project')).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
     ShadyDOM.wrap(document.body).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), document, 'getOwnerRoot not correctly reset when element moved to different root');
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), document, 'getOwnerRoot not correctly reset when element moved to different root');
     ShadyDOM.wrap(c1).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
   });
 
 
   test('getRootNode when out of tree', function() {
     var test = document.createElement('div');
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), test, 'getOwnerRoot incorrect when not in root');
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), test, 'getOwnerRoot incorrect when not in root');
     var c1 = createEnabledElement('x-compose');
-    var project = ShadyDOM.wrap(ShadyDOM.wrap(c1).shadowRoot).querySelector('#project');
-    ShadyDOM.wrap(project).appendChild(test);
+    var project = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project');
+    ShadyDOM.wrapIfNeeded(project).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
-    ShadyDOM.wrap(project).removeChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    ShadyDOM.wrapIfNeeded(project).removeChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
-    ShadyDOM.wrap(project).appendChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
+    ShadyDOM.wrapIfNeeded(project).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
   });
 
   test('getRootNode when out of tree and adding subtree', function() {
     var container = document.createDocumentFragment();
     var test = document.createElement('div');
-    ShadyDOM.wrap(container).appendChild(test);
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), container, 'getOwnerRoot incorrect when not in root');
+    ShadyDOM.wrapIfNeeded(container).appendChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), container, 'getOwnerRoot incorrect when not in root');
     var c1 = createEnabledElement('x-compose');
-    var project = ShadyDOM.wrap(ShadyDOM.wrap(c1).shadowRoot).querySelector('#project');
-    ShadyDOM.wrap(project).appendChild(container);
+    var project = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project');
+    ShadyDOM.wrapIfNeeded(project).appendChild(container);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
-    ShadyDOM.wrap(project).removeChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    ShadyDOM.wrapIfNeeded(project).removeChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
-    ShadyDOM.wrap(project).appendChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
+    ShadyDOM.wrapIfNeeded(project).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
   });
 
   test('getRootNode, subtree', function() {
     var test = document.createElement('div');
     var testChild = document.createElement('div');
-    ShadyDOM.wrap(test).appendChild(testChild);
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), test, 'getOwnerRoot incorrect when not in root');
+    ShadyDOM.wrapIfNeeded(test).appendChild(testChild);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), test, 'getOwnerRoot incorrect when not in root');
     var c1 = createEnabledElement('x-compose');
-    var project = ShadyDOM.wrap(ShadyDOM.wrap(c1).shadowRoot).querySelector('#project');
-    ShadyDOM.wrap(project).appendChild(test);
+    var project = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project');
+    ShadyDOM.wrapIfNeeded(project).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
-    assert.equal(ShadyDOM.wrap(testChild).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for sub-child added to element in root');
-    ShadyDOM.wrap(project).removeChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(testChild).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for sub-child added to element in root');
+    ShadyDOM.wrapIfNeeded(project).removeChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
-    assert.equal(ShadyDOM.wrap(testChild).getRootNode(), test, 'getOwnerRoot incorrect for sub-child moved from a root to no root');
-    ShadyDOM.wrap(project).appendChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.equal(ShadyDOM.wrapIfNeeded(testChild).getRootNode(), test, 'getOwnerRoot incorrect for sub-child moved from a root to no root');
+    ShadyDOM.wrapIfNeeded(project).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
-    assert.equal(ShadyDOM.wrap(testChild).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for sub-child added to element in root');
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(testChild).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for sub-child added to element in root');
   });
 
   test('getRootNode (paper-ripple use case)', function() {
     var test = document.createElement('div');
     // child
     var d = document.createElement('div');
-    ShadyDOM.wrap(test).appendChild(d);
+    ShadyDOM.wrapIfNeeded(test).appendChild(d);
     var c1 = createEnabledElement('x-compose');
     var c2 = createEnabledElement('x-compose');
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(c1).shadowRoot).querySelector('#project')).appendChild(test);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project')).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(c2).shadowRoot).querySelector('#project')).appendChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c2).shadowRoot).querySelector('#project')).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrap(c2).shadowRoot, 'getOwnerRoot not correctly reset when element moved to different root');
-    ShadyDOM.wrap(c1).appendChild(test);
-    assert.equal(ShadyDOM.wrap(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c2).shadowRoot, 'getOwnerRoot not correctly reset when element moved to different root');
+    ShadyDOM.wrapIfNeeded(c1).appendChild(test);
+    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
   });
 
   test('assignedNodes while distributing', function() {
     var testElement = createEnabledElement('x-project');
     var d = document.createElement('div');
-    ShadyDOM.wrap(testElement).appendChild(d);
-    var slot = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('slot');
-    assert.deepEqual(ShadyDOM.wrap(slot).assignedNodes({flatten: true}), [d]);
+    ShadyDOM.wrapIfNeeded(testElement).appendChild(d);
+    var slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('slot');
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(slot).assignedNodes({flatten: true}), [d]);
   });
 
   test('insertion points on non-distributable element', function() {
@@ -1668,75 +1668,75 @@ suite('renders roots', function() {
 
   setup(function() {
     el = document.createElement('x-rereproject');
-    ShadyDOM.wrap(document.body).appendChild(el);
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(el);
     ShadyDOM.flush();
-    sinon.spy(ShadyDOM.wrap(el).shadowRoot, '_renderSelf');
-    p = ShadyDOM.wrap(el).shadowRoot.querySelector('x-reproject');
-    sinon.spy(ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot), '_renderSelf');
-    c = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).querySelector('x-project');
-    sinon.spy(ShadyDOM.wrap(c).shadowRoot, '_renderSelf');
+    sinon.spy(ShadyDOM.wrapIfNeeded(el).shadowRoot, '_renderSelf');
+    p = ShadyDOM.wrapIfNeeded(el).shadowRoot.querySelector('x-reproject');
+    sinon.spy(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot), '_renderSelf');
+    c = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot).querySelector('x-project');
+    sinon.spy(ShadyDOM.wrapIfNeeded(c).shadowRoot, '_renderSelf');
   });
 
   teardown(function() {
-    ShadyDOM.wrap(document.body).removeChild(el);
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(el);
   });
 
   test('renders all roots that are dirtied via distribution', function() {
-    ShadyDOM.wrap(el).appendChild(document.createElement('div'));
+    ShadyDOM.wrapIfNeeded(el).appendChild(document.createElement('div'));
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(el).shadowRoot._renderSelf.callCount, 1);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot)._renderSelf.callCount, 1);
-    assert.equal(ShadyDOM.wrap(c).shadowRoot._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(el).shadowRoot._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot)._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(c).shadowRoot._renderSelf.callCount, 1);
   });
 
   test('renders only roots that are dirty', function() {
-    ShadyDOM.wrap(c).appendChild(document.createElement('div'));
+    ShadyDOM.wrapIfNeeded(c).appendChild(document.createElement('div'));
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(el).shadowRoot._renderSelf.callCount, 0);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot)._renderSelf.callCount, 0);
-    assert.equal(ShadyDOM.wrap(c).shadowRoot._renderSelf.callCount, 1);
-    ShadyDOM.wrap(p).appendChild(document.createElement('div'));
+    assert.equal(ShadyDOM.wrapIfNeeded(el).shadowRoot._renderSelf.callCount, 0);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot)._renderSelf.callCount, 0);
+    assert.equal(ShadyDOM.wrapIfNeeded(c).shadowRoot._renderSelf.callCount, 1);
+    ShadyDOM.wrapIfNeeded(p).appendChild(document.createElement('div'));
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(el).shadowRoot._renderSelf.callCount, 0);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot)._renderSelf.callCount, 1);
-    assert.equal(ShadyDOM.wrap(c).shadowRoot._renderSelf.callCount, 2);
-    ShadyDOM.wrap(el).appendChild(document.createElement('div'));
+    assert.equal(ShadyDOM.wrapIfNeeded(el).shadowRoot._renderSelf.callCount, 0);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot)._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(c).shadowRoot._renderSelf.callCount, 2);
+    ShadyDOM.wrapIfNeeded(el).appendChild(document.createElement('div'));
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(el).shadowRoot._renderSelf.callCount, 1);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot)._renderSelf.callCount, 2);
-    assert.equal(ShadyDOM.wrap(c).shadowRoot._renderSelf.callCount, 3);
+    assert.equal(ShadyDOM.wrapIfNeeded(el).shadowRoot._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot)._renderSelf.callCount, 2);
+    assert.equal(ShadyDOM.wrapIfNeeded(c).shadowRoot._renderSelf.callCount, 3);
   });
 
   test('renders oldest dirty root', function() {
-    ShadyDOM.wrap(c).appendChild(document.createElement('div'));
-    ShadyDOM.wrap(p).appendChild(document.createElement('div'));
+    ShadyDOM.wrapIfNeeded(c).appendChild(document.createElement('div'));
+    ShadyDOM.wrapIfNeeded(p).appendChild(document.createElement('div'));
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(el).shadowRoot._renderSelf.callCount, 0);
-    assert.equal(ShadyDOM.wrap(p).shadowRoot._renderSelf.callCount, 1);
-    assert.equal(ShadyDOM.wrap(c).shadowRoot._renderSelf.callCount, 1);
-    ShadyDOM.wrap(el).appendChild(document.createElement('div'));
-    ShadyDOM.wrap(p).appendChild(document.createElement('div'));
+    assert.equal(ShadyDOM.wrapIfNeeded(el).shadowRoot._renderSelf.callCount, 0);
+    assert.equal(ShadyDOM.wrapIfNeeded(p).shadowRoot._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(c).shadowRoot._renderSelf.callCount, 1);
+    ShadyDOM.wrapIfNeeded(el).appendChild(document.createElement('div'));
+    ShadyDOM.wrapIfNeeded(p).appendChild(document.createElement('div'));
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(el).shadowRoot._renderSelf.callCount, 1);
-    assert.equal(ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot)._renderSelf.callCount, 2);
-    assert.equal(ShadyDOM.wrap(c).shadowRoot._renderSelf.callCount, 2);
+    assert.equal(ShadyDOM.wrapIfNeeded(el).shadowRoot._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot)._renderSelf.callCount, 2);
+    assert.equal(ShadyDOM.wrapIfNeeded(c).shadowRoot._renderSelf.callCount, 2);
   });
 
   test('renders oldest dirty root when slot moved', function() {
-    ShadyDOM.wrap(el).appendChild(document.createElement('div'));
+    ShadyDOM.wrapIfNeeded(el).appendChild(document.createElement('div'));
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(el).shadowRoot._renderSelf.callCount, 1);
-    assert.equal(ShadyDOM.wrap(p).shadowRoot._renderSelf.callCount, 1);
-    assert.equal(ShadyDOM.wrap(c).shadowRoot._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(el).shadowRoot._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(p).shadowRoot._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(c).shadowRoot._renderSelf.callCount, 1);
     // move the slot:
     // from: <x-project><slot></slot></x-project>
     // to: <x-project></x-project><slot></slot>
-    const slot = ShadyDOM.wrap(c).firstElementChild;
-    ShadyDOM.wrap(p).shadowRoot.appendChild(slot);
+    const slot = ShadyDOM.wrapIfNeeded(c).firstElementChild;
+    ShadyDOM.wrapIfNeeded(p).shadowRoot.appendChild(slot);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrap(el).shadowRoot._renderSelf.callCount, 1);
-    assert.equal(ShadyDOM.wrap(p).shadowRoot._renderSelf.callCount, 2);
-    assert.equal(ShadyDOM.wrap(c).shadowRoot._renderSelf.callCount, 2);
+    assert.equal(ShadyDOM.wrapIfNeeded(el).shadowRoot._renderSelf.callCount, 1);
+    assert.equal(ShadyDOM.wrapIfNeeded(p).shadowRoot._renderSelf.callCount, 2);
+    assert.equal(ShadyDOM.wrapIfNeeded(c).shadowRoot._renderSelf.callCount, 2);
   });
 
 

--- a/packages/shadydom/tests/shady-dynamic.html
+++ b/packages/shadydom/tests/shady-dynamic.html
@@ -1739,6 +1739,24 @@ suite('renders roots', function() {
     assert.equal(ShadyDOM.wrapIfNeeded(c).shadowRoot._renderSelf.callCount, 2);
   });
 
+  test('non-element nodes are correctly patched', function() {
+    const d = document.createElement('div');
+    document.body.appendChild(d);
+    d.innerHTML = `
+      <x-echo> <!-- comment --><![CDATA[ data ]]><? processing ?></x-echo>
+    `;
+    ShadyDOM.flush();
+    const el = d.firstElementChild;
+    assert.equal(el.childNodes.length, 4);
+    const slot = (ShadyDOM.wrapIfNeeded(el).shadowRoot.querySelector('slot'));
+    for (let i=0; i < el.childNodes.length; i++) {
+      const child = el.childNodes[i];
+      assert.equal(ShadyDOM.wrapIfNeeded(child).parentNode, el);
+      assert.equal(ShadyDOM.wrapIfNeeded(child).assignedSlot, slot);
+    }
+    document.body.removeChild(d);
+  });
+
 
 });
 

--- a/packages/shadydom/tests/shady-dynamic.html
+++ b/packages/shadydom/tests/shady-dynamic.html
@@ -713,16 +713,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   test('disconnected node: isConnected, getRootNode', function() {
     let div = document.createElement('div');
-    assert.isFalse(ShadyDOM.wrapIfNeeded(div).isConnected);
-    assert.equal(ShadyDOM.wrapIfNeeded(div).getRootNode(), div);
+    assert.isFalse(ShadyDOM.wrap(div).isConnected);
+    assert.equal(ShadyDOM.wrap(div).getRootNode(), div);
   });
 
   test('slot, assignedSlot accessor', function() {
     let div = document.createElement('div');
-    ShadyDOM.wrapIfNeeded(div).slot = 'slot';
-    assert.equal(ShadyDOM.wrapIfNeeded(div).slot, 'slot');
+    ShadyDOM.wrap(div).slot = 'slot';
+    assert.equal(ShadyDOM.wrap(div).slot, 'slot');
     assert.equal(div.getAttribute('slot'), 'slot');
-    assert.equal(ShadyDOM.wrapIfNeeded(div).assignedSlot, null);
+    assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
   });
 
   test('parentNode', function() {
@@ -1552,12 +1552,12 @@ suite('non-distributed elements', function() {
     var c2 = createEnabledElement('x-compose');
     ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project')).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
     ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c2).shadowRoot).querySelector('#project')).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c2).shadowRoot, 'getOwnerRoot not correctly reset when element moved to different root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c2).shadowRoot, 'getOwnerRoot not correctly reset when element moved to different root');
     ShadyDOM.wrapIfNeeded(c1).appendChild(test);
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
   });
 
   test('getRootNode into/out of shadowRoot', function() {
@@ -1565,68 +1565,68 @@ suite('non-distributed elements', function() {
     var c1 = createEnabledElement('x-compose');
     ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project')).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
     ShadyDOM.wrap(document.body).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), document, 'getOwnerRoot not correctly reset when element moved to different root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), document, 'getOwnerRoot not correctly reset when element moved to different root');
     ShadyDOM.wrap(c1).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
   });
 
 
   test('getRootNode when out of tree', function() {
     var test = document.createElement('div');
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), test, 'getOwnerRoot incorrect when not in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), test, 'getOwnerRoot incorrect when not in root');
     var c1 = createEnabledElement('x-compose');
     var project = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project');
     ShadyDOM.wrapIfNeeded(project).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
     ShadyDOM.wrapIfNeeded(project).removeChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
     ShadyDOM.wrapIfNeeded(project).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
   });
 
   test('getRootNode when out of tree and adding subtree', function() {
     var container = document.createDocumentFragment();
     var test = document.createElement('div');
     ShadyDOM.wrapIfNeeded(container).appendChild(test);
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), container, 'getOwnerRoot incorrect when not in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), container, 'getOwnerRoot incorrect when not in root');
     var c1 = createEnabledElement('x-compose');
     var project = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project');
     ShadyDOM.wrapIfNeeded(project).appendChild(container);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
     ShadyDOM.wrapIfNeeded(project).removeChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
     ShadyDOM.wrapIfNeeded(project).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
   });
 
   test('getRootNode, subtree', function() {
     var test = document.createElement('div');
     var testChild = document.createElement('div');
     ShadyDOM.wrapIfNeeded(test).appendChild(testChild);
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), test, 'getOwnerRoot incorrect when not in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), test, 'getOwnerRoot incorrect when not in root');
     var c1 = createEnabledElement('x-compose');
     var project = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project');
     ShadyDOM.wrapIfNeeded(project).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
     assert.equal(ShadyDOM.wrap(testChild).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for sub-child added to element in root');
     ShadyDOM.wrapIfNeeded(project).removeChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
-    assert.equal(ShadyDOM.wrapIfNeeded(testChild).getRootNode(), test, 'getOwnerRoot incorrect for sub-child moved from a root to no root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), test, 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.equal(ShadyDOM.wrap(testChild).getRootNode(), test, 'getOwnerRoot incorrect for sub-child moved from a root to no root');
     ShadyDOM.wrapIfNeeded(project).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
     assert.equal(ShadyDOM.wrap(testChild).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for sub-child added to element in root');
   });
 
@@ -1639,12 +1639,12 @@ suite('non-distributed elements', function() {
     var c2 = createEnabledElement('x-compose');
     ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c1).shadowRoot).querySelector('#project')).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c1).shadowRoot, 'getOwnerRoot incorrect for child added to element in root');
     ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(c2).shadowRoot).querySelector('#project')).appendChild(test);
     ShadyDOM.flush();
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), ShadyDOM.wrapIfNeeded(c2).shadowRoot, 'getOwnerRoot not correctly reset when element moved to different root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), ShadyDOM.wrapIfNeeded(c2).shadowRoot, 'getOwnerRoot not correctly reset when element moved to different root');
     ShadyDOM.wrapIfNeeded(c1).appendChild(test);
-    assert.equal(ShadyDOM.wrapIfNeeded(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
+    assert.equal(ShadyDOM.wrap(test).getRootNode(), c1, 'getOwnerRoot incorrect for child moved from a root to no root');
   });
 
   test('assignedNodes while distributing', function() {

--- a/packages/shadydom/tests/shady.html
+++ b/packages/shadydom/tests/shady.html
@@ -15,7 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script>
-    ShadyDOM = {force: true, noPatch: window.location.search.match('noPatch')};
+    ShadyDOM = {force: true, noPatch: window.location.search.match('noPatch=on-demand') ? 'on-demand' : !!window.location.search.match('noPatch')};
   </script>
   <script src="../shadydom.min.js"></script>
 
@@ -35,59 +35,59 @@ suite('Rendering', function() {
     test(descr, function() {
       // Create an instance of the test element.
       var host = document.createElement('div');
-      ShadyDOM.wrap(host).attachShadow({mode: 'open'});
+      ShadyDOM.wrapIfNeeded(host).attachShadow({mode: 'open'});
       // Populate the initial pool of light DOM children.
-      ShadyDOM.wrap(host).innerHTML = hostInnerHtml;
-      ShadyDOM.wrap(document.body).appendChild(host);
+      ShadyDOM.wrapIfNeeded(host).innerHTML = hostInnerHtml;
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(host);
           // Pretend we're stamping the template contents.
       if (shadowRootHtml) {
-        ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = shadowRootHtml;
+        ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = shadowRootHtml;
       }
       // Invoke distribution and verify the resulting tree.
       ShadyDOM.flush();
       assert.strictEqual(getComposedHTML(host), expectedHtml);
-      ShadyDOM.wrap(document.body).removeChild(host);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(host);
     });
     test(descr + ' fragment', function() {
       // Create an instance of the test element.
       var host = document.createElement('div');
-      ShadyDOM.wrap(host).attachShadow({mode: 'open'});
+      ShadyDOM.wrapIfNeeded(host).attachShadow({mode: 'open'});
       // Populate the initial pool of light DOM children.
-      ShadyDOM.wrap(host).innerHTML = hostInnerHtml;
-      ShadyDOM.wrap(document.body).appendChild(host);
+      ShadyDOM.wrapIfNeeded(host).innerHTML = hostInnerHtml;
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(host);
           // Pretend we're stamping the template contents.
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).innerHTML = shadowRootHtml;
+      ShadyDOM.wrapIfNeeded(div).innerHTML = shadowRootHtml;
       var frag = document.createDocumentFragment();
-      while (ShadyDOM.wrap(div).firstChild) {
-        ShadyDOM.wrap(frag).appendChild(ShadyDOM.wrap(div).firstChild);
+      while (ShadyDOM.wrapIfNeeded(div).firstChild) {
+        ShadyDOM.wrapIfNeeded(frag).appendChild(ShadyDOM.wrapIfNeeded(div).firstChild);
       }
-      ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).appendChild(frag);
       // Invoke distribution and verify the resulting tree.
       ShadyDOM.flush();
       assert.strictEqual(getComposedHTML(host), expectedHtml);
-      ShadyDOM.wrap(document.body).removeChild(host);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(host);
     });
 
     test(descr + ' fragment via options: shadyUpgradeFragment', function() {
       // Create an instance of the test element.
       var host = document.createElement('div');
       // Populate the initial pool of light DOM children.
-      ShadyDOM.wrap(host).innerHTML = hostInnerHtml;
-      ShadyDOM.wrap(document.body).appendChild(host);
+      ShadyDOM.wrapIfNeeded(host).innerHTML = hostInnerHtml;
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(host);
           // Pretend we're stamping the template contents.
       var div = document.createElement('div');
-      ShadyDOM.wrap(div).innerHTML = shadowRootHtml;
+      ShadyDOM.wrapIfNeeded(div).innerHTML = shadowRootHtml;
       var frag = document.createDocumentFragment();
-      while (ShadyDOM.wrap(div).firstChild) {
-        ShadyDOM.wrap(frag).appendChild(ShadyDOM.wrap(div).firstChild);
+      while (ShadyDOM.wrapIfNeeded(div).firstChild) {
+        ShadyDOM.wrapIfNeeded(frag).appendChild(ShadyDOM.wrapIfNeeded(div).firstChild);
       }
-      ShadyDOM.wrap(host).attachShadow({mode: 'open', shadyUpgradeFragment: frag});
-      ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).appendChild(frag);
+      ShadyDOM.wrapIfNeeded(host).attachShadow({mode: 'open', shadyUpgradeFragment: frag});
+      ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).appendChild(frag);
       // Invoke distribution and verify the resulting tree.
       ShadyDOM.flush();
       assert.strictEqual(getComposedHTML(host), expectedHtml);
-      ShadyDOM.wrap(document.body).removeChild(host);
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(host);
     });
   }
 
@@ -142,45 +142,45 @@ suite('Reprojection', function() {
 
   test('Reprojection', function() {
     var host = document.createElement('div');
-    ShadyDOM.wrap(host).attachShadow({mode: 'open'});
-    ShadyDOM.wrap(document.body).appendChild(host);
-      ShadyDOM.wrap(host).innerHTML = '<a></a>';
+    ShadyDOM.wrapIfNeeded(host).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(host);
+      ShadyDOM.wrapIfNeeded(host).innerHTML = '<a></a>';
     // pre-distirbution grab first composed node.
     var a = getComposedChildAtIndex(host, 0);
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<div id="p"></div>';
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstElementChild).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<div id="p"></div>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstElementChild).attachShadow({mode: 'open'});
     // force upgrade on polyfilled browsers
-    var p = ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild;
-      ShadyDOM.wrap(p).innerHTML = '<b slot="b"></b><slot slot="a"></slot>';
-    var b = ShadyDOM.wrap(p).firstChild;
-    var content = ShadyDOM.wrap(p).lastChild;
+    var p = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstChild;
+      ShadyDOM.wrapIfNeeded(p).innerHTML = '<b slot="b"></b><slot slot="a"></slot>';
+    var b = ShadyDOM.wrapIfNeeded(p).firstChild;
+    var content = ShadyDOM.wrapIfNeeded(p).lastChild;
 
-    ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).innerHTML =
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot).innerHTML =
         'a: <slot name="a"></slot>b: <slot name="b"></slot>';
-    var textNodeA = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).firstChild;
-    var contentA = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes[1];
-    var textNodeB = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes[2];
-    var contentB = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes[3];
+    var textNodeA = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot).firstChild;
+    var contentA = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot).childNodes[1];
+    var textNodeB = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot).childNodes[2];
+    var contentB = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot).childNodes[3];
 
     function testRender() {
       ShadyDOM.flush();
       assert.strictEqual(getComposedHTML(host),
           '<div id="p">a: <a></a>b: <b slot="b"></b></div>');
 
-      assert.deepEqual(Array.from(ShadyDOM.wrap(host).childNodes), [a]);
-      assert.strictEqual(ShadyDOM.wrap(a).parentNode, host);
-      assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).childNodes), [p]);
-      assert.strictEqual(ShadyDOM.wrap(p).parentNode, ShadyDOM.wrap(host).shadowRoot);
-      assert.deepEqual(Array.from(ShadyDOM.wrap(p).childNodes), [b, content]);
-      assert.strictEqual(ShadyDOM.wrap(b).parentNode, p);
-      assert.strictEqual(ShadyDOM.wrap(content).parentNode, p);
-      assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes),
+      assert.deepEqual(Array.from(ShadyDOM.wrapIfNeeded(host).childNodes), [a]);
+      assert.strictEqual(ShadyDOM.wrapIfNeeded(a).parentNode, host);
+      assert.deepEqual(Array.from(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).childNodes), [p]);
+      assert.strictEqual(ShadyDOM.wrapIfNeeded(p).parentNode, ShadyDOM.wrapIfNeeded(host).shadowRoot);
+      assert.deepEqual(Array.from(ShadyDOM.wrapIfNeeded(p).childNodes), [b, content]);
+      assert.strictEqual(ShadyDOM.wrapIfNeeded(b).parentNode, p);
+      assert.strictEqual(ShadyDOM.wrapIfNeeded(content).parentNode, p);
+      assert.deepEqual(Array.from(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(p).shadowRoot).childNodes),
           [textNodeA, contentA, textNodeB, contentB]);
     }
 
     testRender();
     testRender();
-    ShadyDOM.wrap(document.body).removeChild(host);
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(host);
   });
 
 });
@@ -191,97 +191,97 @@ suite('Mutate light DOM', function() {
 
   setup(function() {
     host = document.createElement('div');
-    ShadyDOM.wrap(host).attachShadow({mode: 'open'});
-    ShadyDOM.wrap(document.body).appendChild(host);
+    ShadyDOM.wrapIfNeeded(host).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(host);
   });
 
   teardown(function() {
-    ShadyDOM.wrap(document.body).removeChild(host);
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(host);
   });
 
   test('removeAllChildNodes - mutate host', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot>fallback</slot>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot>fallback</slot>';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).firstChild).textContent = '';
+    ShadyDOM.wrap(ShadyDOM.wrapIfNeeded(host).firstChild).textContent = '';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a></a>');
 
-    ShadyDOM.wrap(host).innerHTML = '';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), 'fallback');
   });
 
 
   test('removeAllChildNodes - mutate shadow', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot><b>after</b>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot><b>after</b>';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a><b>after</b>');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).childNodes[1].textContent = '';
+    ShadyDOM.wrap(ShadyDOM.wrapIfNeeded(host).shadowRoot).childNodes[1].textContent = '';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a><b></b>');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '');
   });
 
   test('removeAllChildNodes - mutate shadow nested', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
-    const hostChild = ShadyDOM.wrap(host).firstChild;
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<div><slot></slot><b>after</b></div>';
-    const slot = ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild).firstChild;
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const hostChild = ShadyDOM.wrapIfNeeded(host).firstChild;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<div><slot></slot><b>after</b></div>';
+    const slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstChild).firstChild;
     assert.equal(slot.localName, 'slot');
     assert.deepEqual(ShadyDOM.wrap(slot).assignedNodes(), [hostChild]);
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<div><a>Hello</a><b>after</b></div>');
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).childNodes[0]).textContent = '';
+    ShadyDOM.wrap(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).childNodes[0]).textContent = '';
     ShadyDOM.flush();
-    assert.deepEqual(ShadyDOM.wrap(slot).assignedNodes(), []);
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(slot).assignedNodes(), []);
     assert.strictEqual(getComposedHTML(host), '<div></div>');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '');
   });
 
   test('removeAllChildNodes - mutate shadow deep nested', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
-    const hostChild = ShadyDOM.wrap(host).firstChild;
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<div><div><slot></slot><b>after</b></div></div>';
-    const slot = ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild).firstChild).firstChild;
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const hostChild = ShadyDOM.wrapIfNeeded(host).firstChild;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<div><div><slot></slot><b>after</b></div></div>';
+    const slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstChild).firstChild).firstChild;
     assert.equal(slot.localName, 'slot');
     assert.deepEqual(ShadyDOM.wrap(slot).assignedNodes(), [hostChild]);
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<div><div><a>Hello</a><b>after</b></div></div>');
-    const div = ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).childNodes[0];
+    const div = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).childNodes[0];
     // NOTE: older browsers without prototype accessors need patching
     // to handle setting properties. This node is a child of a shadowRoot
     // and therefore has patched "outside" accessors but "textContent" is
     // only patched if the node has logical "inside" accessors (children)
     // which in this case it does not. We workaround this by manually patching
     // for the test.
-    ShadyDOM.wrap(ShadyDOM.patch(div)).textContent = '';
+    ShadyDOM.wrap(div).textContent = '';
     ShadyDOM.flush();
-    assert.deepEqual(ShadyDOM.wrap(slot).assignedNodes(), []);
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(slot).assignedNodes(), []);
     assert.strictEqual(getComposedHTML(host), '<div></div>');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '');
   });
 
   test('removeAllChildNodes - mutate shadow fallback', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot name="xxx"><b>fallback</b></slot>';
-    var b = ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild).firstChild;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot name="xxx"><b>fallback</b></slot>';
+    var b = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstChild).firstChild;
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<b>fallback</b>');
 
@@ -289,19 +289,19 @@ suite('Mutate light DOM', function() {
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<b></b>');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild).innerHTML = '';
+    ShadyDOM.wrap(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstChild).innerHTML = '';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '');
   });
 
   test('removeChild - mutate host', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot>fallback</slot>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot>fallback</slot>';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
 
@@ -309,34 +309,34 @@ suite('Mutate light DOM', function() {
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a></a>');
 
-    ShadyDOM.wrap(host).innerHTML = '';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), 'fallback');
   });
 
   test('removeChild - mutate host 2', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a></a><b></b>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a></a><b></b>';
     var a = getComposedChildAtIndex(host, 0);
     var b = getComposedChildAtIndex(host, 1);
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot>fallback</slot>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot>fallback</slot>';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a></a><b></b>');
 
-    ShadyDOM.wrap(host).removeChild(b);
+    ShadyDOM.wrapIfNeeded(host).removeChild(b);
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a></a>');
 
-    ShadyDOM.wrap(host).removeChild(a);
+    ShadyDOM.wrapIfNeeded(host).removeChild(a);
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), 'fallback');
   });
 
   test('removeChild - mutate shadow', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot><b>after</b>';
-    var b = ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).lastChild;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot><b>after</b>';
+    var b = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).lastChild;
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a><b>after</b>');
 
@@ -344,37 +344,37 @@ suite('Mutate light DOM', function() {
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a><b></b>');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).removeChild(b);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).removeChild(b);
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).removeChild(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).removeChild(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstChild);
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '');
   });
 
   test('setAttribute slot', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a slot="a">Hello</a><b slot="b">World</b>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a slot="a">Hello</a><b slot="b">World</b>';
 
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot name="b">fallback b</slot>' +
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot name="b">fallback b</slot>' +
                             '<slot name="a">fallback a</slot>';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<b slot="b">World</b><a slot="a">Hello</a>');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild).setAttribute('name', 'xxx');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstChild).setAttribute('name', 'xxx');
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), 'fallback b<a slot="a">Hello</a>');
 
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild).setAttribute('name', '');
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).lastChild).setAttribute('name', '');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstChild).setAttribute('name', '');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).lastChild).setAttribute('name', '');
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), 'fallback bfallback a');
   });
 
   test('appendChild - mutate host', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
 
@@ -385,21 +385,21 @@ suite('Mutate light DOM', function() {
   });
 
   test('appendChild - mutate shadow', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
 
     var b = document.createElement('b');
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).appendChild(b);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).appendChild(b);
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a><b></b>');
   });
 
   test('insertBefore - mutate host', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
     var a = getComposedChildAtIndex(host, 0);
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
 
@@ -410,92 +410,92 @@ suite('Mutate light DOM', function() {
   });
 
   test('insertBefore - mutate shadow', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
 
 
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot>';
-    var content = ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    var content = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstChild;
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
 
     var b = document.createElement('b');
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).insertBefore(b, content);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).insertBefore(b, content);
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<b></b><a>Hello</a>');
   });
 
   test('replaceChild - mutate host', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
     var b = document.createElement('b');
-    host.replaceChild(b, ShadyDOM.wrap(host).firstChild);
+    host.replaceChild(b, ShadyDOM.wrapIfNeeded(host).firstChild);
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<b></b>');
   });
 
   test('replaceChild - mutate shadow', function() {
-    ShadyDOM.wrap(host).innerHTML = '<a>Hello</a>';
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot>';
-    var content = ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild;
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    var content = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).firstChild;
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
     var b = document.createElement('b');
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).replaceChild(b, content);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).replaceChild(b, content);
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<b></b>');
   });
 
   test('querySelectorAll .shadowRoot', function() {
-    ShadyDOM.wrap(host).innerHTML = '<div id="main"></div>';
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot><span id="main"></span>' +
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<div id="main"></div>';
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot><span id="main"></span>' +
       '<div></div>';
-    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).lastElementChild).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).lastElementChild).attachShadow({mode: 'open'});
     // force upgrade on polyfilled browsers
         ShadyDOM.flush();
-    var hostLocalMain = getComposedChildAtIndex(ShadyDOM.wrap(host).shadowRoot, 1);
-    var child = getComposedChildAtIndex(ShadyDOM.wrap(host).shadowRoot, 100);
-    ShadyDOM.wrap(child).innerHTML = '<div id="sub"></div>';
+    var hostLocalMain = getComposedChildAtIndex(ShadyDOM.wrapIfNeeded(host).shadowRoot, 1);
+    var child = getComposedChildAtIndex(ShadyDOM.wrapIfNeeded(host).shadowRoot, 100);
+    ShadyDOM.wrapIfNeeded(child).innerHTML = '<div id="sub"></div>';
     var childLightSub = getComposedChildAtIndex(child, 0);
-    ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
-    var childLocalSub = ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).lastChild;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
+    var childLocalSub = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(child).shadowRoot).lastChild;
     ShadyDOM.flush();
-    assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelectorAll('span#main').item(0), hostLocalMain);
-    assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelectorAll('div#sub')[0], childLightSub);
-    assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).querySelectorAll('span#sub')), [childLocalSub]);
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).querySelectorAll('span#main').item(0), hostLocalMain);
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).querySelectorAll('div#sub')[0], childLightSub);
+    assert.deepEqual(Array.from(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(child).shadowRoot).querySelectorAll('span#sub')), [childLocalSub]);
   });
 
   test('querySelectorAll (light dom)', function() {
-    ShadyDOM.wrap(host).innerHTML = '<div id="main"></div>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<div id="main"></div>';
     var hostLightMain = getComposedChildAtIndex(host, 0);
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot><span id="main"></span>' +
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot><span id="main"></span>' +
       '<div></div>';
-    var child = ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).lastElementChild;
-    ShadyDOM.wrap(child).attachShadow({mode: 'open'});
-    ShadyDOM.wrap(child).innerHTML = '<div id="sub"></div>';
-    var childLightSub = ShadyDOM.wrap(child).lastElementChild;
-    ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
+    var child = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).lastElementChild;
+    ShadyDOM.wrapIfNeeded(child).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(child).innerHTML = '<div id="sub"></div>';
+    var childLightSub = ShadyDOM.wrapIfNeeded(child).lastElementChild;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
     ShadyDOM.flush();
-    assert.deepEqual(ShadyDOM.wrap(host).querySelectorAll('div#main').item(0), hostLightMain);
-    assert.deepEqual(Array.from(ShadyDOM.wrap(host).querySelectorAll('#sub')), []);
-    assert.deepEqual(ShadyDOM.wrap(child).querySelectorAll('div#sub')[0], childLightSub);
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(host).querySelectorAll('div#main').item(0), hostLightMain);
+    assert.deepEqual(Array.from(ShadyDOM.wrapIfNeeded(host).querySelectorAll('#sub')), []);
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(child).querySelectorAll('div#sub')[0], childLightSub);
   });
 
   test('querySelectorAll useNative (light dom)', function() {
-    ShadyDOM.wrap(host).innerHTML = '<div id="main"></div>';
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<div id="main"></div>';
     var hostLightMain = getComposedChildAtIndex(host, 0);
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<slot></slot><span id="main"></span>' +
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot><span id="main"></span>' +
       '<div></div>';
-    var child = ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).lastElementChild;
-    ShadyDOM.wrap(child).attachShadow({mode: 'open'});
-    ShadyDOM.wrap(child).innerHTML = '<div id="sub"></div>';
-    var childLightSub = ShadyDOM.wrap(child).lastElementChild;
-    ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
+    var child = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).lastElementChild;
+    ShadyDOM.wrapIfNeeded(child).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(child).innerHTML = '<div id="sub"></div>';
+    var childLightSub = ShadyDOM.wrapIfNeeded(child).lastElementChild;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
     ShadyDOM.flush();
-    assert.deepEqual(ShadyDOM.wrap(host).querySelectorAll('div#main', true).item(0), hostLightMain);
-    assert.deepEqual(Array.from(ShadyDOM.wrap(host).querySelectorAll('#sub', true)), []);
-    assert.deepEqual(ShadyDOM.wrap(child).querySelectorAll('div#sub', true)[0], childLightSub);
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(host).querySelectorAll('div#main', true).item(0), hostLightMain);
+    assert.deepEqual(Array.from(ShadyDOM.wrapIfNeeded(host).querySelectorAll('#sub', true)), []);
+    assert.deepEqual(ShadyDOM.wrapIfNeeded(child).querySelectorAll('div#sub', true)[0], childLightSub);
   });
 
 });
@@ -507,8 +507,8 @@ suite('Add.shadowRoot to element with childNodes', function() {
   setup(function() {
     el = document.createElement('div');
     el.testHTML = '<div slot="a">hi</div>';
-    ShadyDOM.wrap(el).innerHTML = el.testHTML;
-    ShadyDOM.wrap(el).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(el).innerHTML = el.testHTML;
+    ShadyDOM.wrapIfNeeded(el).attachShadow({mode: 'open'});
   });
 
   test('empty root', function() {
@@ -518,21 +518,21 @@ suite('Add.shadowRoot to element with childNodes', function() {
 
   test('simple root', function() {
     var shadow = '<div>shadow</div>';
-    ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).innerHTML = shadow;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).innerHTML = shadow;
     ShadyDOM.flush();
     assert.equal(getComposedHTML(el), shadow);
   });
 
   test('slot matching', function() {
     var shadow = '<div><slot name="a"></slot></div>';
-    ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).innerHTML = shadow;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).innerHTML = shadow;
     ShadyDOM.flush();
     assert.equal(getComposedHTML(el), '<div>' + el.testHTML + '</div>');
   });
 
   test('slot not matching', function() {
     var shadow = '<div><slot name="b"></slot></div>';
-    ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).innerHTML = shadow;
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).innerHTML = shadow;
     ShadyDOM.flush();
     assert.equal(getComposedHTML(el), '<div></div>');
   });
@@ -554,9 +554,9 @@ suite('Add.shadowRoot to element with childNodes', function() {
     }
     var div = document.createElement("div");
     var span = document.createElement("span");
-    ShadyDOM.wrap(span).innerText = 'Hello';
-    ShadyDOM.wrap(div).appendChild(span);
-    ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(div);
+    ShadyDOM.wrapIfNeeded(span).innerText = 'Hello';
+    ShadyDOM.wrapIfNeeded(div).appendChild(span);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(div);
     assert.isOk(JSON.stringify(div));
   });
 });
@@ -568,36 +568,36 @@ suite('Patch of addEventListener/removeEventListener', function() {
 
   setup(function() {
     el1 = document.createElement('button');
-    ShadyDOM.wrap(el1).textContent = 'hi';
-    ShadyDOM.wrap(document.body).appendChild(el1);
+    ShadyDOM.wrapIfNeeded(el1).textContent = 'hi';
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(el1);
 
     el2 = document.createElement('button');
-    ShadyDOM.wrap(el2).textContent = 'hi again';
-    ShadyDOM.wrap(document.body).appendChild(el2);
+    ShadyDOM.wrapIfNeeded(el2).textContent = 'hi again';
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(el2);
 
     callback = sinon.stub();
   });
 
   teardown(function() {
-    ShadyDOM.wrap(el1).parentNode && ShadyDOM.wrap(ShadyDOM.wrap(el1).parentNode).removeChild(el1);
-    ShadyDOM.wrap(el2).parentNode && ShadyDOM.wrap(ShadyDOM.wrap(el2).parentNode).removeChild(el2);
+    ShadyDOM.wrapIfNeeded(el1).parentNode && ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el1).parentNode).removeChild(el1);
+    ShadyDOM.wrapIfNeeded(el2).parentNode && ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el2).parentNode).removeChild(el2);
   });
 
   test('different events, same callback', function() {
-    ShadyDOM.wrap(el1).addEventListener('test-event-1', callback);
-    ShadyDOM.wrap(el1).addEventListener('test-event-2', callback);
-    ShadyDOM.wrap(el1).dispatchEvent(new CustomEvent('test-event-1'));
-    ShadyDOM.wrap(el1).dispatchEvent(new CustomEvent('test-event-2'));
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('test-event-1', callback);
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('test-event-2', callback);
+    ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new CustomEvent('test-event-1'));
+    ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new CustomEvent('test-event-2'));
     assert.equal(callback.callCount, 2, 'called twice');
-    ShadyDOM.wrap(el1).removeEventListener('test-event-1', callback);
-    ShadyDOM.wrap(el1).removeEventListener('test-event-2', callback);
-    ShadyDOM.wrap(el1).dispatchEvent(new CustomEvent('test-event-1'));
-    ShadyDOM.wrap(el1).dispatchEvent(new CustomEvent('test-event-2'));
+    ShadyDOM.wrapIfNeeded(el1).removeEventListener('test-event-1', callback);
+    ShadyDOM.wrapIfNeeded(el1).removeEventListener('test-event-2', callback);
+    ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new CustomEvent('test-event-1'));
+    ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new CustomEvent('test-event-2'));
     assert.equal(callback.callCount, 2, 'listeners removed (callCount did not increase)');
   });
 
   test('support `once` option', function() {
-    ShadyDOM.wrap(el1).addEventListener('click', callback, {once: true});
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {once: true});
     el1.click();
     assert.equal(callback.callCount, 1, 'listener called once');
     el1.click();
@@ -605,57 +605,57 @@ suite('Patch of addEventListener/removeEventListener', function() {
   });
 
   test('same event, same callback, different options', function() {
-    ShadyDOM.wrap(el1).addEventListener('click', callback, {passive: true});
-    ShadyDOM.wrap(el1).addEventListener('click', callback, {capture: true});
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {passive: true});
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {capture: true});
     el1.click();
     assert.equal(callback.callCount, 2, 'called twice');
-    ShadyDOM.wrap(el1).removeEventListener('click', callback, {passive: true});
+    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback, {passive: true});
     el1.click();
     assert.equal(callback.callCount, 3, 'called by capturing listener');
-    ShadyDOM.wrap(el1).removeEventListener('click', callback, {capture: true});
+    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback, {capture: true});
     el1.click();
     assert.equal(callback.callCount, 3, 'listeners removed (callCount did not increase)');
   });
 
   test('add same listener twice, invoke callback once', function() {
-    ShadyDOM.wrap(el1).addEventListener('click', callback);
-    ShadyDOM.wrap(el1).addEventListener('click', callback);
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback);
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback);
     el1.click();
     assert.equal(callback.callCount, 1, 'called once');
-    ShadyDOM.wrap(el1).removeEventListener('click', callback);
+    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback);
     el1.click();
     assert.equal(callback.callCount, 1, 'listener removed (callCount did not increase)');
   });
 
   test('add same listener twice, invoke callback once (different useCapture notation)', function() {
-    ShadyDOM.wrap(el1).addEventListener('click', callback, true /* useCapture */);
-    ShadyDOM.wrap(el1).addEventListener('click', callback, {capture: true});
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, true /* useCapture */);
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {capture: true});
     el1.click();
     assert.equal(callback.callCount, 1, 'listener called once');
-    ShadyDOM.wrap(el1).removeEventListener('click', callback, {capture: true});
+    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback, {capture: true});
     el1.click();
     assert.equal(callback.callCount, 1, 'listener removed (callCount did not increase)');
   });
 
   test('add same listener twice, different order of options keys', function() {
-    ShadyDOM.wrap(el1).addEventListener('click', callback, {capture: false, passive: true});
-    ShadyDOM.wrap(el1).addEventListener('click', callback, {passive: true, capture: false});
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {capture: false, passive: true});
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {passive: true, capture: false});
     el1.click();
     assert.equal(callback.callCount, 1, 'listener called once');
-    ShadyDOM.wrap(el1).removeEventListener('click', callback, {passive: true, capture: false});
+    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback, {passive: true, capture: false});
     el1.click();
     assert.equal(callback.callCount, 1, 'listener removed (callCount did not increase)');
   });
 
   test('add same listener on two different nodes', function() {
-    ShadyDOM.wrap(el1).addEventListener('click', callback);
-    ShadyDOM.wrap(el2).addEventListener('click', callback);
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback);
+    ShadyDOM.wrapIfNeeded(el2).addEventListener('click', callback);
     el1.click();
     assert.equal(callback.callCount, 1, 'called once');
     el2.click();
     assert.equal(callback.callCount, 2, 'called twice');
-    ShadyDOM.wrap(el1).removeEventListener('click', callback);
-    ShadyDOM.wrap(el2).removeEventListener('click', callback);
+    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback);
+    ShadyDOM.wrapIfNeeded(el2).removeEventListener('click', callback);
     el1.click();
     el2.click();
     assert.equal(callback.callCount, 2, 'listeners removed (callCount did not increase)');
@@ -663,16 +663,16 @@ suite('Patch of addEventListener/removeEventListener', function() {
 
   test('add listener with `handleEvent` function', function() {
     var obj = {handleEvent: sinon.stub()};
-    ShadyDOM.wrap(el1).addEventListener('click', obj);
-    ShadyDOM.wrap(el2).addEventListener('click', obj);
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', obj);
+    ShadyDOM.wrapIfNeeded(el2).addEventListener('click', obj);
     el1.click();
     assert.isTrue(obj.handleEvent.calledOn(obj), 'called on object listened');
     assert.isTrue(obj.handleEvent.args[0][0] instanceof Event, 'called with event argument');
     assert.equal(obj.handleEvent.callCount, 1, 'called once');
     el2.click();
     assert.equal(obj.handleEvent.callCount, 2, 'called twice');
-    ShadyDOM.wrap(el1).removeEventListener('click', obj);
-    ShadyDOM.wrap(el2).removeEventListener('click', obj);
+    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', obj);
+    ShadyDOM.wrapIfNeeded(el2).removeEventListener('click', obj);
     el1.click();
     el2.click();
     assert.equal(obj.handleEvent.callCount, 2, 'listeners removed (callCount did not increase)');
@@ -680,23 +680,23 @@ suite('Patch of addEventListener/removeEventListener', function() {
 
   test('add listener with an object missing `handleEvent` function', function() {
     var obj = {};
-    ShadyDOM.wrap(el1).addEventListener('foo', obj);
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('foo', obj);
     assert.doesNotThrow(function() {
-      ShadyDOM.wrap(el1).dispatchEvent(new Event('foo'))
+      ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new Event('foo'))
     });
   });
 
   test('add listener with an object with `handleEvent` that is not a function', function() {
     var obj = {handleEvent: true};
-    ShadyDOM.wrap(el1).addEventListener('zip', obj);
+    ShadyDOM.wrapIfNeeded(el1).addEventListener('zip', obj);
     assert.doesNotThrow(function () {
-      ShadyDOM.wrap(el1).dispatchEvent(new Event('zip'))
+      ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new Event('zip'))
     });
   });
 
   test('add null listener', function() {
     assert.doesNotThrow(function() {
-      ShadyDOM.wrap(el1).addEventListener('baz', null);
+      ShadyDOM.wrapIfNeeded(el1).addEventListener('baz', null);
     });
   });
 
@@ -705,7 +705,7 @@ suite('Patch of addEventListener/removeEventListener', function() {
 suite('Patch of innerHTML setter', function() {
   test('support top-level table elements in template', function() {
     const template = document.createElement('template');
-    ShadyDOM.wrap(template).innerHTML = '<tr><td></td></tr><tr><td></td></tr>';
+    ShadyDOM.wrapIfNeeded(template).innerHTML = '<tr><td></td></tr><tr><td></td></tr>';
     assert.equal(template.content.childNodes.length, 2);
     assert.equal(template.content.childNodes[0].tagName, 'TR');
     assert.equal(template.content.childNodes[1].tagName, 'TR');
@@ -723,10 +723,10 @@ suite('Patch of getElementById', function() {
 
 function getEffectiveChildNodes(node) {
   var list = [];
-  var c$ = ShadyDOM.wrap(node).childNodes;
+  var c$ = ShadyDOM.wrapIfNeeded(node).childNodes;
   for (var i=0, l=c$.length, c; (i<l) && (c=c$[i]); i++) {
     if (c.localName && (c.localName === 'slot')) {
-      list = list.concat(ShadyDOM.wrap(c).assignedNodes({flatten: true}));
+      list = list.concat(ShadyDOM.wrapIfNeeded(c).assignedNodes({flatten: true}));
     } else {
       list.push(c);
     }

--- a/packages/shadydom/tests/shady.html
+++ b/packages/shadydom/tests/shady.html
@@ -584,20 +584,20 @@ suite('Patch of addEventListener/removeEventListener', function() {
   });
 
   test('different events, same callback', function() {
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('test-event-1', callback);
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('test-event-2', callback);
-    ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new CustomEvent('test-event-1'));
-    ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new CustomEvent('test-event-2'));
+    ShadyDOM.wrap(el1).addEventListener('test-event-1', callback);
+    ShadyDOM.wrap(el1).addEventListener('test-event-2', callback);
+    ShadyDOM.wrap(el1).dispatchEvent(new CustomEvent('test-event-1'));
+    ShadyDOM.wrap(el1).dispatchEvent(new CustomEvent('test-event-2'));
     assert.equal(callback.callCount, 2, 'called twice');
-    ShadyDOM.wrapIfNeeded(el1).removeEventListener('test-event-1', callback);
-    ShadyDOM.wrapIfNeeded(el1).removeEventListener('test-event-2', callback);
-    ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new CustomEvent('test-event-1'));
-    ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new CustomEvent('test-event-2'));
+    ShadyDOM.wrap(el1).removeEventListener('test-event-1', callback);
+    ShadyDOM.wrap(el1).removeEventListener('test-event-2', callback);
+    ShadyDOM.wrap(el1).dispatchEvent(new CustomEvent('test-event-1'));
+    ShadyDOM.wrap(el1).dispatchEvent(new CustomEvent('test-event-2'));
     assert.equal(callback.callCount, 2, 'listeners removed (callCount did not increase)');
   });
 
   test('support `once` option', function() {
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {once: true});
+    ShadyDOM.wrap(el1).addEventListener('click', callback, {once: true});
     el1.click();
     assert.equal(callback.callCount, 1, 'listener called once');
     el1.click();
@@ -605,57 +605,57 @@ suite('Patch of addEventListener/removeEventListener', function() {
   });
 
   test('same event, same callback, different options', function() {
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {passive: true});
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {capture: true});
+    ShadyDOM.wrap(el1).addEventListener('click', callback, {passive: true});
+    ShadyDOM.wrap(el1).addEventListener('click', callback, {capture: true});
     el1.click();
     assert.equal(callback.callCount, 2, 'called twice');
-    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback, {passive: true});
+    ShadyDOM.wrap(el1).removeEventListener('click', callback, {passive: true});
     el1.click();
     assert.equal(callback.callCount, 3, 'called by capturing listener');
-    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback, {capture: true});
+    ShadyDOM.wrap(el1).removeEventListener('click', callback, {capture: true});
     el1.click();
     assert.equal(callback.callCount, 3, 'listeners removed (callCount did not increase)');
   });
 
   test('add same listener twice, invoke callback once', function() {
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback);
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback);
+    ShadyDOM.wrap(el1).addEventListener('click', callback);
+    ShadyDOM.wrap(el1).addEventListener('click', callback);
     el1.click();
     assert.equal(callback.callCount, 1, 'called once');
-    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback);
+    ShadyDOM.wrap(el1).removeEventListener('click', callback);
     el1.click();
     assert.equal(callback.callCount, 1, 'listener removed (callCount did not increase)');
   });
 
   test('add same listener twice, invoke callback once (different useCapture notation)', function() {
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, true /* useCapture */);
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {capture: true});
+    ShadyDOM.wrap(el1).addEventListener('click', callback, true /* useCapture */);
+    ShadyDOM.wrap(el1).addEventListener('click', callback, {capture: true});
     el1.click();
     assert.equal(callback.callCount, 1, 'listener called once');
-    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback, {capture: true});
+    ShadyDOM.wrap(el1).removeEventListener('click', callback, {capture: true});
     el1.click();
     assert.equal(callback.callCount, 1, 'listener removed (callCount did not increase)');
   });
 
   test('add same listener twice, different order of options keys', function() {
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {capture: false, passive: true});
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback, {passive: true, capture: false});
+    ShadyDOM.wrap(el1).addEventListener('click', callback, {capture: false, passive: true});
+    ShadyDOM.wrap(el1).addEventListener('click', callback, {passive: true, capture: false});
     el1.click();
     assert.equal(callback.callCount, 1, 'listener called once');
-    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback, {passive: true, capture: false});
+    ShadyDOM.wrap(el1).removeEventListener('click', callback, {passive: true, capture: false});
     el1.click();
     assert.equal(callback.callCount, 1, 'listener removed (callCount did not increase)');
   });
 
   test('add same listener on two different nodes', function() {
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', callback);
-    ShadyDOM.wrapIfNeeded(el2).addEventListener('click', callback);
+    ShadyDOM.wrap(el1).addEventListener('click', callback);
+    ShadyDOM.wrap(el2).addEventListener('click', callback);
     el1.click();
     assert.equal(callback.callCount, 1, 'called once');
     el2.click();
     assert.equal(callback.callCount, 2, 'called twice');
-    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', callback);
-    ShadyDOM.wrapIfNeeded(el2).removeEventListener('click', callback);
+    ShadyDOM.wrap(el1).removeEventListener('click', callback);
+    ShadyDOM.wrap(el2).removeEventListener('click', callback);
     el1.click();
     el2.click();
     assert.equal(callback.callCount, 2, 'listeners removed (callCount did not increase)');
@@ -663,16 +663,16 @@ suite('Patch of addEventListener/removeEventListener', function() {
 
   test('add listener with `handleEvent` function', function() {
     var obj = {handleEvent: sinon.stub()};
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('click', obj);
-    ShadyDOM.wrapIfNeeded(el2).addEventListener('click', obj);
+    ShadyDOM.wrap(el1).addEventListener('click', obj);
+    ShadyDOM.wrap(el2).addEventListener('click', obj);
     el1.click();
     assert.isTrue(obj.handleEvent.calledOn(obj), 'called on object listened');
     assert.isTrue(obj.handleEvent.args[0][0] instanceof Event, 'called with event argument');
     assert.equal(obj.handleEvent.callCount, 1, 'called once');
     el2.click();
     assert.equal(obj.handleEvent.callCount, 2, 'called twice');
-    ShadyDOM.wrapIfNeeded(el1).removeEventListener('click', obj);
-    ShadyDOM.wrapIfNeeded(el2).removeEventListener('click', obj);
+    ShadyDOM.wrap(el1).removeEventListener('click', obj);
+    ShadyDOM.wrap(el2).removeEventListener('click', obj);
     el1.click();
     el2.click();
     assert.equal(obj.handleEvent.callCount, 2, 'listeners removed (callCount did not increase)');
@@ -680,19 +680,17 @@ suite('Patch of addEventListener/removeEventListener', function() {
 
   test('add listener with an object missing `handleEvent` function', function() {
     var obj = {};
-    // Note, FF natively throws here so ensure always wrapped to test ShadyDOM behavior only.
     ShadyDOM.wrap(el1).addEventListener('foo', obj);
     assert.doesNotThrow(function() {
-      ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new Event('foo'))
+      ShadyDOM.wrap(el1).dispatchEvent(new Event('foo'))
     });
   });
 
   test('add listener with an object with `handleEvent` that is not a function', function() {
     var obj = {handleEvent: true};
-    // Note, FF natively throws here so ensure always wrapped to test ShadyDOM behavior only.
     ShadyDOM.wrap(el1).addEventListener('zip', obj);
     assert.doesNotThrow(function () {
-      ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new Event('zip'))
+      ShadyDOM.wrap(el1).dispatchEvent(new Event('zip'))
     });
   });
 

--- a/packages/shadydom/tests/shady.html
+++ b/packages/shadydom/tests/shady.html
@@ -453,7 +453,7 @@ suite('Mutate light DOM', function() {
       '<div></div>';
     ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).lastElementChild).attachShadow({mode: 'open'});
     // force upgrade on polyfilled browsers
-        ShadyDOM.flush();
+    ShadyDOM.flush();
     var hostLocalMain = getComposedChildAtIndex(ShadyDOM.wrapIfNeeded(host).shadowRoot, 1);
     var child = getComposedChildAtIndex(ShadyDOM.wrapIfNeeded(host).shadowRoot, 100);
     ShadyDOM.wrapIfNeeded(child).innerHTML = '<div id="sub"></div>';

--- a/packages/shadydom/tests/shady.html
+++ b/packages/shadydom/tests/shady.html
@@ -680,7 +680,8 @@ suite('Patch of addEventListener/removeEventListener', function() {
 
   test('add listener with an object missing `handleEvent` function', function() {
     var obj = {};
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('foo', obj);
+    // Note, FF natively throws here so ensure always wrapped to test ShadyDOM behavior only.
+    ShadyDOM.wrap(el1).addEventListener('foo', obj);
     assert.doesNotThrow(function() {
       ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new Event('foo'))
     });
@@ -688,7 +689,8 @@ suite('Patch of addEventListener/removeEventListener', function() {
 
   test('add listener with an object with `handleEvent` that is not a function', function() {
     var obj = {handleEvent: true};
-    ShadyDOM.wrapIfNeeded(el1).addEventListener('zip', obj);
+    // Note, FF natively throws here so ensure always wrapped to test ShadyDOM behavior only.
+    ShadyDOM.wrap(el1).addEventListener('zip', obj);
     assert.doesNotThrow(function () {
       ShadyDOM.wrapIfNeeded(el1).dispatchEvent(new Event('zip'))
     });

--- a/packages/shadydom/tests/slot-scenarios.html
+++ b/packages/shadydom/tests/slot-scenarios.html
@@ -63,16 +63,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     suite('Slot distribution in various scenarios', function () {
       test('slot distribution is not interrupted by events', function (done) {
-        let innerTemplate = ShadyDOM.wrap(document).querySelector('template#inner');
-        let outerTemplate = ShadyDOM.wrap(document).querySelector('template#outer');
-        let failureTemplate = ShadyDOM.wrap(document).querySelector('template#failure');
+        let innerTemplate = ShadyDOM.wrapIfNeeded(document).querySelector('template#inner');
+        let outerTemplate = ShadyDOM.wrapIfNeeded(document).querySelector('template#outer');
+        let failureTemplate = ShadyDOM.wrapIfNeeded(document).querySelector('template#failure');
 
         class XInner extends HTMLElement {
           connectedCallback() {
             if (!this.shadowRoot) {
-              ShadyDOM.wrap(this).attachShadow({ mode: 'open' });
-              ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(ShadyDOM.wrap(document).importNode(innerTemplate.content, true));
-              ShadyDOM.wrap(this).dispatchEvent(new Event('test', { bubbles: true, composed: true }));
+              ShadyDOM.wrapIfNeeded(this).attachShadow({ mode: 'open' });
+              ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(ShadyDOM.wrapIfNeeded(document).importNode(innerTemplate.content, true));
+              ShadyDOM.wrapIfNeeded(this).dispatchEvent(new Event('test', { bubbles: true, composed: true }));
             }
           }
         }
@@ -80,8 +80,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         class XOuter extends HTMLElement {
           connectedCallback() {
             if (!this.shadowRoot) {
-              ShadyDOM.wrap(this).attachShadow({ mode: 'open' });
-              ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(ShadyDOM.wrap(document).importNode(outerTemplate.content, true));
+              ShadyDOM.wrapIfNeeded(this).attachShadow({ mode: 'open' });
+              ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(ShadyDOM.wrapIfNeeded(document).importNode(outerTemplate.content, true));
             }
           }
         }
@@ -90,27 +90,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         customElements.define('x-outer', XOuter);
 
         assert.doesNotThrow(() => {
-          ShadyDOM.wrap(document.body).appendChild(ShadyDOM.wrap(document).importNode(failureTemplate.content, true));
+          ShadyDOM.wrapIfNeeded(document.body).appendChild(ShadyDOM.wrapIfNeeded(document).importNode(failureTemplate.content, true));
           ShadyDOM.flush();
           done();
         });
       });
 
       suite('querying slots for assignedNodes in constructors', function () {
-        let innerTemplate = ShadyDOM.wrap(document).querySelector('template#innerTemplate');
-        let outerTemplate = ShadyDOM.wrap(document).querySelector('template#outerTemplate');
-        let outerWithChildTemplate = ShadyDOM.wrap(document).querySelector('template#outerWithChildTemplate');
+        let innerTemplate = ShadyDOM.wrapIfNeeded(document).querySelector('template#innerTemplate');
+        let outerTemplate = ShadyDOM.wrapIfNeeded(document).querySelector('template#outerTemplate');
+        let outerWithChildTemplate = ShadyDOM.wrapIfNeeded(document).querySelector('template#outerWithChildTemplate');
 
         let nodeLength = 0;
 
         class InnerElement extends HTMLElement {
           constructor() {
             super();
-            const clone = ShadyDOM.wrap(document).importNode(innerTemplate.content, true);
-            ShadyDOM.wrap(this).attachShadow({ mode: 'open' });
-            ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(clone);
-            const slot = ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).querySelector('slot');
-            const nodes = ShadyDOM.wrap(slot).assignedNodes({ flatten: true });
+            const clone = ShadyDOM.wrapIfNeeded(document).importNode(innerTemplate.content, true);
+            ShadyDOM.wrapIfNeeded(this).attachShadow({ mode: 'open' });
+            ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(clone);
+            const slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).querySelector('slot');
+            const nodes = ShadyDOM.wrapIfNeeded(slot).assignedNodes({ flatten: true });
             nodeLength = nodes.length;
           }
         }
@@ -119,9 +119,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         class OuterElement extends HTMLElement {
           constructor() {
             super();
-            const clone = ShadyDOM.wrap(document).importNode(outerTemplate.content, true);
-            ShadyDOM.wrap(this).attachShadow({ mode: 'open' });
-            ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(clone);
+            const clone = ShadyDOM.wrapIfNeeded(document).importNode(outerTemplate.content, true);
+            ShadyDOM.wrapIfNeeded(this).attachShadow({ mode: 'open' });
+            ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(clone);
           }
         }
         customElements.define('outer-element', OuterElement);
@@ -144,15 +144,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           if (!window.customElements.forcePolyfill) {
             this.skip();
           }
-          const dom = ShadyDOM.wrap(document).importNode(outerWithChildTemplate.content, true);
-          const outer = ShadyDOM.wrap(dom).querySelector('outer-element');
-          const inner = ShadyDOM.wrap(ShadyDOM.wrap(outer).shadowRoot).querySelector('inner-element')
-          const innerSlot = ShadyDOM.wrap(ShadyDOM.wrap(inner).shadowRoot).querySelector('slot');
+          const dom = ShadyDOM.wrapIfNeeded(document).importNode(outerWithChildTemplate.content, true);
+          const outer = ShadyDOM.wrapIfNeeded(dom).querySelector('outer-element');
+          const inner = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(outer).shadowRoot).querySelector('inner-element')
+          const innerSlot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(inner).shadowRoot).querySelector('slot');
           assert.equal(nodeLength, 2);
           // NOTE: accessing assignedNodes here causes needs to flush the
           // rendering of the entire distribution tree. In this case, inner
           // is not dirty, but outer is.
-          assert.equal(ShadyDOM.wrap(innerSlot).assignedNodes({flatten: true}).length, 3);
+          assert.equal(ShadyDOM.wrapIfNeeded(innerSlot).assignedNodes({flatten: true}).length, 3);
         });
       });
 
@@ -167,9 +167,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             super();
             const template = document.createElement('template');
             template.innerHTML = '<slot></slot>';
-            const clone = ShadyDOM.wrap(document).importNode(template.content, true);
-            ShadyDOM.wrap(this).attachShadow({ mode: 'open' });
-            ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(clone);
+            const clone = ShadyDOM.wrapIfNeeded(document).importNode(template.content, true);
+            ShadyDOM.wrapIfNeeded(this).attachShadow({ mode: 'open' });
+            ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(clone);
           }
         }
         customElements.define('inner-inline-element', InnerInlineElement);
@@ -178,17 +178,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           constructor() {
             super();
             const template = document.createElement('template');
-            ShadyDOM.wrap(template).innerHTML = '<inner-inline-element><slot></slot></inner-inline-element>';
-            const clone = ShadyDOM.wrap(document).importNode(template.content, true);
-            ShadyDOM.wrap(this).attachShadow({ mode: 'open' });
-            ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(clone);
+            ShadyDOM.wrapIfNeeded(template).innerHTML = '<inner-inline-element><slot></slot></inner-inline-element>';
+            const clone = ShadyDOM.wrapIfNeeded(document).importNode(template.content, true);
+            ShadyDOM.wrapIfNeeded(this).attachShadow({ mode: 'open' });
+            ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(this).shadowRoot).appendChild(clone);
           }
         }
         customElements.define('outer-inline-element', OuterInlineElement);
 
         assert.doesNotThrow(() => {
           const outer = document.createElement('outer-inline-element');
-          ShadyDOM.wrap(outer).innerHTML = `<div>Hello</div>`;
+          ShadyDOM.wrapIfNeeded(outer).innerHTML = `<div>Hello</div>`;
           if (window.ShadyDOM) {
             window.ShadyDOM.flush();
           }
@@ -198,17 +198,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('slots can be modified before rendering', function() {
         const host = document.createElement('div');
         const child = document.createElement('span');
-        ShadyDOM.wrap(child).textContent = 'Hello!';
-        ShadyDOM.wrap(child).setAttribute('slot', 'foo');
-        ShadyDOM.wrap(host).appendChild(child);
-        ShadyDOM.wrap(host).attachShadow({mode: 'open'});
+        ShadyDOM.wrapIfNeeded(child).textContent = 'Hello!';
+        ShadyDOM.wrapIfNeeded(child).setAttribute('slot', 'foo');
+        ShadyDOM.wrapIfNeeded(host).appendChild(child);
+        ShadyDOM.wrapIfNeeded(host).attachShadow({mode: 'open'});
         const slot = document.createElement('slot');
-        ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).appendChild(slot);
+        ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).appendChild(slot);
         assert.doesNotThrow(() => {
-          ShadyDOM.wrap(slot).setAttribute('name', 'foo');
+          ShadyDOM.wrapIfNeeded(slot).setAttribute('name', 'foo');
         });
         window.ShadyDOM.flush();
-        assert.equal(ShadyDOM.wrap(child).assignedSlot, slot, 'child should be assigned to slot');
+        assert.equal(ShadyDOM.wrapIfNeeded(child).assignedSlot, slot, 'child should be assigned to slot');
       });
     })
   </script>

--- a/packages/shadydom/tests/slotchange.html
+++ b/packages/shadydom/tests/slotchange.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="wct-browser-config.js"></script>
   <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
   <script>
-    ShadyDOM = {force: true, noPatch: window.location.search.match('noPatch')};
+    ShadyDOM = {force: true, noPatch: window.location.search.match('noPatch=on-demand') ? 'on-demand' : !!window.location.search.match('noPatch')};
   </script>
   <script src="../shadydom.min.js"></script>
 
@@ -30,8 +30,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   suite('slotchange', function() {
 
   function makeShadowRootWithSlot(element) {
-    ShadyDOM.wrap(element).attachShadow({mode: 'open'});
-    ShadyDOM.wrap(ShadyDOM.wrap(element).shadowRoot).appendChild(document.createElement('slot'));
+    ShadyDOM.wrapIfNeeded(element).attachShadow({mode: 'open'});
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(element).shadowRoot).appendChild(document.createElement('slot'));
   }
 
   function afterFlush(fn) {
@@ -46,12 +46,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   test('slotchange fires when node added', function(done) {
     var d = document.createElement('div');
     makeShadowRootWithSlot(d);
-    var slot = ShadyDOM.wrap(ShadyDOM.wrap(d).shadowRoot).firstChild;
+    var slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(d).shadowRoot).firstChild;
     var slotChangeFired = false;
-    ShadyDOM.wrap(slot).addEventListener('slotchange', function(e) {
+    ShadyDOM.wrapIfNeeded(slot).addEventListener('slotchange', function(e) {
       slotChangeFired = true;
     });
-    ShadyDOM.wrap(d).appendChild(document.createElement('div'));
+    ShadyDOM.wrapIfNeeded(d).appendChild(document.createElement('div'));
     afterFlush(function() {
       assert.isTrue(slotChangeFired, 'slotchange did not fire');
       done();
@@ -61,16 +61,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   test('slotchange fires when node removed', function(done) {
     var d = document.createElement('div');
     makeShadowRootWithSlot(d);
-    var slot = ShadyDOM.wrap(ShadyDOM.wrap(d).shadowRoot).firstChild;
+    var slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(d).shadowRoot).firstChild;
     var slotChangeFired = false;
-    ShadyDOM.wrap(slot).addEventListener('slotchange', function(e) {
+    ShadyDOM.wrapIfNeeded(slot).addEventListener('slotchange', function(e) {
       slotChangeFired = true;
     });
     var e = document.createElement('div');
-    ShadyDOM.wrap(d).appendChild(e);
+    ShadyDOM.wrapIfNeeded(d).appendChild(e);
     afterFlush(function() {
       assert.isTrue(slotChangeFired, 'slotchange did not fire');
-      ShadyDOM.wrap(d).removeChild(e);
+      ShadyDOM.wrapIfNeeded(d).removeChild(e);
       slotChangeFired = false;
       afterFlush(function() {
         assert.isTrue(slotChangeFired, 'slotchange did not fire');
@@ -82,10 +82,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   test('slotchange fires via fallback added', function(done) {
     var d = document.createElement('div');
     makeShadowRootWithSlot(d);
-    var slot = ShadyDOM.wrap(ShadyDOM.wrap(d).shadowRoot).firstChild;
-    ShadyDOM.wrap(slot).appendChild(document.createElement('div'));
+    var slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(d).shadowRoot).firstChild;
+    ShadyDOM.wrapIfNeeded(slot).appendChild(document.createElement('div'));
     var slotChangeFired = false;
-    ShadyDOM.wrap(slot).addEventListener('slotchange', function(e) {
+    ShadyDOM.wrapIfNeeded(slot).addEventListener('slotchange', function(e) {
       slotChangeFired = true;
     });
     afterFlush(function() {
@@ -98,17 +98,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   test('slotchange does not fire when unused fallback changes', function(done) {
     var d = document.createElement('div');
     makeShadowRootWithSlot(d);
-    var slot = ShadyDOM.wrap(ShadyDOM.wrap(d).shadowRoot).firstChild;
+    var slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(d).shadowRoot).firstChild;
     var slotChangeFired = false;
-    ShadyDOM.wrap(slot).addEventListener('slotchange', function(e) {
+    ShadyDOM.wrapIfNeeded(slot).addEventListener('slotchange', function(e) {
       slotChangeFired = true;
     });
     var e = document.createElement('div');
-    ShadyDOM.wrap(d).appendChild(e);
+    ShadyDOM.wrapIfNeeded(d).appendChild(e);
     afterFlush(function() {
       assert.isTrue(slotChangeFired, 'slotchange did not fire');
       slotChangeFired = false;
-      ShadyDOM.wrap(slot).appendChild(document.createElement('div'));
+      ShadyDOM.wrapIfNeeded(slot).appendChild(document.createElement('div'));
       afterFlush(function() {
         assert.isFalse(slotChangeFired, 'slotchange fired when unused fallback changed');
         done();
@@ -120,42 +120,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var d = document.createElement('div');
     d.id = 'host';
     makeShadowRootWithSlot(d);
-    var slot = ShadyDOM.wrap(ShadyDOM.wrap(d).shadowRoot).firstChild;
+    var slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(d).shadowRoot).firstChild;
     slot.id = 'slot';
     var inner = document.createElement('div');
     inner.id = 'innerHost';
     makeShadowRootWithSlot(inner);
-    var innerSlot = ShadyDOM.wrap(ShadyDOM.wrap(inner).shadowRoot).firstChild;
+    var innerSlot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(inner).shadowRoot).firstChild;
     innerSlot.id = 'innerSlot';
-    ShadyDOM.wrap(ShadyDOM.wrap(d).shadowRoot).appendChild(inner);
-    ShadyDOM.wrap(inner).appendChild(slot);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(d).shadowRoot).appendChild(inner);
+    ShadyDOM.wrapIfNeeded(inner).appendChild(slot);
     var innerInner = document.createElement('div');
     innerInner.id = 'innerInnerHost';
     makeShadowRootWithSlot(innerInner);
-    var innerInnerSlot = ShadyDOM.wrap(ShadyDOM.wrap(innerInner).shadowRoot).firstChild;
+    var innerInnerSlot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(innerInner).shadowRoot).firstChild;
     innerInnerSlot.id = 'innerInnerSlot';
-    ShadyDOM.wrap(ShadyDOM.wrap(inner).shadowRoot).appendChild(innerInner);
-    ShadyDOM.wrap(innerInner).appendChild(innerSlot);
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(inner).shadowRoot).appendChild(innerInner);
+    ShadyDOM.wrapIfNeeded(innerInner).appendChild(innerSlot);
     afterFlush(function() {
       var slotChangeFired = 0;
-      ShadyDOM.wrap(slot).addEventListener('slotchange', function(e) {
+      ShadyDOM.wrapIfNeeded(slot).addEventListener('slotchange', function(e) {
         if (e.eventPhase !== Event.BUBBLING_PHASE) {
           slotChangeFired++;
         }
       });
       var innerSlotChangeFired = 0;
-      ShadyDOM.wrap(innerSlot).addEventListener('slotchange', function(e) {
+      ShadyDOM.wrapIfNeeded(innerSlot).addEventListener('slotchange', function(e) {
         if (e.eventPhase !== Event.BUBBLING_PHASE) {
           innerSlotChangeFired++;
         }
       });
       var innerInnerSlotChangeFired = 0;
-      ShadyDOM.wrap(innerInnerSlot).addEventListener('slotchange', function(e) {
+      ShadyDOM.wrapIfNeeded(innerInnerSlot).addEventListener('slotchange', function(e) {
         if (e.eventPhase !== Event.BUBBLING_PHASE) {
           innerInnerSlotChangeFired++;
         }
       });
-      ShadyDOM.wrap(d).appendChild(document.createElement('div'));
+      ShadyDOM.wrapIfNeeded(d).appendChild(document.createElement('div'));
       afterFlush(function() {
         assert.equal(slotChangeFired, 1, 'slotchange did not fire 1x based on distribution');
         assert.equal(innerSlotChangeFired, 1, 'inner did not fire 1x based on distribution');

--- a/packages/shadydom/tests/sync-style-scoping.html
+++ b/packages/shadydom/tests/sync-style-scoping.html
@@ -100,7 +100,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           window.ShadyCSS.styleElement(this);
           if (!ShadyDOM.wrapIfNeeded(this).shadowRoot) {
             ShadyDOM.wrapIfNeeded(this).attachShadow({mode: 'open'});
-            ShadyDOM.wrapIfNeeded(this).shadowRoot.appendChild(ShadyDOM.wrapIfNeeded(this.__template.content).cloneNode(true));
+            ShadyDOM.wrapIfNeeded(this).shadowRoot.appendChild(ShadyDOM.wrap(this.__template.content).cloneNode(true));
           }
         }
       }
@@ -144,7 +144,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // NOTE: wrapping here is critical to avoid using native `innerHTML`
         // setter which, on IE11, nukes the DOM subtree and can cause
         // pending ShadyDOM renders to fail.
-        ShadyDOM.wrapIfNeeded(arena).innerHTML = '';
+        ShadyDOM.wrap(arena).innerHTML = '';
         // Ensure clean rendering state between tests
         ShadyDOM.flush();
       });
@@ -399,7 +399,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.isTrue(ShadyDOM.wrapIfNeeded(host).shadowRoot.firstChild.classList.contains('style-scope'));
           assert.isTrue(ShadyDOM.wrapIfNeeded(host).shadowRoot.firstChild.classList.contains('x-host'));
         });
-      });
+       });
     });
   </script>
 </body>

--- a/packages/shadydom/tests/sync-style-scoping.html
+++ b/packages/shadydom/tests/sync-style-scoping.html
@@ -89,7 +89,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     class Base extends HTMLElement {
       constructor() {
         super();
-        this.__template = ShadyDOM.wrap(document).querySelector(`template#${this.localName}`);
+        this.__template = ShadyDOM.wrapIfNeeded(document).querySelector(`template#${this.localName}`);
       }
       connectedCallback() {
         if (this.__template) {
@@ -98,9 +98,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             this.__template.__prepared = true;
           }
           window.ShadyCSS.styleElement(this);
-          if (!ShadyDOM.wrap(this).shadowRoot) {
-            ShadyDOM.wrap(this).attachShadow({mode: 'open'});
-            ShadyDOM.wrap(this).shadowRoot.appendChild(ShadyDOM.wrap(this.__template.content).cloneNode(true));
+          if (!ShadyDOM.wrapIfNeeded(this).shadowRoot) {
+            ShadyDOM.wrapIfNeeded(this).attachShadow({mode: 'open'});
+            ShadyDOM.wrapIfNeeded(this).shadowRoot.appendChild(ShadyDOM.wrapIfNeeded(this.__template.content).cloneNode(true));
           }
         }
       }
@@ -110,7 +110,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     customElements.define('naive-element', class extends HTMLElement {
       constructor() {
         super();
-        ShadyDOM.wrap(this).attachShadow({mode: 'open'});
+        ShadyDOM.wrapIfNeeded(this).attachShadow({mode: 'open'});
       }
     });
 
@@ -122,7 +122,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return window.ShadyCSS.ScopingShim.currentScopeForNode(node);
       };
 
-      const arena = ShadyDOM.wrap(document).querySelector('#arena');
+      const arena = ShadyDOM.wrapIfNeeded(document).querySelector('#arena');
 
 
       // set up spies on scoping APIs
@@ -144,7 +144,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // NOTE: wrapping here is critical to avoid using native `innerHTML`
         // setter which, on IE11, nukes the DOM subtree and can cause
         // pending ShadyDOM renders to fail.
-        ShadyDOM.wrap(arena).innerHTML = '';
+        ShadyDOM.wrapIfNeeded(arena).innerHTML = '';
         // Ensure clean rendering state between tests
         ShadyDOM.flush();
       });
@@ -153,23 +153,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('elements appended to the document are unscoped', function() {
           const el = document.createElement('div');
-          ShadyDOM.wrap(arena).appendChild(el);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
           assert.equal(csfn(el), '');
         });
 
         test('elements appended to a shadowRoot are scoped to that shadowroot', function () {
           const el = document.createElement('api-element');
-          ShadyDOM.wrap(arena).appendChild(el);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
           const newDiv = document.createElement('div');
-          ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(newDiv);
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(newDiv);
           ShadyDOM.flush();
           assert.equal(csfn(newDiv), 'api-element');
         });
 
         test('elements moved from a shadowroot to document are unscoped', function() {
           const el = document.createElement('api-element');
-          ShadyDOM.wrap(arena).appendChild(el);
-          const inner = ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).querySelector('#internal');
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
+          const inner = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).querySelector('#internal');
           ShadyDOM.wrap(arena).appendChild(inner);
           assert.equal(csfn(inner), '');
         });
@@ -177,24 +177,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('elements moving document to document do not do unnecessary work', function() {
           const owner1 = document.createElement('div');
           const inner = document.createElement('a');
-          ShadyDOM.wrap(owner1).appendChild(inner);
+          ShadyDOM.wrapIfNeeded(owner1).appendChild(inner);
           const owner2 = document.createElement('span');
-          ShadyDOM.wrap(arena).appendChild(owner1);
-          ShadyDOM.wrap(arena).appendChild(owner2);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(owner1);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(owner2);
           createSpies();
-          ShadyDOM.wrap(owner2).appendChild(inner);
+          ShadyDOM.wrapIfNeeded(owner2).appendChild(inner);
           assert(scopeSpy.notCalled, 'scoping function should not have been called');
           assert(unscopeSpy.notCalled, 'unscoping function should not have been called');
         });
 
         test('appending to a deep shadowroot gets the right scope', function () {
           const el = document.createElement('naive-element');
-          ShadyDOM.wrap(arena).appendChild(el);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
           const api = document.createElement('api-element');
-          ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(api);
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(api);
           assert.equal(csfn(api), 'naive-element');
           const div = document.createElement('div');
-          ShadyDOM.wrap(ShadyDOM.wrap(api).shadowRoot).appendChild(div);
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(api).shadowRoot).appendChild(div);
           assert.equal(csfn(div), 'api-element');
         });
 
@@ -202,12 +202,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           const owner1 = document.createElement('naive-element');
           const owner2 = document.createElement('naive-element');
           const el = document.createElement('div');
-          ShadyDOM.wrap(arena).appendChild(owner1);
-          ShadyDOM.wrap(arena).appendChild(owner2);
-          ShadyDOM.wrap(ShadyDOM.wrap(owner1).shadowRoot).appendChild(el);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(owner1);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(owner2);
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(owner1).shadowRoot).appendChild(el);
           assert.equal(csfn(el), 'naive-element');
           createSpies();
-          ShadyDOM.wrap(ShadyDOM.wrap(owner2).shadowRoot).appendChild(el);
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(owner2).shadowRoot).appendChild(el);
           assert.equal(csfn(el), 'naive-element');
           assert(unscopeSpy.notCalled, 'unscopeNode should not have been called');
           assert(scopeSpy.notCalled, 'scopeNode should not have been called');
@@ -215,10 +215,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('ShadyCSS prepareTemplate is not needed for bulk append', function() {
           const el = document.createElement('naive-element');
-          ShadyDOM.wrap(arena).appendChild(el);
-          const template = ShadyDOM.wrap(document).querySelector('template#complicated');
-          ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(ShadyDOM.wrap(template.content).cloneNode(true));
-          const nodes = Array.from(ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).querySelectorAll('*'));
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
+          const template = ShadyDOM.wrapIfNeeded(document).querySelector('template#complicated');
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(ShadyDOM.wrapIfNeeded(template.content).cloneNode(true));
+          const nodes = Array.from(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).querySelectorAll('*'));
           nodes.forEach((node) =>
             assert.equal(csfn(node), 'naive-element'));
         });
@@ -226,20 +226,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('appending to a document fragment does not scope', function() {
           const df = document.createDocumentFragment();
           const api = document.createElement('api-element');
-          ShadyDOM.wrap(df).appendChild(api);
+          ShadyDOM.wrapIfNeeded(df).appendChild(api);
           assert.equal(csfn(api), '');
         });
 
         test('appending a distributed node has the correct scope', function() {
           const span = document.createElement('span');
           const el = document.createElement('api-element');
-          ShadyDOM.wrap(arena).appendChild(el);
-          ShadyDOM.wrap(el).appendChild(span);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
+          ShadyDOM.wrapIfNeeded(el).appendChild(span);
           ShadyDOM.flush();
           assert.equal(csfn(span), '');
           const naive = document.createElement('naive-element');
-          ShadyDOM.wrap(arena).appendChild(naive);
-          ShadyDOM.wrap(ShadyDOM.wrap(naive).shadowRoot).appendChild(el);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(naive);
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(naive).shadowRoot).appendChild(el);
           ShadyDOM.flush();
           assert.equal(csfn(span), 'naive-element');
         });
@@ -247,14 +247,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('appending a node to a disconnected light dom tree does not scope', function () {
           const el = document.createElement('div');
           const child = document.createElement('span');
-          ShadyDOM.wrap(el).appendChild(child);
+          ShadyDOM.wrapIfNeeded(el).appendChild(child);
           assert.equal(csfn(child), '');
         });
 
         test('appending a disconnected, scoped node to document unscopes correctly', function() {
           const el = document.createElement('api-element');
-          ShadyDOM.wrap(arena).appendChild(el);
-          const clone = ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).querySelector('div').cloneNode(true);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
+          const clone = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).querySelector('div').cloneNode(true);
           assert.equal(csfn(clone), 'api-element');
           ShadyDOM.wrap(arena).appendChild(clone);
           assert.equal(csfn(clone), '');
@@ -263,9 +263,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('appending a cloned, scoped node to document unscopes correctly', function() {
           customElements.define('clone-element', class extends Base {});
           const el = document.createElement('clone-element');
-          ShadyDOM.wrap(arena).appendChild(el);
-          const clone = ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).querySelector('div').cloneNode(true);
-          const span = ShadyDOM.wrap(clone).querySelector('span');
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
+          const clone = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).querySelector('div').cloneNode(true);
+          const span = ShadyDOM.wrapIfNeeded(clone).querySelector('span');
           assert.equal(csfn(span), 'clone-element');
           ShadyDOM.wrap(arena).appendChild(span);
           assert.equal(csfn(span), '');
@@ -274,39 +274,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('appending a unscoped node into a disconnected shadowroot scopes correctly', function() {
           const el = document.createElement('naive-element');
           const span = document.createElement('span');
-          ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(span);
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(span);
           assert.equal(csfn(span), 'naive-element');
         });
 
         test('`setAttribute(\'class\', ...)` scopes correctly', function() {
           const el = document.createElement('naive-element');
           const span = document.createElement('span');
-          ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(span);
-          ShadyDOM.wrap(span).setAttribute('class', 'foo');
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(span);
+          ShadyDOM.wrapIfNeeded(span).setAttribute('class', 'foo');
           assert.equal(csfn(span), 'naive-element');
         });
 
         test('`removeAttribute(\'class\', ...)` scopes correctly', function() {
           const el = document.createElement('naive-element');
           const span = document.createElement('span');
-          ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(span);
-          ShadyDOM.wrap(span).removeAttribute('class');
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(span);
+          ShadyDOM.wrapIfNeeded(span).removeAttribute('class');
           assert.equal(csfn(span), 'naive-element');
         });
 
         test('`removeAttribute(\'class\', ...)` removes if class is empty', function () {
           const el = document.createElement('naive-element');
           const span = document.createElement('span');
-          ShadyDOM.wrap(ShadyDOM.wrap(el)).appendChild(span);
-          ShadyDOM.wrap(span).removeAttribute('class');
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el)).appendChild(span);
+          ShadyDOM.wrapIfNeeded(span).removeAttribute('class');
           assert.equal(span.getAttribute('class'), null);
         });
 
         test('`className` scopes correctly', function() {
           const el = document.createElement('naive-element');
           const span = document.createElement('span');
-          ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(span);
-          ShadyDOM.wrap(span).className = 'foo';
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).appendChild(span);
+          ShadyDOM.wrapIfNeeded(span).className = 'foo';
           assert.equal(csfn(span), 'naive-element');
         });
       });
@@ -315,17 +315,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('removing a shadowed node removes the scope', function() {
           const el = document.createElement('api-element');
-          ShadyDOM.wrap(arena).appendChild(el);
-          const inner = ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).querySelector('#internal');
-          ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).removeChild(inner);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
+          const inner = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).querySelector('#internal');
+          ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).removeChild(inner);
           assert.equal(csfn(inner), '');
         });
 
         test('removing document scope node does not use scoping API', function() {
           const el = document.createElement('div');
-          ShadyDOM.wrap(arena).appendChild(el);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
           createSpies();
-          ShadyDOM.wrap(arena).removeChild(el);
+          ShadyDOM.wrapIfNeeded(arena).removeChild(el);
           assert(scopeSpy.notCalled, 'scopeNode should not be called');
           assert(unscopeSpy.notCalled, 'unscopeNode should not be called');
         });
@@ -334,9 +334,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('mutation', function() {
         test('setting class and className works and preserves scoping', function() {
           const el = document.createElement('api-element');
-          ShadyDOM.wrap(arena).appendChild(el);
-          const inner = ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).querySelector('#internal');
-          const innerWrapper = ShadyDOM.wrap(inner);
+          ShadyDOM.wrapIfNeeded(arena).appendChild(el);
+          const inner = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(el).shadowRoot).querySelector('#internal');
+          const innerWrapper = ShadyDOM.wrapIfNeeded(inner);
           assert.equal(csfn(inner), 'api-element');
           innerWrapper.setAttribute('class', 'a');
           assert.isTrue(inner.classList.contains('a'));
@@ -359,23 +359,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('setAttribute does not update a scoping class', function() {
-          ShadyDOM.wrap(el).setAttribute('class', el.getAttribute('class') + ' nug');
-          assert.equal(ShadyDOM.wrap(el).getAttribute('class'), scopeSelector + ' nug');
+          ShadyDOM.wrapIfNeeded(el).setAttribute('class', el.getAttribute('class') + ' nug');
+          assert.equal(ShadyDOM.wrapIfNeeded(el).getAttribute('class'), scopeSelector + ' nug');
         });
 
         test('appendChild does not update a scoping class', function() {
           const container = doc.createElement('div');
-          ShadyDOM.wrap(container).appendChild(el);
-          assert.equal(ShadyDOM.wrap(el).getAttribute('class'), scopeSelector);
+          ShadyDOM.wrapIfNeeded(container).appendChild(el);
+          assert.equal(ShadyDOM.wrapIfNeeded(el).getAttribute('class'), scopeSelector);
         });
 
         test('removeChild does not update a scoping class', function() {
           const container = doc.createElement('div');
           const d = doc.createElement('div');
-          ShadyDOM.wrap(container).appendChild(d);
+          ShadyDOM.wrapIfNeeded(container).appendChild(d);
           d.className = scopeSelector;
-          ShadyDOM.wrap(container).removeChild(d);
-          assert.equal(ShadyDOM.wrap(el).getAttribute('class'), scopeSelector);
+          ShadyDOM.wrapIfNeeded(container).removeChild(d);
+          assert.equal(ShadyDOM.wrapIfNeeded(el).getAttribute('class'), scopeSelector);
         });
       });
 
@@ -385,19 +385,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           template.innerHTML = '<span></span>';
           window.ShadyCSS.prepareTemplate(template, 'x-host');
           const host = document.body.appendChild(document.createElement('x-host'));
-          ShadyDOM.wrap(host).attachShadow({mode: 'open'});
-          const fragment = ShadyDOM.wrap(document).importNode(template.content, true);
+          ShadyDOM.wrapIfNeeded(host).attachShadow({mode: 'open'});
+          const fragment = ShadyDOM.wrapIfNeeded(document).importNode(template.content, true);
           fragment.__noInsertionPoint = true;
-          ShadyDOM.wrap(host).shadowRoot.appendChild(fragment);
-          ShadyDOM.wrap(fragment).appendChild(ShadyDOM.wrap(host).shadowRoot.firstChild);
+          ShadyDOM.wrapIfNeeded(host).shadowRoot.appendChild(fragment);
+          ShadyDOM.wrap(fragment).appendChild(ShadyDOM.wrapIfNeeded(host).shadowRoot.firstChild);
           // Under preferPerformance, the scoping classes are not removed when moving
           // back into a pre-scoped fragment, otherwise they are
-          assert.equal(ShadyDOM.wrap(fragment).firstChild.classList.contains('style-scope'), ShadyDOM.preferPerformance);
-          assert.equal(ShadyDOM.wrap(fragment).firstChild.classList.contains('x-host'), ShadyDOM.preferPerformance);
-          ShadyDOM.wrap(host).shadowRoot.appendChild(fragment);
+          assert.equal(ShadyDOM.wrapIfNeeded(fragment).firstChild.classList.contains('style-scope'), ShadyDOM.preferPerformance);
+          assert.equal(ShadyDOM.wrapIfNeeded(fragment).firstChild.classList.contains('x-host'), ShadyDOM.preferPerformance);
+          ShadyDOM.wrapIfNeeded(host).shadowRoot.appendChild(fragment);
           // However, when put back into a shadowRoot, it should always be scoped
-          assert.isTrue(ShadyDOM.wrap(host).shadowRoot.firstChild.classList.contains('style-scope'));
-          assert.isTrue(ShadyDOM.wrap(host).shadowRoot.firstChild.classList.contains('x-host'));
+          assert.isTrue(ShadyDOM.wrapIfNeeded(host).shadowRoot.firstChild.classList.contains('style-scope'));
+          assert.isTrue(ShadyDOM.wrapIfNeeded(host).shadowRoot.firstChild.classList.contains('x-host'));
         });
       });
     });

--- a/packages/webcomponentsjs/src/platform/flag-parser.js
+++ b/packages/webcomponentsjs/src/platform/flag-parser.js
@@ -55,6 +55,8 @@ let forceShady = flags['shadydom'];
 if (forceShady) {
   window['ShadyDOM'] = window['ShadyDOM'] || {};
   window['ShadyDOM']['force'] = forceShady;
+  const noPatch = flags['noPatch'];
+  window['ShadyDOM']['noPatch'] = noPatch === 'true' ? true : noPatch;
 }
 
 let forceCE = flags['register'] || flags['ce'];


### PR DESCRIPTION
Fixes #187, adds on-demand patching option to ShadyDOM. Use by setting `ShadyDOM = {noPatch: 'on-demand'}`.