### PR TITLE
Fix a typo that prevents the document construction observer from being created.

### DIFF
--- a/packages/custom-elements/ts_src/CustomElementInternals.ts
+++ b/packages/custom-elements/ts_src/CustomElementInternals.ts
@@ -30,7 +30,7 @@ export default class CustomElementInternals {
   }) {
     this.shadyDomFastWalk = options.shadyDomFastWalk;
     this.useDocumentConstructionObserver =
-        options.noDocumentConstructionObserver;
+        !options.noDocumentConstructionObserver;
   }
 
   forEachElement(

--- a/packages/tests/custom-elements/html/DocumentConstructionObserver.html
+++ b/packages/tests/custom-elements/html/DocumentConstructionObserver.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+<title>DocumentConstructionObserver</title>
+<script>
+  (window.customElements = window.customElements || {}).forcePolyfill = true;
+</script>
+<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+<script>
+  // This needs to be a classic script so that it runs before the parser gets
+  // to <body>.
+
+  // This snippet is copied from '../safari-gc-bug-workaround.js' because this
+  // test suite can't use the Safari GC workaround script as a module: it
+  // specifically tests behavior of a definition provided before the document's
+  // body has begun to be parsed.
+  if (customElements.polyfillWrapFlushCallback === undefined) {
+    window.__CE_installPolyfill();
+    console.warn('The custom elements polyfill was reinstalled.');
+  }
+
+  class DCOCreated extends HTMLElement {
+    constructor() {
+      super();
+      this.wasConstructed = true;
+    }
+  }
+  customElements.define('dco-created', DCOCreated);
+</script>
+<script type="module">
+  // Safari GC bug workaround applied earlier.
+
+  suite('DocumentConstructionObserver', function() {
+    test('The DocumentConstructionObserver constructs parser-created ' +
+        'elements in the document body.', function() {
+      const parserCreatedElement = document.body.querySelector('dco-created');
+      assert(parserCreatedElement.wasConstructed);
+    });
+  });
+</script>
+</head>
+<body>
+  <dco-created></dco-created>
+</body>
+</html>

--- a/packages/tests/custom-elements/index.html
+++ b/packages/tests/custom-elements/index.html
@@ -33,5 +33,6 @@
     'html/Document/index.html',
     'html/HTMLElement/index.html',
     'html/Interface/index.html',
+    'html/DocumentConstructionObserver.html',
   ]);
 </script>


### PR DESCRIPTION
This `!` was accidentally removed during the TS conversion and causes elements in the main document not to be upgraded.