### PR TITLE
Change to the scoping shim selector in README

### DIFF
--- a/packages/shadycss/README.md
+++ b/packages/shadycss/README.md
@@ -72,10 +72,10 @@ becomes:
 my-element {
   display: block;
 }
-#container.my-element > * {
+my-element#container > * {
   color: gray;
 }
-#foo.my-element {
+my-element#foo {
   color: black;
 }
 </style>


### PR DESCRIPTION
Was reading how ScopingShim polyfill worked and I think there is a mistake in the README that showed the scoped selector using class name instead of element name.

