### PR TITLE
remove wait for page load in webcomponent loader

### DIFF
--- a/packages/webcomponentsjs/webcomponents-loader.js
+++ b/packages/webcomponentsjs/webcomponents-loader.js
@@ -174,8 +174,8 @@
       polyfillsLoaded = true;
       fireEvent();
     } else { // readyState is loading
-      window.addEventListener('readystatechange', function loadWhenInteractive() {
-        if (document.readyState !== 'loading') {
+      window.addEventListener('readystatechange', function loadWhenInteractive(event) {
+        if (event.target.readyState !== 'loading') {
           window.removeEventListener('readystatechange', loadWhenInteractive);
           ready();
         }

--- a/packages/webcomponentsjs/webcomponents-loader.js
+++ b/packages/webcomponentsjs/webcomponents-loader.js
@@ -170,17 +170,14 @@
     }
   } else {
     // script is loaded imperatively on a spec-compliant browser, so just fire WCR
-    var loadAnyways = function() {
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
       polyfillsLoaded = true;
       fireEvent();
-    };
-    if (document.readyState === 'complete' || document.readyState === 'interactive') {
-      loadAnyways();
-    } else {
-      window.addEventListener('readystatechange', function loadWhenReady() {
-        if (document.readyState === 'complete' || document.readyState === 'interactive') {
-          window.removeEventListener('readystatechange', loadWhenReady);
-          loadAnyways();
+    } else { // readyState is loading
+      window.addEventListener('readystatechange', function loadWhenInteractive() {
+        if (document.readyState !== 'loading') {
+          window.removeEventListener('readystatechange', loadWhenInteractive);
+          ready();
         }
       });
     }

--- a/packages/webcomponentsjs/webcomponents-loader.js
+++ b/packages/webcomponentsjs/webcomponents-loader.js
@@ -173,7 +173,7 @@
     if (document.readyState === 'complete' || document.readyState === 'interactive') {
       polyfillsLoaded = true;
       fireEvent();
-    } else { // readyState is loading
+    } else {
       window.addEventListener('readystatechange', function loadWhenInteractive(event) {
         if (event.target.readyState !== 'loading') {
           window.removeEventListener('readystatechange', loadWhenInteractive);

--- a/packages/webcomponentsjs/webcomponents-loader.js
+++ b/packages/webcomponentsjs/webcomponents-loader.js
@@ -170,16 +170,14 @@
     }
   } else {
     // script is loaded imperatively on a spec-compliant browser, so just fire WCR
-    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    if (document.readyState === 'loading') {
+      document.addEventListener('readystatechange', function loadWhenInteractive() {
+        document.removeEventListener('readystatechange', loadWhenInteractive);
+        ready();
+      });
+    } else { // readyState is interactive or complete
       polyfillsLoaded = true;
       fireEvent();
-    } else {
-      window.addEventListener('readystatechange', function loadWhenInteractive(event) {
-        if (event.target.readyState !== 'loading') {
-          window.removeEventListener('readystatechange', loadWhenInteractive);
-          ready();
-        }
-      });
     }
   }
 })();

--- a/packages/webcomponentsjs/webcomponents-loader.js
+++ b/packages/webcomponentsjs/webcomponents-loader.js
@@ -169,17 +169,20 @@
       document.head.appendChild(newScript);
     }
   } else {
-    // if readyState is 'complete', script is loaded imperatively on a spec-compliant browser, so just fire WCR
-    if (document.readyState === 'complete') {
+    // script is loaded imperatively on a spec-compliant browser, so just fire WCR
+    var loadAnyways = function() {
       polyfillsLoaded = true;
       fireEvent();
+    };
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+      loadAnyways();
     } else {
-      // this script may come between DCL and load, so listen for both, and cancel load listener if DCL fires
-      window.addEventListener('load', ready);
-      window.addEventListener('DOMContentLoaded', function() {
-        window.removeEventListener('load', ready);
-        ready();
-      })
+      window.addEventListener('readystatechange', function loadWhenReady() {
+        if (document.readyState === 'complete' || document.readyState === 'interactive') {
+          window.removeEventListener('readystatechange', loadWhenReady);
+          loadAnyways();
+        }
+      });
     }
   }
 })();


### PR DESCRIPTION
Issue: wait for page load adds unnecessary latency for the latest browsers

Current behavior:
If the loader is loaded before DOMContentLoaded, the components are loaded on DomContentLoaded.
If the loader is loaded after DOMContentLoaded and before page load, the components are loaded on page load.

Desired behavior:
Any time after DOMContentLoaded, web components should load on spec compliant browsers. 

### Reference Issue
Fixes #233 
