### PR TITLE
ShadyDOM: Fix externs for `_activeElement`.

### DIFF
--- a/packages/shadydom/externs/shadydom.js
+++ b/packages/shadydom/externs/shadydom.js
@@ -16,7 +16,7 @@ Node.prototype.__shady;
 /** @interface */
 function IWrapper() {}
 
-/** @type {Object} */
+/** @type {!Node|undefined} */
 IWrapper.prototype._activeElement;
 
 // NOTE: For some reason, Closure likes to remove focus() from the IWrapper


### PR DESCRIPTION
This fixes an internal conformance error that's preventing ShadyDOM from being imported as-is:
```
ERROR - [JSC_HIDDEN_INTERFACE_PROPERTY_MISMATCH] mismatch of the _activeElement property on type Wrapper$$module$third_party$javascript$shadydom$src$wrapper and the type of the property it overrides from interface IWrapper
original: (Object|null)
override: (Node|undefined)
  get _activeElement() {
      ^^^^^^^^^^^^^^
```