### PR TITLE
Make @webcomponents/shady-css-scoped-element private.

### DIFF
--- a/packages/shady-css-scoped-element/package.json
+++ b/packages/shady-css-scoped-element/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@webcomponents/shady-css-scoped-element",
   "version": "0.0.1",
+  "private": true,
   "description": "ShadyCSS scoped element",
   "main": "shady-css-scoped.min.js",
   "repository": "github:webcomponents/polyfills",


### PR DESCRIPTION
AFAIK, this package isn't ready for release, so we should mark it as private until then.