### PR TITLE
Remove externs that aren't used internally.

### DIFF
--- a/packages/webcomponentsjs/externs/webcomponents.js
+++ b/packages/webcomponentsjs/externs/webcomponents.js
@@ -9,14 +9,6 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
-var require;
-var global;
-var ES6Promise;
-var process;
-var define;
-var module;
-var exports;
-
 var ShadyDOM;
 var WebComponents;
 


### PR DESCRIPTION
These externs break the internal build and don't seem to have any effect on the external one.

Related to #271, but doesn't close.