### PR TITLE
Update tests to include polyfills required. Fixes #55.

### DIFF
--- a/packages/shady-css-scoped-element/package-lock.json
+++ b/packages/shady-css-scoped-element/package-lock.json
@@ -25,16 +25,34 @@
       "integrity": "sha512-IxzUe6YzaORzUksafHAXHprV29YncOJgr0+1zNAifl0/f+cb5iAd4IWUrnsnVFHG5UGTLjvis5RgV6vvIZPDrA==",
       "dev": true
     },
+    "@webcomponents/custom-elements": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.3.0.tgz",
+      "integrity": "sha512-Mj2g0ZlqHgV+HFFb4ErPbu64l3Bq//wTv/jOBcMBYM178zLF5YN77mBd9er8xLjekeqvI6FFUuQxwEsnbKL3CQ==",
+      "dev": true
+    },
     "@webcomponents/shadycss": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.1.tgz",
-      "integrity": "sha512-IaZOnWOKXHghqk/WfPNDRIgDBi3RsVPY2IFAw6tYiL9UBGvQRy5R6uC+Fk7qTZsReTJ0xh5MTT8yAcb3MUR4mQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.2.tgz",
+      "integrity": "sha512-GsD7RpDVrVdgC6e+D8zQia8RGNmEGQ9/qotnVPQYPrIXhGS5xSt6ZED9YmuHz3HbLqY+E54tE1EK3tjLzSCGrw==",
+      "dev": true
+    },
+    "@webcomponents/shadydom": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadydom/-/shadydom-1.6.1.tgz",
+      "integrity": "sha512-jajkrVafQ/QVWvTQNCO2QTPlZf4ut16T9V/wIn7WHt6q1V8FPIkAvnho+eYqwXb3DPxIxm2ngtO1XoFFQUtbQg==",
       "dev": true
     },
     "@webcomponents/template": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@webcomponents/template/-/template-1.4.1.tgz",
       "integrity": "sha512-v7vwYZPKsAxczkWIjCOfCki9SpRdUcDjMZyweTGj3EPvVi+awQVHFPZ6X3jDW5nLSOs6Ls3h/AX8x8T+df2X0Q==",
+      "dev": true
+    },
+    "@webcomponents/webcomponents-platform": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponents-platform/-/webcomponents-platform-1.0.1.tgz",
+      "integrity": "sha512-7Ua2c3FvqAuiC2++gIoStG9r0B5sxleq8B7o0XKuIM052amWPTaCka0UMvnQRRJEsdGgRGIUv6sLkOyfhcr1dw==",
       "dev": true
     },
     "@webcomponents/webcomponentsjs": {

--- a/packages/shady-css-scoped-element/package.json
+++ b/packages/shady-css-scoped-element/package.json
@@ -27,10 +27,13 @@
     "src/"
   ],
   "devDependencies": {
-    "@webcomponents/shadycss": "^1.9.1",
+    "@webcomponents/custom-elements": "^1.3.0",
+    "@webcomponents/shadycss": "^1.9.2",
+    "@webcomponents/shadydom": "^1.6.1",
     "@webcomponents/template": "^1.4.0",
+    "@webcomponents/webcomponents-platform": "^1.0.1",
     "@webcomponents/webcomponentsjs": "^2.2.10",
-    "es6-promise": "4.2.4",
+    "es6-promise": "^4.2.4",
     "wct-browser-legacy": "^1.0.2"
   },
   "publishConfig": {

--- a/packages/shady-css-scoped-element/tests/shady-css-scoped.html
+++ b/packages/shady-css-scoped-element/tests/shady-css-scoped.html
@@ -12,45 +12,79 @@
 <head>
   <title>HTML Imports Dynamic Elements</title>
   <script src="../node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
+  <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
+  <script src="../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+  <script src="../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
+  <script src="../node_modules/@webcomponents/shadycss/custom-style-interface.min.js"></script>
   <script src="../shady-css-scoped-element.min.js"></script>
   <script>WCT = {waitFor: function(cb){cb()}};</script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+
+
 </head>
 <body>
   <shady-css-scoped>
     <style>
-      html{
-        --foo: #333333;
+      html {
+        --background: green;
+      }
+      div {
+        border-top: 1px solid red;
       }
     </style>
   </shady-css-scoped>
   <template>
     <style>
       div {
-        background-color: var(--foo);
+        border-bottom: 1px solid blue;
+        background-color: var(--background);
       }
     </style>
-    <div id="test-div"></div>
+    <div id="test-div">should be green with bottom blue border</div>
   </template>
+
+  <div>should be transparent with top red border</div>
+  <hr>
   <my-element></my-element>
 
   <script>
     suite('shady-css-scoped-element', function() {
       suiteSetup(function() {
+        const template = document.querySelector('template');
+        if (window.ShadyCSS) {
+          ShadyCSS.prepareTemplate(template, 'my-element');
+        }
         class MyElement extends HTMLElement {
-
           connectedCallback() {
+            window.ShadyCSS && ShadyCSS.styleElement(this);
             this.attachShadow({mode: 'open'});
-            this.shadowRoot.appendChild(document.querySelector('template').content.cloneNode(true));
+            this.shadowRoot.appendChild(template.content.cloneNode(true));
           }
         }
         customElements.define('my-element', MyElement);
       });
-      test('css vars are applied to custom elements', function() {
+      test('scoped style applies to shadow root', function() {
         const myElement = document.querySelector('my-element');
         const computed = getComputedStyle(myElement.shadowRoot.querySelector('div'));
-        chai.assert.equal(computed.backgroundColor, 'rgb(51, 51, 51)', 'background color applied');
+        chai.assert.notEqual(computed.borderTopColor, 'rgb(255, 0, 0)', 'top border not applied');
+        chai.assert.equal(computed.borderBottomColor, 'rgb(0, 0, 255)', 'bottom border applied');
+      });
+      test('scoped css vars are applied to shadow root', function() {
+        const myElement = document.querySelector('my-element');
+        const computed = getComputedStyle(myElement.shadowRoot.querySelector('div'));
+        chai.assert.equal(computed.backgroundColor, 'rgb(0, 128, 0)', 'background color applied');
+      });
+      test('scoped style does not apply to document element', function() {
+        const computed = getComputedStyle(document.querySelector('div'));
+        chai.assert.equal(computed.borderTopColor, 'rgb(255, 0, 0)', 'top border not applied');
+        chai.assert.notEqual(computed.borderBottomColor, 'rgb(0, 0, 255)', 'border applied');
+      });
+      test('scoped css vars are not applied to custom document element', function() {
+        const computed = getComputedStyle(document.querySelector('div'));
+        chai.assert.notEqual(computed.backgroundColor, 'rgb(0, 128, 0)', 'background color applied');
       });
     });
   </script>


### PR DESCRIPTION
The original test doesn't include any polyfills, so wasn't testing the polyfilled behavior (the point of the element), and was only passing on browsers with native CE & SD.
