### PR TITLE
Correctly detect `slot.insertBefore` as requiring shadowRoot distribution

### DIFF
--- a/packages/shadydom/src/patches/Node.js
+++ b/packages/shadydom/src/patches/Node.js
@@ -338,22 +338,23 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     }
     if (utils.isTrackingLogicalChildNodes(this)) {
       recordInsertBefore(node, this, ref_node);
-      // when inserting into a host with a shadowRoot with slot, use
-      // `shadowRoot._asyncRender()` via `attach-shadow` module
       const parentData = shadyDataForNode(this);
-      if (utils.hasShadowRootWithSlot(this)) {
-        parentData.root._asyncRender();
+      // if the node being inserted into has a shadowRoot, do not perform
+      // a native insertion
+      if (parentData.root) {
         allowNativeInsert = false;
-      // when inserting into a host with shadowRoot with NO slot, do nothing
-      // as the node should not be added to composed dome anywhere.
-      } else if (parentData.root) {
-        allowNativeInsert = false;
-      }
-      // when inserting into a slot inside a shadowRoot, must render the
+        // when inserting into a host with a shadowRoot with slot, use
+        // `shadowRoot._asyncRender()` via `attach-shadow` module
+        // when inserting into a host with shadowRoot with NO slot, do nothing
+        // as the node should not be added to composed DOM anywhere.
+        if (utils.hasShadowRootWithSlot(this)) {
+          parentData.root._asyncRender();
+        }
+      // when inserting into a slot inside a shadowRoot, render the
       // containing shadowRoot to update fallback content.
-      if (ownerRoot && this.localName === 'slot') {
-        ownerRoot._asyncRender();
+      } else if (ownerRoot && this.localName === 'slot') {
         allowNativeInsert = false;
+        ownerRoot._asyncRender();
       }
     }
     if (allowNativeInsert) {

--- a/packages/shadydom/src/patches/Node.js
+++ b/packages/shadydom/src/patches/Node.js
@@ -349,6 +349,12 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
       } else if (parentData.root) {
         allowNativeInsert = false;
       }
+      // when inserting into a slot inside a shadowRoot, must render the
+      // containing shadowRoot to update fallback content.
+      if (ownerRoot && this.localName === 'slot') {
+        ownerRoot._asyncRender();
+        allowNativeInsert = false;
+      }
     }
     if (allowNativeInsert) {
       // if adding to a shadyRoot, add to host instead
@@ -423,7 +429,7 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     removeOwnerShadyRoot(node);
     // if removing slot, must render containing root
     if (ownerRoot) {
-      let changeSlotContent = this && this.localName === 'slot';
+      let changeSlotContent = this.localName === 'slot';
       if (changeSlotContent) {
         preventNativeRemove = true;
       }

--- a/packages/shadydom/tests/shady-dynamic.html
+++ b/packages/shadydom/tests/shady-dynamic.html
@@ -1155,6 +1155,25 @@ suite('insertBefore', function() {
     assert.deepEqual(composed, [first, last]);
   });
 
+  test('insertBefore with a `<slot>` child as refNode in a shadowRoot that has rendered', function() {
+    var e = document.createElement('div');
+    ShadyDOM.wrapIfNeeded(e).attachShadow({mode: 'open'});
+    var ref = document.createElement('div');
+    var slot = document.createElement('slot');
+    ShadyDOM.wrapIfNeeded(slot).appendChild(ref);
+    ShadyDOM.wrapIfNeeded(e).shadowRoot.appendChild(slot);
+    ShadyDOM.flush();
+    var fallback = document.createElement('div');
+    ShadyDOM.wrapIfNeeded(slot).insertBefore(fallback, ref);
+    ShadyDOM.flush();
+    var composed = Array.from(ShadyDOM.nativeTree.childNodes(e));
+    assert.deepEqual(composed, [fallback, ref]);
+    ShadyDOM.wrapIfNeeded(slot).removeChild(fallback);
+    ShadyDOM.flush();
+    var composed = Array.from(ShadyDOM.nativeTree.childNodes(e));
+    assert.deepEqual(composed, [ref]);
+  });
+
   test('contains', function() {
     var e = document.createElement('x-simple');
     ShadyDOM.wrapIfNeeded(document.body).appendChild(e);


### PR DESCRIPTION
Fixes #266. If a `<slot>` is in a shadowRoot, when its children change, the shadowRoot needs to distribute to correctly render.