### PR TITLE
Only modify `customElements` at load if it's a CustomElementRegistry.

### DIFF
--- a/packages/shadydom/src/attach-shadow.js
+++ b/packages/shadydom/src/attach-shadow.js
@@ -587,7 +587,7 @@ export const attachShadow = (host, options) => {
 }
 
 // Mitigate connect/disconnect spam by wrapping custom element classes.
-if (window['customElements'] && utils.settings.inUse && !utils.settings['preferPerformance']) {
+if (utils.settings.hasNativeCustomElements && utils.settings.inUse && !utils.settings['preferPerformance']) {
 
   // process connect/disconnect after roots have rendered to avoid
   // issues with reaction stack.

--- a/packages/shadydom/src/attach-shadow.js
+++ b/packages/shadydom/src/attach-shadow.js
@@ -586,8 +586,10 @@ export const attachShadow = (host, options) => {
   return root;
 }
 
-// Mitigate connect/disconnect spam by wrapping custom element classes.
-if (utils.settings.hasNativeCustomElements && utils.settings.inUse && !utils.settings['preferPerformance']) {
+// Mitigate connect/disconnect spam by wrapping custom element classes. This
+// should happen if custom elements are available in any capacity, polyfilled or
+// not.
+if (utils.hasCustomElements() && utils.settings.inUse && !utils.settings['preferPerformance']) {
 
   // process connect/disconnect after roots have rendered to avoid
   // issues with reaction stack.

--- a/packages/shadydom/src/patch-instances.js
+++ b/packages/shadydom/src/patch-instances.js
@@ -167,9 +167,9 @@ export let patchInsideElementAccessors = noInstancePatching ?
       // * When SD is in `noPatch` mode, the SD patches call through to
       // "native" methods that are patched by CE (since CE is at the bottom).
       // Therefore continue to patch in this case.
-      // If customElements is not loaded, then these accessors should be
-      // patched so they work correctly.
-      if (!window['customElements'] || utils.settings.noPatch) {
+      // If the custom elements polyfill is not loaded, then these accessors
+      // should be patched so they work correctly.
+      if (!utils.hasPolyfilledCustomElements() || utils.settings.noPatch) {
         utils.patchExistingProperties(element, TextContentInnerHTMLDescriptors);
       }
     }

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -13,10 +13,14 @@ import {shadyDataForNode} from './shady-data.js';
 export const settings = window['ShadyDOM'] || {};
 
 settings.hasNativeShadowDOM = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
-// The user might need to pass the custom elements polyfill a flag by setting
-// an object to `window.customElements`, so check for
-// `window.CustomElementRegistry` instead.
-settings.hasNativeCustomElements = Boolean(window.CustomElementRegistry);
+
+export const hasCustomElements =
+    () => Boolean(window.customElements && window.customElements.define);
+// The custom elements polyfill is typically loaded after Shady DOM, so this
+// check isn't reliable during initial evaluation. However, because the
+// polyfills are loaded immediately after one another, it works at runtime.
+export const hasPolyfilledCustomElements =
+    () => Boolean(window.customElements && window.customElements['polyfillWrapFlushCallback']);
 
 const desc = Object.getOwnPropertyDescriptor(Node.prototype, 'firstChild');
 

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -14,6 +14,8 @@ export const settings = window['ShadyDOM'] || {};
 
 settings.hasNativeShadowDOM = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
 
+// The user might need to pass the custom elements polyfill a flag by setting an
+// object to `customElements`, so check for `customElements.define` also.
 export const hasCustomElements =
     () => Boolean(window.customElements && window.customElements.define);
 // The custom elements polyfill is typically loaded after Shady DOM, so this

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -13,6 +13,10 @@ import {shadyDataForNode} from './shady-data.js';
 export const settings = window['ShadyDOM'] || {};
 
 settings.hasNativeShadowDOM = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
+// The user might need to pass the custom elements polyfill a flag by setting
+// an object to `window.customElements`, so check for
+// `window.CustomElementRegistry` instead.
+settings.hasNativeCustomElements = Boolean(window.CustomElementRegistry);
 
 const desc = Object.getOwnPropertyDescriptor(Node.prototype, 'firstChild');
 


### PR DESCRIPTION
Updates decisions about when Shady DOM should patch the custom elements polyfill in a few places to fix the case where the user creates a global `customElements` object for the sake of passing flags to the custom elements polyfill.