### PR TITLE
GitHub Action to require PRs to touch a CHANGELOG

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,6 +20,10 @@ jobs:
 
     - name: Check for CHANGELOG changes
       run: |
+        # Only the latest commit of the feature branch is checkoued out
+        # automatically (see https://github.com/webcomponents/polyfills). To
+        # diff with the base branch, we need to fetch that too (and we only
+        # need its latest commit).
         git fetch origin ${{ github.base_ref }} --depth=1
         if [[ $(git diff --name-only FETCH_HEAD | grep CHANGELOG) ]]
         then

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Check for CHANGELOG changes
       run: |
-        # Only the latest commit of the feature branch is checkoued out
+        # Only the latest commit of the feature branch is available
         # automatically (see https://github.com/webcomponents/polyfills). To
         # diff with the base branch, we need to fetch that too (and we only
         # need its latest commit).

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,31 @@
+# This action requires that any PR targeting the master branch should touch at
+# least one CHANGELOG file. If a CHANGELOG entry is not required, add the "Skip
+# Changelog" label to disable this action.
+
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - master
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.labels.*.name, 'Skip Changelog')"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Check for CHANGELOG changes
+      run: |
+        git fetch origin ${{ github.base_ref }} --depth=1
+        if [[ $(git diff --name-only FETCH_HEAD | grep CHANGELOG) ]]
+        then
+          echo "A CHANGELOG was modified. Looks good!"
+        else
+          echo "No CHANGELOG was modified."
+          echo "Please add a CHANGELOG entry, or add the \"Skip Changelog\" label if not required."
+          false
+        fi


### PR DESCRIPTION
Only runs on PRs targeting the master branch, and can be disabled by adding the "Skip Changelog" label.

Fixes https://github.com/webcomponents/polyfills/issues/319
Related to https://github.com/webcomponents/polyfills/issues/54