### PR TITLE
[Shady DOM] Avoid an IE11 bug that breaks Closure's WeakMap polyfill.

### DIFF
--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -108,17 +108,7 @@ const PATCHED_PROTO = utils.SHADY_PREFIX + 'patchedProto';
 
 // Patch non-element prototypes up front so that we don't have to check
 // the type of Node when patching an can always assume we're patching an element.
-const nonElements = ['Text', 'Comment', 'ProcessingInstruction'];
-if (!utils.settings.IS_IE) {
-  // For some bizarre reason the WeakMap polyfill on some IE browser versions
-  // fails to work with CDATASection.prototype (the hasOwnProperty check on
-  // the WeakMap key fails despite it being properly defined); We won't properly
-  // patch CDATASection on IE, but a) that's a rare thing to use anyway, and
-  // b) it just means it'll get Element patches, which isn't the end of the
-  // world
-  nonElements.push('CDATASection');
-}
-nonElements.forEach(name => {
+['Text', 'Comment', 'CDATASection', 'ProcessingInstruction'].forEach(name => {
   const ctor = window[name];
   const patchedProto = Object.create(ctor.prototype);
   patchedProto[PROTO_IS_PATCHED] = true;


### PR DESCRIPTION
The IE11 bug that https://github.com/webcomponents/polyfills/pull/220 addresses apparently also applies to Text. This PR works around the bug more generally by not storing these prototypes in Map keys so that they aren't inserted into a polyfilled WeakMap.