### PR TITLE
[ShadyCSS] custom-style element

### DIFF
--- a/packages/custom-elements/src/custom-elements.js
+++ b/packages/custom-elements/src/custom-elements.js
@@ -39,13 +39,12 @@ function installPolyfill() {
 
   // The main document is associated with the global registry.
   document.__CE_registry = customElements;
-
   Object.defineProperty(window, 'customElements', {
     configurable: true,
     enumerable: true,
     value: customElements,
   });
-};
+}
 
 if (!priorCustomElements ||
      priorCustomElements['forcePolyfill'] ||

--- a/packages/custom-elements/src/custom-elements.js
+++ b/packages/custom-elements/src/custom-elements.js
@@ -39,12 +39,13 @@ function installPolyfill() {
 
   // The main document is associated with the global registry.
   document.__CE_registry = customElements;
+
   Object.defineProperty(window, 'customElements', {
     configurable: true,
     enumerable: true,
     value: customElements,
   });
-}
+};
 
 if (!priorCustomElements ||
      priorCustomElements['forcePolyfill'] ||

--- a/packages/shadycss/entrypoints/custom-style-interface.js
+++ b/packages/shadycss/entrypoints/custom-style-interface.js
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import CustomStyleInterface from '../src/custom-style-interface.js';
 import {getComputedStyleValue, updateNativeProperties} from '../src/common-utils.js';
 import {nativeCssVariables, nativeShadow, cssBuild, disableRuntime} from '../src/style-settings.js';
-import CustomStyle from '../src/custom-style.js';
+import createCustomStyleElement from '../src/custom-style.js';
 
 const customStyleInterface = new CustomStyleInterface();
 
@@ -79,5 +79,11 @@ if (!window.ShadyCSS) {
     disableRuntime: disableRuntime,
   }
 }
-window.ShadyCss.CustomStyle = CustomStyle;
+// wait until customElements registry exists
+const waitForCustomElements = setInterval(() => {
+  if (window.customElements) {
+    clearInterval(waitForCustomElements);
+    createCustomStyleElement(customStyleInterface);
+  }
+}, 10);
 window.ShadyCSS.CustomStyleInterface = customStyleInterface;

--- a/packages/shadycss/entrypoints/custom-style-interface.js
+++ b/packages/shadycss/entrypoints/custom-style-interface.js
@@ -85,5 +85,5 @@ const waitForCustomElements = setInterval(() => {
     clearInterval(waitForCustomElements);
     createCustomStyleElement(customStyleInterface);
   }
-}, 10);
+}, 0);
 window.ShadyCSS.CustomStyleInterface = customStyleInterface;

--- a/packages/shadycss/entrypoints/custom-style-interface.js
+++ b/packages/shadycss/entrypoints/custom-style-interface.js
@@ -13,6 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import CustomStyleInterface from '../src/custom-style-interface.js';
 import {getComputedStyleValue, updateNativeProperties} from '../src/common-utils.js';
 import {nativeCssVariables, nativeShadow, cssBuild, disableRuntime} from '../src/style-settings.js';
+import CustomStyle from '../src/custom-style.js';
 
 const customStyleInterface = new CustomStyleInterface();
 
@@ -78,5 +79,5 @@ if (!window.ShadyCSS) {
     disableRuntime: disableRuntime,
   }
 }
-
+window.ShadyCss.CustomStyle = CustomStyle;
 window.ShadyCSS.CustomStyleInterface = customStyleInterface;

--- a/packages/shadycss/src/custom-style.js
+++ b/packages/shadycss/src/custom-style.js
@@ -3,17 +3,23 @@ function createCustomStyleElement(customStyleInterface) {
 
     constructor() {
       super();
+      /** @type {HTMLStyleElement} */
       this.styleElement = null;
       customStyleInterface.addCustomStyle(this);
     }
 
-    ['getStyle']() {
+    /**
+     * @return {HTMLStyleElement}
+     */
+    getStyle() {
       if (!this.styleElement) {
-        this.styleElement = this.querySelector('style');
+        this.styleElement = /** @type {HTMLStyleElement} */(this.querySelector('style'));
       }
       return this.styleElement;
     }
   }
+
+  CustomStyle.prototype['getStyle'] = CustomStyle.prototype.getStyle; // eslint-disable-line no-self-assign
   customElements.define('custom-style', CustomStyle);
 }
 

--- a/packages/shadycss/src/custom-style.js
+++ b/packages/shadycss/src/custom-style.js
@@ -1,0 +1,18 @@
+import CustomStyleInterface from './custom-style-interface.js';
+
+export default class CustomStyle extends HTMLElement {
+
+  constructor() {
+    super();
+    this.styleElement = null;
+    CustomStyleInterface.addCustomStyle(this);
+  }
+
+  getStyle() {
+    if (!this.styleElement) {
+      this.styleElement = this.querySelector('style');
+    }
+    return this.styleElement;
+  }
+}
+customElements.define('custom-style', CustomStyle);

--- a/packages/shadycss/src/custom-style.js
+++ b/packages/shadycss/src/custom-style.js
@@ -1,18 +1,20 @@
-import CustomStyleInterface from './custom-style-interface.js';
+function createCustomStyleElement(customStyleInterface) {
+  class CustomStyle extends HTMLElement {
 
-export default class CustomStyle extends HTMLElement {
-
-  constructor() {
-    super();
-    this.styleElement = null;
-    CustomStyleInterface.addCustomStyle(this);
-  }
-
-  getStyle() {
-    if (!this.styleElement) {
-      this.styleElement = this.querySelector('style');
+    constructor() {
+      super();
+      this.styleElement = null;
+      customStyleInterface.addCustomStyle(this);
     }
-    return this.styleElement;
+
+    ['getStyle']() {
+      if (!this.styleElement) {
+        this.styleElement = this.querySelector('style');
+      }
+      return this.styleElement;
+    }
   }
+  customElements.define('custom-style', CustomStyle);
 }
-customElements.define('custom-style', CustomStyle);
+
+export default createCustomStyleElement;


### PR DESCRIPTION
<!-- Instructions: https://github.com/webcomponents/shadydom/blob/master/CONTRIBUTING.md -->
### Reference Issue
#55 

Adds a standalone `<custom-style>` element that works with the custom-style-interface to enable css variables to be used at the document level.

### Caveats
I fought with this for quite a while. I'm dynamically loading polyfills at runtime, and discovered that in order for this to work, the webcomponents polyfill must load before the custom-style-interface polyfill. I don't have a great solution to that problem, but in my project I ended up just concatenating the two together and loading that. 🤷‍♂ 