### PR TITLE
[HTMLImports] Fix issue with style elements in svg

### DIFF
--- a/packages/html-imports/src/html-imports.js
+++ b/packages/html-imports/src/html-imports.js
@@ -613,9 +613,11 @@
     if (element['__loaded']) {
       callback && callback();
     } else if ((element.localName === 'script' && !element.src) ||
-      (element.localName === 'style' && !element.firstChild)) {
-      // Inline scripts and empty styles don't trigger load/error events,
-      // consider them already loaded.
+      (element.localName === 'style' && !element.firstChild) ||
+      (element.localName === 'style' &&
+        element.namespaceURI === 'http://www.w3.org/2000/svg')) {
+      // Inline scripts,empty styles, and styles in <svg> don't trigger
+      // load/error events, consider them already loaded.
       element['__loaded'] = true;
       callback && callback();
     } else {

--- a/packages/html-imports/tests/html/imports/svg-style.html
+++ b/packages/html-imports/tests/html/imports/svg-style.html
@@ -1,0 +1,17 @@
+<!--
+    @license
+    Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<svg>
+  <style>
+    .foo {
+      fill: red;
+    }
+  </style>
+  <path class="fill"></path>
+</svg>

--- a/packages/html-imports/tests/html/load-svg-style.html
+++ b/packages/html-imports/tests/html/load-svg-style.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<!--
+    @license
+    Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>Style in SVG loads</title>
+    <script>WCT = {waitFor: function(cb){ cb() }}</script>
+    <script src="../../html-imports.min.js"></script>
+    <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+    <link rel="import" href="imports/svg-style.html">
+  </head>
+  <body>
+    <script>
+      test('style in svg loads', function() {
+        let resolve;
+        const promise = new Promise((res) => {resolve = res});
+        HTMLImports.whenReady(() => {
+          resolve();
+        });
+        return promise;
+      });
+    </script>
+  </body>
+</html>

--- a/packages/html-imports/tests/html/load-svg-style.html
+++ b/packages/html-imports/tests/html/load-svg-style.html
@@ -18,13 +18,12 @@
   </head>
   <body>
     <script>
-      test('style in svg loads', function() {
-        let resolve;
-        const promise = new Promise((res) => {resolve = res});
-        HTMLImports.whenReady(() => {
-          resolve();
+      suite('style in svg', function() {
+        test('style in svg loads', function(done) {
+          HTMLImports.whenReady(() => {
+            done();
+          });
         });
-        return promise;
       });
     </script>
   </body>

--- a/packages/html-imports/tests/index.html
+++ b/packages/html-imports/tests/index.html
@@ -32,6 +32,7 @@
     'html/load-404.html',
     'html/load-empty.html',
     'html/load-loop.html',
+    'html/load-svg-style.html',
     'html/base/imports-with-base.html',
     'html/currentScript.html',
     'html/dedupe.html',


### PR DESCRIPTION
`<style>` elements inside of `<svg>` will never fire a load event, and then the HTMLImports polyfill will wait for them forever.

External version of http://cl/269369964