### PR TITLE
[ShadyCSS] For shady-unscoped styles, create style fresh

### DIFF
--- a/packages/shadycss/src/unscoped-style-handler.js
+++ b/packages/shadycss/src/unscoped-style-handler.js
@@ -25,7 +25,9 @@ export function processUnscopedStyle(style) {
   const text = style.textContent;
   if (!styleTextSet.has(text)) {
     styleTextSet.add(text);
-    const newStyle = style.cloneNode(true);
+    const newStyle = document.createElement('style');
+    newStyle.setAttribute('shady-unscoped', '');
+    newStyle.textContent = text;
     document.head.appendChild(newStyle);
   }
 }


### PR DESCRIPTION
There is some weird edge-case bug in Edge where a cloned style does not
apply correctly to the page.

An easy workaround is to just create a new style and set the
textContent.

Fixes internal bug http://b/146331642