### PR TITLE
Shadydom on demand patch proto fix

### DIFF
--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -135,7 +135,10 @@ export const patchNodeProto = (node) => {
     return;
   }
   const nativeProto = Object.getPrototypeOf(node);
-  let proto = nativeProto[PATCHED_PROTO];
+  // Note, this hasOwnProperty check is critical to avoid seeing a patched
+  // prototype lower in the prototype chain, e.g. if an <s> element has been
+  // patched, without this check, an <input> element would get the wrong patch.
+  let proto = nativeProto.hasOwnProperty(PATCHED_PROTO) && nativeProto[PATCHED_PROTO];
   if (!proto) {
     proto = Object.create(nativeProto);
     patchElementProto(proto);

--- a/packages/shadydom/tests/shady-dynamic.html
+++ b/packages/shadydom/tests/shady-dynamic.html
@@ -268,6 +268,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
   </script>
 
+  <template id="x-has-input">
+    <s>element with HTMLElement protoype</s>
+    <input value="hi">
+  </template>
+
+  <script>
+    defineTestElement('x-has-input');
+  </script>
+
   <template id="innerTemplate"><slot></slot></template>
 
   <template id="outerTemplate"><inner-element><slot></slot></inner-element></template>
@@ -986,6 +995,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var innerSlot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(innerElement).shadowRoot).querySelector('slot');
     assert.deepEqual(ShadyDOM.wrapIfNeeded(outerSlot).assignedNodes(), [test]);
     assert.deepEqual(ShadyDOM.wrapIfNeeded(innerSlot).assignedNodes(), [outerSlot]);
+  });
+
+  test('non-basic elements ok regardless of patching mode', function() {
+    var e = document.createElement('x-has-input');
+    ShadyDOM.wrapIfNeeded(document.body).appendChild(e);
+    var input = ShadyDOM.wrapIfNeeded(e).shadowRoot.querySelector('input');
+    assert.equal(input.value, 'hi');
+    ShadyDOM.wrapIfNeeded(document.body).removeChild(e);
   });
 
 });
@@ -1756,7 +1773,6 @@ suite('renders roots', function() {
     }
     document.body.removeChild(d);
   });
-
 
 });
 

--- a/packages/webcomponentsjs/package.json
+++ b/packages/webcomponentsjs/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "gulp",
+    "build:link": "cd ../../ && npm run bootstrap && cd packages/webcomponentsjs/ && npm run build && npm link",
     "test": "wct",
     "lint": "eslint src tests",
     "regen-package-lock": "rm -rf node_modules package-lock.json; npm install",

--- a/packages/webcomponentsjs/package.json
+++ b/packages/webcomponentsjs/package.json
@@ -16,7 +16,6 @@
   ],
   "scripts": {
     "build": "gulp",
-    "build:link": "cd ../../ && npm run bootstrap && cd packages/webcomponentsjs/ && npm run build && npm link",
     "test": "wct",
     "lint": "eslint src tests",
     "regen-package-lock": "rm -rf node_modules package-lock.json; npm install",


### PR DESCRIPTION
Augments the change in #228 to check `hasOwnProperty` to avoid picking up an incorrect patch. Without this, an `<input>` could be incorrectly patched with HTMLElement's prototype if, for example, an `<s>` was previously patched.