### PR TITLE
Fixes inserting next to a <slot> not in a shadowRoot

### DIFF
--- a/packages/shadydom/package-lock.json
+++ b/packages/shadydom/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@webcomponents/shadydom",
-	"version": "1.6.0",
+	"version": "1.7.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -25,10 +25,22 @@
 			"integrity": "sha512-IxzUe6YzaORzUksafHAXHprV29YncOJgr0+1zNAifl0/f+cb5iAd4IWUrnsnVFHG5UGTLjvis5RgV6vvIZPDrA==",
 			"dev": true
 		},
+		"@webcomponents/custom-elements": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.3.2.tgz",
+			"integrity": "sha512-0HtVxwE+PLPCIFL2i8/d+vjlrj8fgafmzZvIblZMyMcww9upicXTdfQT7K0Tg7tDlSoWxjmP2xKYP09A2YMocQ==",
+			"dev": true
+		},
 		"@webcomponents/shadycss": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.1.tgz",
-			"integrity": "sha512-IaZOnWOKXHghqk/WfPNDRIgDBi3RsVPY2IFAw6tYiL9UBGvQRy5R6uC+Fk7qTZsReTJ0xh5MTT8yAcb3MUR4mQ==",
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.4.tgz",
+			"integrity": "sha512-tgNcVEaKssyeZPbUBjVQf4aryO5Fi7fxRvOxV982ZJuRVDcefmIblBh0SXAbcvAAlQ2zpNEP4SuQUnr8uApIpw==",
+			"dev": true
+		},
+		"@webcomponents/template": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@webcomponents/template/-/template-1.4.1.tgz",
+			"integrity": "sha512-v7vwYZPKsAxczkWIjCOfCki9SpRdUcDjMZyweTGj3EPvVi+awQVHFPZ6X3jDW5nLSOs6Ls3h/AX8x8T+df2X0Q==",
 			"dev": true
 		},
 		"@webcomponents/webcomponents-platform": {

--- a/packages/shadydom/src/patches/Node.js
+++ b/packages/shadydom/src/patches/Node.js
@@ -351,7 +351,7 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
         /** @type {ShadowRoot} */(this).host : this;
       // if ref_node, get the ref_node that's actually in composed dom.
       if (ref_node) {
-        ref_node = firstComposedNode(ref_node);
+        ref_node = ownerRoot ? firstComposedNode(ref_node) : ref_node;
         container[utils.NATIVE_PREFIX + 'insertBefore'](node, ref_node);
       } else {
         container[utils.NATIVE_PREFIX + 'appendChild'](node);

--- a/packages/shadydom/src/patches/Node.js
+++ b/packages/shadydom/src/patches/Node.js
@@ -63,6 +63,9 @@ function firstComposedNode(node) {
   if (node && node.localName === 'slot') {
     const nodeData = shadyDataForNode(node);
     const flattened = nodeData && nodeData.flattenedNodes;
+    // Note, if `flattened` is falsey, it means that the containing shadowRoot
+    // has not rendered and therefore the `<slot>` is still in the composed
+    // DOM. If that's the case the `<slot>` is the first composed node.
     if (flattened) {
       composed = flattened.length ? flattened[0] :
         firstComposedNode(node[utils.SHADY_PREFIX + 'nextSibling']);

--- a/packages/shadydom/src/patches/Node.js
+++ b/packages/shadydom/src/patches/Node.js
@@ -63,8 +63,10 @@ function firstComposedNode(node) {
   if (node && node.localName === 'slot') {
     const nodeData = shadyDataForNode(node);
     const flattened = nodeData && nodeData.flattenedNodes;
-    composed = flattened && flattened.length ? flattened[0] :
-      firstComposedNode(node[utils.SHADY_PREFIX + 'nextSibling']);
+    if (flattened) {
+      composed = flattened.length ? flattened[0] :
+        firstComposedNode(node[utils.SHADY_PREFIX + 'nextSibling']);
+    }
   }
   return composed;
 }
@@ -351,7 +353,7 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
         /** @type {ShadowRoot} */(this).host : this;
       // if ref_node, get the ref_node that's actually in composed dom.
       if (ref_node) {
-        ref_node = ownerRoot ? firstComposedNode(ref_node) : ref_node;
+        ref_node = firstComposedNode(ref_node);
         container[utils.NATIVE_PREFIX + 'insertBefore'](node, ref_node);
       } else {
         container[utils.NATIVE_PREFIX + 'appendChild'](node);

--- a/packages/shadydom/tests/shady-dynamic.html
+++ b/packages/shadydom/tests/shady-dynamic.html
@@ -543,7 +543,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     assert.equal(ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(testElement).shadowRoot).querySelector('#added2'), s);
   });
 
-  test('insertBefore before a <slot> in light', function() {
+  test('insertBefore/removeChild before a <slot> in lightDOM causes no exception', function() {
     var template = ShadyDOM.wrapIfNeeded(document).querySelector('template#insertBeforeSlot');
     var frag = ShadyDOM.wrapIfNeeded(template.content).cloneNode(true);
     var div = ShadyDOM.wrapIfNeeded(frag).querySelector('div#slotHost');

--- a/packages/shadydom/tests/shady-dynamic.html
+++ b/packages/shadydom/tests/shady-dynamic.html
@@ -1132,11 +1132,27 @@ suite('insertBefore', function() {
   test('insertBefore with a `<slot>` as refNode not in a shadowRoot', function() {
     var e = document.createElement('div');
     var slot = document.createElement('slot');
-    e.appendChild(slot);
+    ShadyDOM.wrapIfNeeded(e).appendChild(slot);
     var div = document.createElement('div');
-    e.insertBefore(div, slot);
+    ShadyDOM.wrapIfNeeded(e).insertBefore(div, slot);
     var composed = Array.from(ShadyDOM.nativeTree.childNodes(e));
     assert.deepEqual(composed, [div, slot]);
+  });
+
+  test('insertBefore with a `<slot>` as refNode in a shadowRoot that hasn\'t rendered', function() {
+    var e = document.createElement('div');
+    ShadyDOM.wrapIfNeeded(e).attachShadow({mode: 'open'});
+    var last = document.createElement('div');
+    var slot = document.createElement('slot');
+    ShadyDOM.wrapIfNeeded(e).shadowRoot.appendChild(slot);
+    ShadyDOM.wrapIfNeeded(e).shadowRoot.appendChild(last);
+    var first = document.createElement('div');
+    ShadyDOM.wrapIfNeeded(e).shadowRoot.insertBefore(first, slot);
+    var composed = Array.from(ShadyDOM.nativeTree.childNodes(e));
+    assert.deepEqual(composed, [first, slot, last]);
+    ShadyDOM.flush();
+    composed = Array.from(ShadyDOM.nativeTree.childNodes(e));
+    assert.deepEqual(composed, [first, last]);
   });
 
   test('contains', function() {

--- a/packages/shadydom/tests/shady-dynamic.html
+++ b/packages/shadydom/tests/shady-dynamic.html
@@ -1129,6 +1129,16 @@ suite('insertBefore', function() {
     });
   });
 
+  test('insertBefore with a `<slot>` as refNode not in a shadowRoot', function() {
+    var e = document.createElement('div');
+    var slot = document.createElement('slot');
+    e.appendChild(slot);
+    var div = document.createElement('div');
+    e.insertBefore(div, slot);
+    var composed = Array.from(ShadyDOM.nativeTree.childNodes(e));
+    assert.deepEqual(composed, [div, slot]);
+  });
+
   test('contains', function() {
     var e = document.createElement('x-simple');
     ShadyDOM.wrapIfNeeded(document.body).appendChild(e);


### PR DESCRIPTION
Fixes #253: `insertBefore`: only insert next to the first composed node of a slot when inserting into a shadowRoot.
