### PR TITLE
[Custom Elements] Remove `console.warn` calls when `insertAdjacent{Element,HTML}` aren't wrapped.

### DIFF
--- a/packages/custom-elements/src/Patch/Element.js
+++ b/packages/custom-elements/src/Patch/Element.js
@@ -238,8 +238,6 @@ export default function(internals) {
     patch_insertAdjacentElement(HTMLElement.prototype, Native.HTMLElement_insertAdjacentElement);
   } else if (Native.Element_insertAdjacentElement) {
     patch_insertAdjacentElement(Element.prototype, Native.Element_insertAdjacentElement);
-  } else {
-    console.warn('Custom Elements: `Element#insertAdjacentElement` was not patched.');
   }
 
 
@@ -297,8 +295,6 @@ export default function(internals) {
     patch_insertAdjacentHTML(HTMLElement.prototype, Native.HTMLElement_insertAdjacentHTML);
   } else if (Native.Element_insertAdjacentHTML) {
     patch_insertAdjacentHTML(Element.prototype, Native.Element_insertAdjacentHTML);
-  } else {
-    console.warn('Custom Elements: `Element#insertAdjacentHTML` was not patched.');
   }
 
 


### PR DESCRIPTION
I don't think it's necessary to warn people about this since I don't think people expect the polyfill to add APIs that aren't related to the thing the polyfill is creating.