### PR TITLE
Fix issue with custom-style ordering under Custom Property shim

### DIFF
--- a/packages/shadycss/src/scoping-shim.js
+++ b/packages/shadycss/src/scoping-shim.js
@@ -22,7 +22,7 @@ import {flush as watcherFlush, getOwnerScope, getCurrentScope} from './document-
 import templateMap from './template-map.js';
 import * as ApplyShimUtils from './apply-shim-utils.js';
 import {updateNativeProperties, detectMixin} from './common-utils.js';
-import {CustomStyleInterfaceInterface} from './custom-style-interface.js'; // eslint-disable-line no-unused-vars
+import {CustomStyleInterfaceInterface, CustomStyleProvider} from './custom-style-interface.js'; // eslint-disable-line no-unused-vars
 
 /** @type {!Object<string, string>} */
 const adoptedCssTextMap = {};
@@ -229,6 +229,7 @@ export default class ScopingShim {
       return;
     }
     if (!nativeCssVariables) {
+      this._validateCustomStyleOrder(customStyles);
       this._updateProperties(this._documentOwner, this._documentOwnerStyleInfo);
       this._applyCustomStyles(customStyles);
       if (this._elementsHaveApplied) {
@@ -239,6 +240,29 @@ export default class ScopingShim {
       this._revalidateCustomStyleApplyShim(customStyles);
     }
     this._customStyleInterface['enqueued'] = false;
+  }
+  /**
+   * Validate ordering of custom styles for Custom Property shim
+   * @param {!Array<!CustomStyleProvider>} customStyles
+   */
+  _validateCustomStyleOrder(customStyles) {
+    const styles = customStyles.map(c => this._customStyleInterface['getStyleForCustomStyle'](c));
+    // sort styles in document order
+    styles.sort((a, b) => {
+      // use `b.compare(a)` to be more straightforward
+      const position = b.compareDocumentPosition(a);
+      if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+        // A is after B, A should be higher sorted
+        return 1;
+      } else if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+        // A is before B, A should be lower sorted
+        return -1;
+      } else {
+        return 0;
+      }
+    });
+    // sort ast ordering for document
+    this._documentOwnerStyleInfo.styleRules['rules'] = styles.map(s => StyleUtil.rulesForStyle(s));
   }
   /**
    * Apply styles for the given element

--- a/packages/shadycss/src/scoping-shim.js
+++ b/packages/shadycss/src/scoping-shim.js
@@ -229,7 +229,7 @@ export default class ScopingShim {
       return;
     }
     if (!nativeCssVariables) {
-      this._validateCustomStyleOrder(customStyles);
+      this._reorderCustomStylesRules(customStyles);
       this._updateProperties(this._documentOwner, this._documentOwnerStyleInfo);
       this._applyCustomStyles(customStyles);
       if (this._elementsHaveApplied) {
@@ -242,10 +242,10 @@ export default class ScopingShim {
     this._customStyleInterface['enqueued'] = false;
   }
   /**
-   * Validate ordering of custom styles for Custom Property shim
+   * Reorder of custom styles for Custom Property shim
    * @param {!Array<!CustomStyleProvider>} customStyles
    */
