### PR TITLE
docs: add lerna badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/webcomponents/polyfills.svg?branch=master)](https://travis-ci.org/webcomponents/polyfills)
 [![Mentioned in Web Components the Right Way](https://awesome.re/mentioned-badge.svg)](https://github.com/mateusortiz/webcomponents-the-right-way)
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)
 
 # Monorepository for WebComponents v1 polyfills
 


### PR DESCRIPTION
These polyfills are organized as a monorepo using [Lerna](https://lerna.js.org/). So I think we should either add lerna badge
[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/) or some kind of acknowledgment in Readme (If addition of badge is not acceptable).
