### PR TITLE
[ShadyDOM] When checking if a node is a shadyRoot, avoid looking at e…

### DIFF
--- a/packages/shadydom/src/attach-shadow.js
+++ b/packages/shadydom/src/attach-shadow.js
@@ -60,11 +60,6 @@ class ShadyRoot {
   }
 
   _init(host, options) {
-    // NOTE: set a fake local name so this element can be
-    // distinguished from a DocumentFragment when patching.
-    // FF doesn't allow this to be `localName`
-    /** @type {string} */
-    this._localName = SHADYROOT_NAME;
     // root <=> host
     this.host = host;
     /** @type {!string|undefined} */

--- a/packages/shadydom/src/attach-shadow.js
+++ b/packages/shadydom/src/attach-shadow.js
@@ -22,7 +22,6 @@ import {patchShadyRoot} from './patch-shadyRoot.js';
 const ShadyRootConstructionToken = {};
 
 const CATCHALL_NAME = '__catchall';
-const SHADYROOT_NAME = 'ShadyRoot';
 
 const MODE_CLOSED = 'closed';
 

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -578,7 +578,8 @@ function patchEvent(event) {
   // attempt to patch prototype (via cache)
   if (utils.settings.hasDescriptors) {
     const proto = Object.getPrototypeOf(event);
-    if (!Object.hasOwnProperty(proto, SHADY_PROTO)) {
+    // eslint-disable-next-line no-prototype-builtins
+    if (!proto.hasOwnProperty(SHADY_PROTO)) {
       const patchedProto = Object.create(proto);
       patchedProto[SHADY_SOURCE_PROTO] = proto;
       utils.patchProperties(patchedProto, EventPatchesDescriptors);

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -35,7 +35,7 @@ export const isTrackingLogicalChildNodes = (node) => {
 }
 
 export const isShadyRoot = (obj) => {
-  return Boolean(obj instanceof DocumentFragment && obj._localName === 'ShadyRoot');
+  return obj instanceof ShadowRoot;
 }
 
 export const hasShadowRootWithSlot = (node) => {

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -35,7 +35,7 @@ export const isTrackingLogicalChildNodes = (node) => {
 }
 
 export const isShadyRoot = (obj) => {
-  return Boolean(obj._localName === 'ShadyRoot');
+  return Boolean(obj instanceof DocumentFragment && obj._localName === 'ShadyRoot');
 }
 
 export const hasShadowRootWithSlot = (node) => {

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -34,9 +34,7 @@ export const isTrackingLogicalChildNodes = (node) => {
   return (nodeData && nodeData.firstChild !== undefined);
 }
 
-export const isShadyRoot = (obj) => {
-  return obj instanceof ShadowRoot;
-}
+export const isShadyRoot = obj => obj instanceof ShadowRoot;
 
 export const hasShadowRootWithSlot = (node) => {
   const nodeData = shadyDataForNode(node);


### PR DESCRIPTION
…xpando property on document

Fixes #215.

This is extremely slow on some versions of IE/Edge. Instead check if the node is a DocumentFragment first.

Possibly related to the getter on Document defined here: https://html.spec.whatwg.org/multipage/dom.html#document and https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem