### PR TITLE
Add CHANGELOGs to all packages with recent release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ there are certain patterns that require direct interaction with the library:
 
 This repo is a _monorepo_. Each package lives under `packages/<package>`.
 
-### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/webcomponentsjs.svg)](https://www.npmjs.com/package/@webcomponents/webcomponentsjs) [webcomponentsjs](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs) ([Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+webcomponentsjs%22))
+### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/webcomponentsjs.svg)](https://www.npmjs.com/package/@webcomponents/webcomponentsjs) [webcomponentsjs](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs)
+
+##### [Documentation](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs#readme) | [Changelog](https://github.com/webcomponents/polyfills/blob/master/packages/webcomponentsjs/CHANGELOG.md) | [Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+webcomponentsjs%22)
 
 Loader and pre-minimized bundles for the full suite of Web Components
 polyfills.
@@ -90,24 +92,44 @@ polyfills.
 Most users only need to install this package, but it is also possible to
 separately install any of the individual polyfills listed below.
 
-### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/custom-elements.svg)](https://www.npmjs.com/package/@webcomponents/custom-elements) [custom-elements](https://github.com/webcomponents/polyfills/tree/master/packages/custom-elements) ([Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+custom-elements%22))
+---
+
+### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/custom-elements.svg)](https://www.npmjs.com/package/@webcomponents/custom-elements) [custom-elements](https://github.com/webcomponents/polyfills/tree/master/packages/custom-elements)
+
+##### [Documentation](https://github.com/webcomponents/polyfills/tree/master/packages/custom-elements#readme) | [Changelog](https://github.com/webcomponents/polyfills/blob/master/packages/custom-elements/CHANGELOG.md) | [Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+custom-elements%22)
 
 Polyfill for Custom Elements ([MDN](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements), [Spec](https://html.spec.whatwg.org/multipage/custom-elements.html))
 
-### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/template.svg)](https://www.npmjs.com/package/@webcomponents/template) [template](https://github.com/webcomponents/polyfills/tree/master/packages/template) ([Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+template%22))
+---
 
+### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/template.svg)](https://www.npmjs.com/package/@webcomponents/template) [template](https://github.com/webcomponents/polyfills/tree/master/packages/template)
+
+##### [Documentation](https://github.com/webcomponents/polyfills/tree/master/packages/template#readme) | [Changelog](https://github.com/webcomponents/polyfills/blob/master/packages/template/CHANGELOG.md) | [Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+template%22)
 
 Polyfill for Template Element ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTemplateElement), [Spec](https://html.spec.whatwg.org/multipage/scripting.html#the-template-element))
 
-### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/shadydom.svg)](https://www.npmjs.com/package/@webcomponents/shadydom) [shadydom](https://github.com/webcomponents/polyfills/tree/master/packages/shadydom) ([Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+shadydom%22))
+---
+
+### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/shadydom.svg)](https://www.npmjs.com/package/@webcomponents/shadydom) [shadydom](https://github.com/webcomponents/polyfills/tree/master/packages/shadydom)
+
+##### [Documentation](https://github.com/webcomponents/polyfills/tree/master/packages/shadydom#readme) | [Changelog](https://github.com/webcomponents/polyfills/blob/master/packages/shadydom/CHANGELOG.md) | [Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+shadydom%22)
 
 Polyfill for Shadow DOM ([MDN](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), [Spec](https://dom.spec.whatwg.org/#shadow-trees))
 
-### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/shadycss.svg)](https://www.npmjs.com/package/@webcomponents/shadycss) [shadycss](https://github.com/webcomponents/polyfills/tree/master/packages/shadycss) ([Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+shadycss%22))
+---
+
+### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/shadycss.svg)](https://www.npmjs.com/package/@webcomponents/shadycss) [shadycss](https://github.com/webcomponents/polyfills/tree/master/packages/shadycss)
+
+##### [Documentation](https://github.com/webcomponents/polyfills/tree/master/packages/shadycss#readme) | [Changelog](https://github.com/webcomponents/polyfills/blob/master/packages/shadycss/CHANGELOG.md) | [Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+shadycss%22)
 
 Polyfill for Scoped CSS ([Spec](https://drafts.csswg.org/css-scoping))
 
-### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/html-imports.svg)](https://www.npmjs.com/package/@webcomponents/html-imports) [html-imports](https://github.com/webcomponents/polyfills/tree/master/packages/html-imports) ([Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+html-imports%22))
+---
+
+### [![Published on npm](https://img.shields.io/npm/v/@webcomponents/html-imports.svg)](https://www.npmjs.com/package/@webcomponents/html-imports) [html-imports](https://github.com/webcomponents/polyfills/tree/master/packages/html-imports)
+
+##### [Documentation](https://github.com/webcomponents/polyfills/tree/master/packages/html-imports#readme) | [Changelog](https://github.com/webcomponents/polyfills/blob/master/packages/html-imports/CHANGELOG.md) | [Issues](https://github.com/webcomponents/polyfills/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+html-imports%22)
+
 Polyfill for HTML Imports ([Spec](https://w3c.github.io/webcomponents/spec/imports/))
 
 Note that HTML Imports are

--- a/packages/custom-elements/CHANGELOG.md
+++ b/packages/custom-elements/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+- Type annotation improvements for Closure ([#287](https://github.com/webcomponents/polyfills/pull/287))
+- README improvements ([#169](https://github.com/webcomponents/polyfills/pull/169))
+
+## [1.4.1] - 2020-03-16
+
+- Fix bug that prevented elements in the main document from being upgraded
+  ([#283](https://github.com/webcomponents/polyfills/pull/283))
+
+## [1.4.0] - 2020-02-26
+
+- Convert to TypeScript
+  ([#246](https://github.com/webcomponents/polyfills/pull/246))
+
+## [1.3.2] - 2020-01-08
+
+- Maintenance release (no user-facing changes)
+
+## [1.3.1] - 2019-11-12
+
+- Remove warnings about `insertAdjacentElement` and `insertAdjacentHTML` not
+  being patched ([#229](https://github.com/webcomponents/polyfills/pull/229))
+- Fix incorrect `polyfillWrapFlushCallback` example in README
+  ([#219](https://github.com/webcomponents/polyfills/pull/219))

--- a/packages/html-imports/CHANGELOG.md
+++ b/packages/html-imports/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- ## [Unreleased] -->
+
+## [1.2.4] - 2020-03-16
+
+- Maintenance release (no user-facing changes)
+
+## [1.2.3] - 2020-02-26
+
+- Maintenance release (no user-facing changes)
+
+## [1.2.2] - 2019-09-19
+
+- Fix bug where `<style>` elements within `<svg>` elements would cause the HTML
+  imports polyfill to wait for them forever
+  ([#203](https://github.com/webcomponents/polyfills/pull/203))
+- Fix Edge and Chrome 41 timing issues
+  ([#141](https://github.com/webcomponents/polyfills/pull/141))

--- a/packages/shadycss/CHANGELOG.md
+++ b/packages/shadycss/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- ## [Unreleased] -->
+
+## [1.9.6] - 2020-03-16
+
+- Closure type annotation improvements ([#284](https://github.com/webcomponents/polyfills/pull/284), [#280](https://github.com/webcomponents/polyfills/pull/280))
+
+## [1.9.5] - 2020-02-26
+
+- Maintenance release (no user-facing changes)
+
+## [1.9.4] - 2020-01-08
+
+- Fix Edge bug where cloned style would not apply correctly
+  ([#242](https://github.com/webcomponents/polyfills/pull/242))
+
+## [1.9.3] - 2019-11-12
+
+- When the apply shim is loaded, update custom-styles even if none are currently
+  enqueued ([#208](https://github.com/webcomponents/polyfills/pull/208))

--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+- Remove outdated references to `customElements.nativeHTMLElement`
+  ([#234](https://github.com/webcomponents/polyfills/pull/234))
+- Add README warning about polyfill ordering when using `noPatch`
+  ([#179](https://github.com/webcomponents/polyfills/pull/179))
+
+## [1.7.3] - 2020-03-16
+
+- Maintenance release (no user-facing changes)
+
+## [1.7.2] - 2020-02-26
+
+- Correctly detect `slot.insertBefore` as requiring shadowRoot distribution
+  ([#267](https://github.com/webcomponents/polyfills/pull/267))
+- Gather event properties from the correct prototypes
+  ([#263](https://github.com/webcomponents/polyfills/pull/263/files))
+
+## [1.7.1] - 2020-01-08
+
+- Fix case where user creates a global `customElements` object for the sake of
+  passing flags to the polyfill by only modify `customElements` at load if it's
+  a `CustomElementRegistry`
+  ([#235](https://github.com/webcomponents/polyfills/pull/235))
+
+## [1.7.0] - 2019-11-12
+
+- Add on-demand patching mode
+  ([#189](https://github.com/webcomponents/polyfills/pull/189))
+- Avoid IE11 bug that breaks Closure's `WeakMap` polyfill
+  ([#228](https://github.com/webcomponents/polyfills/pull/228))

--- a/packages/template/CHANGELOG.md
+++ b/packages/template/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- ## [Unreleased] -->
+
+## [1.4.2] - 2020-03-16
+
+- Maintenance release (no user-facing changes)

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- ## [Unreleased] -->
+
+## [0.7.5] - 2020-03-16
+
+- Maintenance release (no user-facing changes)

--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+- Convert platform (`Array.from`, `CustomEvent`, `Promise` etc.) polyfills to
+  TypeScript ([#292](https://github.com/webcomponents/polyfills/pull/292))
+- Improve types for JSCompiler compatibility
+  ([#307](https://github.com/webcomponents/polyfills/pull/307))
+- README improvements
+  ([#128](https://github.com/webcomponents/polyfills/pull/128),
+  [#212](https://github.com/webcomponents/polyfills/pull/212),
+  [#214](https://github.com/webcomponents/polyfills/pull/214))
+
+## [2.4.3] - 2020-03-16
+
+- Maintenance release (no user-facing changes)
+
+## [2.4.2] - 2020-02-26
+
+- Remove unnecessary externs
+  ([#272](https://github.com/webcomponents/polyfills/pull/272))
+
+## [2.4.1] - 2020-01-09
+
+- Maintenance release (no user-facing changes)
+
+## [2.4.0] - 2019-11-12
+
+- Add on-demand patching mode
+  ([#189](https://github.com/webcomponents/polyfills/pull/189))


### PR DESCRIPTION
I retroactively included releases since November last year.

Going forward we should include CHANGELOG entries for any new user-facing changes. https://github.com/webcomponents/polyfills/issues/319 tracks enforcing this with a GitHub Action.

Also updates the main README to link to each CHANGELOG, and a little reformatting.

Fixes https://github.com/webcomponents/polyfills/issues/54