### PR TITLE
Update README.md: Removed text that says ShadowDOM is required; I’m assuming that is a typo.

### DIFF
--- a/packages/shadycss/README.md
+++ b/packages/shadycss/README.md
@@ -3,7 +3,7 @@
 ShadyCSS provides a library to simulate ShadowDOM style encapsulation (ScopingShim), a shim for the proposed CSS mixin `@apply` syntax (ApplyShim), and a library to integrate document-level stylesheets with both of the former libraries (CustomStyleInterface).
 
 ## Requirements
-ShadyCSS requires support for the `<template>` element, ShadowDOM, MutationObserver, Promise, and Object.assign
+ShadyCSS requires support for the `<template>` element, MutationObserver, Promise, and Object.assign
 
 ## Loading
 


### PR DESCRIPTION
Removed text that says ShadowDOM is required; I’m assuming that is a typo.

<!-- Instructions: https://github.com/webcomponents/shadydom/blob/master/CONTRIBUTING.md -->
### Reference Issue
<!-- Example: Fixes #1234 -->
