### PR TITLE
Handle empty custom-styles when sorting

### DIFF
--- a/packages/shadycss/src/scoping-shim.js
+++ b/packages/shadycss/src/scoping-shim.js
@@ -246,7 +246,7 @@ export default class ScopingShim {
    * @param {!Array<!CustomStyleProvider>} customStyles
    */
   _reorderCustomStylesRules(customStyles) {
-    const styles = customStyles.map(c => this._customStyleInterface['getStyleForCustomStyle'](c));
+    const styles = customStyles.map(c => this._customStyleInterface['getStyleForCustomStyle'](c)).filter(s => !!s);
     // sort styles in document order
     styles.sort((a, b) => {
       // use `b.compare(a)` to be more straightforward

--- a/packages/shadycss/tests/custom-style-ordering.html
+++ b/packages/shadycss/tests/custom-style-ordering.html
@@ -77,5 +77,11 @@ WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
       ShadyCSS.styleDocument();
       assertComputed(el, 'rgb(255, 0, 0)', 'background-color', 'late custom style should be processed in document order');
     });
+
+    test('empty custom-style is processed correctly', function() {
+      const empty = document.createElement('custom-style');
+      document.head.appendChild(empty);
+      ShadyCSS.flushCustomStyles();
+    });
   });
 </script>


### PR DESCRIPTION
Empty custom-styles leave return `null` from `CustomStyleInterface.getStyleForCustomStyle`, which will throw in the sort function.