-  _validateCustomStyleOrder(customStyles) {
+  _reorderCustomStylesRules(customStyles) {
     const styles = customStyles.map(c => this._customStyleInterface['getStyleForCustomStyle'](c));
     // sort styles in document order
     styles.sort((a, b) => {

--- a/packages/shadycss/tests/custom-style-ordering.html
+++ b/packages/shadycss/tests/custom-style-ordering.html
@@ -25,7 +25,7 @@ WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
 <script src="module/generated/make-element.js"></script>
 <script src="module/generated/custom-style-element.js"></script>
 
-<custom-style>
+<custom-style id="first">
   <style>
     html {
       --shared: rgb(255, 0, 0);
@@ -68,8 +68,9 @@ WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
       }
       assertComputed(el, 'rgb(255, 0, 0)', 'background-color');
       const tmpl = document.querySelector('template#late-style');
-      // append style to head, before custom-style in body
-      document.head.appendChild(tmpl.content.cloneNode(true));
+      // append style before custom-style in body
+      const first = document.querySelector('custom-style#first');
+      first.parentNode.insertBefore(tmpl.content.cloneNode(true), first);
       // force style updates
       if (window.ShadyDOM) {
         ShadyDOM.flush();

--- a/packages/shadycss/tests/custom-style-ordering.html
+++ b/packages/shadycss/tests/custom-style-ordering.html
@@ -43,22 +43,24 @@ WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
   </custom-style>
 </template>
 
-<template id="x-foo">
-  <style>
-    :host {
-      background-color: var(--shared);
-    }
-  </style>
-</template>
-
 <script>
   suite('Custom Style Ordering', function() {
     function assertComputed(node, expected, property = 'border-top-width', msg = undefined) {
       const actual = getComputedStyle(node).getPropertyValue(property).trim();
       assert.equal(expected, actual, msg);
     }
+    let tmpl;
     suiteSetup(function() {
       makeElement('x-foo');
+      tmpl = document.createElement('template');
+      tmpl.innerHTML = `
+      <custom-style>
+        <style>
+          html {
+            --shared: rgb(0, 0, 255);
+          }
+        </style>
+      </custom-style>`;
     })
     test('custom styles apply properties in document order', function() {
       const el = document.createElement('x-foo');
@@ -67,7 +69,6 @@ WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
         ShadyDOM.flush();
       }
       assertComputed(el, 'rgb(255, 0, 0)', 'background-color');
-      const tmpl = document.querySelector('template#late-style');
       // append style before custom-style in body
       const first = document.querySelector('custom-style#first');
       first.parentNode.insertBefore(tmpl.content.cloneNode(true), first);

--- a/packages/shadycss/tests/custom-style-ordering.html
+++ b/packages/shadycss/tests/custom-style-ordering.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<script>
+WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
+</script>
+<script src="./test-flags.js"></script>
+<script src="../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/template/template.js"></script>
+<script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
+<script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
+<script src="../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+<script src="../scoping-shim.min.js"></script>
+<script src="../apply-shim.min.js"></script>
+<script src="../custom-style-interface.min.js"></script>
+<script src="module/generated/make-element.js"></script>
+<script src="module/generated/custom-style-element.js"></script>
+
+<custom-style>
+  <style>
+    html {
+      --shared: rgb(255, 0, 0);
+    }
+  </style>
+</custom-style>
+
+<template id="late-style">
+  <custom-style>
+    <style>
+      html {
+        --shared: rgb(0, 0, 255);
+      }
+    </style>
+  </custom-style>
+</template>
+
+<template id="x-foo">
+  <style>
+    :host {
+      background-color: var(--shared);
+    }
+  </style>
+</template>
+
+<script>
+  suite('Custom Style Ordering', function() {
+    function assertComputed(node, expected, property = 'border-top-width', msg = undefined) {
+      const actual = getComputedStyle(node).getPropertyValue(property).trim();
+      assert.equal(expected, actual, msg);
+    }
+    suiteSetup(function() {
+      makeElement('x-foo');
+    })
+    test('custom styles apply properties in document order', function() {
+      const el = document.createElement('x-foo');
+      document.body.appendChild(el);
+      if (window.ShadyDOM) {
+        ShadyDOM.flush();
+      }
+      assertComputed(el, 'rgb(255, 0, 0)', 'background-color');
+      const tmpl = document.querySelector('template#late-style');
+      // append style to head, before custom-style in body
+      document.head.appendChild(tmpl.content.cloneNode(true));
+      // force style updates
+      if (window.ShadyDOM) {
+        ShadyDOM.flush();
+      }
+      ShadyCSS.styleDocument();
+      assertComputed(el, 'rgb(255, 0, 0)', 'background-color', 'late custom style should be processed in document order');
+    });
+  });
+</script>

--- a/packages/shadycss/tests/custom-style-ordering.html
+++ b/packages/shadycss/tests/custom-style-ordering.html
@@ -33,14 +33,12 @@ WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
   </style>
 </custom-style>
 
-<template id="late-style">
-  <custom-style>
-    <style>
-      html {
-        --shared: rgb(0, 0, 255);
-      }
-    </style>
-  </custom-style>
+<template id="x-foo">
+  <style>
+    :host {
+      background-color: var(--shared);
+    }
+  </style>
 </template>
 
 <script>

--- a/packages/shadycss/tests/runner.html
+++ b/packages/shadycss/tests/runner.html
@@ -27,6 +27,7 @@
     'custom-style.html',
     'custom-style-late.html',
     'custom-style-only.html',
+    'custom-style-ordering.html',
     'complicated-mixin-ordering.html',
     'dynamic-scoping.html',
     'settings.html',


### PR DESCRIPTION
When using shim'd Custom Properties, the ordering of custom styles must
be in document order, matching the CSS cascade order when using native
Custom Properties.

The order of custom-styles internally was only in "upgrade" order, which
could be out of date if a custom-style is created after loading.