### PR TITLE
Shady Parts: Parsing and formatting functions

### DIFF
--- a/packages/shadycss/src/shadow-parts.js
+++ b/packages/shadycss/src/shadow-parts.js
@@ -49,11 +49,15 @@ export function parseExportPartsAttribute(attr) {
     const split = part.split(/\s*:\s*/);
     let inner, outer;
     if (split.length === 1) {
+      // E.g. "foo"
       inner = outer = split[0];
     } else if (split.length === 2) {
+      // E.g. "foo:bar"
       inner = split[0];
       outer = split[1];
     } else {
+      // E.g. "foo:bar:baz". Invalid format; skip but keep parsing (this
+      // matches native behavior).
       continue;
     }
     parts.push({ inner, outer });
@@ -66,7 +70,7 @@ export function parseExportPartsAttribute(attr) {
  * parsePartSelector for description of pieces.
  *                  [0  ][1         ][2      ]        [3 ]   [4   ]
  */
-const PART_REGEX = /(.*?)([a-z]+-\w+)([^\s]*?)::part\((.*)?\)(::.*)?/;
+const PART_REGEX = /(.*?)([a-z]+-\w+)([^\s]*?)::part\((.*)?\)(::?.*)?/;
 
 /**
  * De-compose a ::part rule into interesting pieces.
@@ -87,7 +91,7 @@ const PART_REGEX = /(.*?)([a-z]+-\w+)([^\s]*?)::part\((.*)?\)(::.*)?/;
  *
  * Example:
  *   [0       ][1      ][2   ]       [3    ] [4    ]
- *   #parent > my-button.fancy::part(foo bar)::hover
+ *   #parent > my-button.fancy::part(foo bar):hover
  *
  * @param {!string} selector The selector.
  * @return {?{

--- a/packages/shadycss/src/shadow-parts.js
+++ b/packages/shadycss/src/shadow-parts.js
@@ -1,0 +1,163 @@
+/**
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+/**
+ * Parse a CSS Shadow Parts "part" attribute into an array of part names.
+ *
+ * Example:
+ *   Given: "foo bar  foo "
+ *   Returns: ["foo", "bar", "foo"]
+ *
+ * @param {?string} str The "part" attribute value.
+ * @return {!Array<!string>} The part names. Order and duplicates are preserved.
+ */
+export function splitPartString(str) {
+  if (!str) {
+    return [];
+  }
+  return str.trim().split(/\s+/);
+}
+
+/**
+ * Parse a CSS Shadow Parts "exportparts" attribute into an array of inner/outer
+ * part mappings.
+ *
+ * Example:
+ *   Given: "foo, bar:baz"
+ *   Returns: [
+ *     {inner:"foo", outer:"foo"},
+ *     {inner:"bar", outer:"baz"},
+ *   ]
+ *
+ * @param {?string} attr The "exportparts" attribute value.
+ * @return {!Array<{inner: !string, outer: !string}>} The inner/outer mapping.
+ * Order and duplicates are preserved.
+ */
+export function parseExportPartsAttribute(attr) {
+  if (!attr) {
+    return [];
+  }
+  const parts = [];
+  for (const part of attr.split(/\s*,\s*/)) {
+    const split = part.split(/\s*:\s*/);
+    let inner, outer;
+    if (split.length === 1) {
+      inner = outer = split[0];
+    } else if (split.length === 2) {
+      inner = split[0];
+      outer = split[1];
+    } else {
+      continue;
+    }
+    parts.push({ inner, outer });
+  }
+  return parts;
+}
+
+/**
+ * Regular expression to de-compose a ::part rule into interesting pieces. See
+ * parsePartSelector for description of pieces.
+ *                  [0  ][1         ][2      ]        [3 ]   [4   ]
+ */
+const PART_REGEX = /(.*?)([a-z]+-\w+)([^\s]*?)::part\((.*)?\)(::.*)?/;
+
+/**
+ * De-compose a ::part rule into interesting pieces.
+ *
+ * [0] combinators: Optional combinator selectors constraining the receiving
+ *     host.
+ * [1] elementName: Required custom element name of the receiving host. Note
+ *     that ShadyCSS part support requires there to be an explicit custom
+ *     element name here, unlike native parts.
+ * [2] selectors: Optional additional selectors constraining the receiving host.
+ * [3] parts: The part name or names (whitespace-separated, this function does
+ *     not split them).
+ * [4] pseudos: Optional pseudo-classes or pseudo-elements of the part.
+ *
+ *     TODO(aomarks) Actually only "non-structural" pseudo-classes and
+ *     pseudo-elements are supported here. We should validate them to be more
+ *     spec-compliant.
+ *
+ * Example:
+ *   [0       ][1      ][2   ]       [3    ] [4    ]
+ *   #parent > my-button.fancy::part(foo bar)::hover
+ *
+ * @param {!string} selector The selector.
+ * @return {?{
+ *   combinators: !string,
+ *   elementName: !string,
+ *   selectors: !string,
+ *   parts: !string,
+ *   pseudos: !string
+ * }}
+ */
+export function parsePartSelector(selector) {
+  const match = selector.match(PART_REGEX);
+  if (match === null) {
+    return null;
+  }
+  const [, combinators, elementName, selectors, parts, pseudos] = match;
+  return { combinators, elementName, selectors, parts, pseudos: pseudos || "" };
+}
+
+/**
+ * Format the shady-part attribute value for a part.
+ *
+ * Example:
+ *   Given: "x-app", "x-btn", "prt1"
+ *   Returns: "x-app:x-btn:prt1"
+ *
+ * @param {!string} providerScope Lowercase name of the custom element that
+ *     provides the part style, or "document" if the style comes from the main
+ *     document.
+ * @param {!string} receiverScope Lowercase name of the custom element that
+ *     receives the part style.
+ * @param {!string} partName Name of the part.
+ * @return {!string} Value for the shady-part attribute.
+ */
+export function formatShadyPartAttribute(
+  providerScope,
+  receiverScope,
+  partName
+) {
+  return `${providerScope}:${receiverScope}:${partName}`;
+}
+
+/**
+ * Format the shady-part attribute CSS selector for a part rule.
+ *
+ * Example:
+ *   Given: "x-app", "x-btn", "prt1 prt2"
+ *   Returns: '[shady-part~="x-app:x-btn:prt1"][shady-part~="x-app:x-btn:prt2"]'
+ *
+ * @param {!string} providerScope Lowercase name of the custom element that
+ *     provides the part style, or "document" if the style comes from the main
+ *     document.
+ * @param {!string} receiverScope Lowercase name of the custom element that
+ *     receives the part style.
+ * @param {!string} partNames Whitespace-separated part list.
+ * @return {!string} shady-part attribute CSS selector.
+ */
+export function formatShadyPartSelector(
+  providerScope,
+  receiverScope,
+  partNames
+) {
+  return splitPartString(partNames)
+    .map((partName) => {
+      const attr = formatShadyPartAttribute(
+        providerScope,
+        receiverScope,
+        partName
+      );
+      return `[shady-part~="${attr}"]`;
+    })
+    .join("");
+}

--- a/packages/tests/shadycss/shadow-parts/parsing-formatting.html
+++ b/packages/tests/shadycss/shadow-parts/parsing-formatting.html
@@ -48,17 +48,47 @@
           );
         });
 
+        test("pseudo-class", () => {
+          assert.deepEqual(
+            shadowParts.parsePartSelector(
+              "my-button::part(foo):hover"
+            ),
+            {
+              combinators: "",
+              elementName: "my-button",
+              selectors: "",
+              parts: "foo",
+              pseudos: ":hover",
+            }
+          );
+        });
+
+        test("pseudo-element", () => {
+          assert.deepEqual(
+            shadowParts.parsePartSelector(
+              "my-button::part(foo)::before"
+            ),
+            {
+              combinators: "",
+              elementName: "my-button",
+              selectors: "",
+              parts: "foo",
+              pseudos: "::before",
+            }
+          );
+        });
+
         test("all components", () => {
           assert.deepEqual(
             shadowParts.parsePartSelector(
-              "#parent > my-button.fancy::part(foo bar)::hover"
+              "#parent > my-button.fancy::part(foo bar):hover"
             ),
             {
               combinators: "#parent > ",
               elementName: "my-button",
               selectors: ".fancy",
               parts: "foo bar",
-              pseudos: "::hover",
+              pseudos: ":hover",
             }
           );
         });

--- a/packages/tests/shadycss/shadow-parts/parsing-formatting.html
+++ b/packages/tests/shadycss/shadow-parts/parsing-formatting.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<head>
+  <script>
+    WCT = {
+      waitFor: function (cb) {
+        HTMLImports.whenReady(cb);
+      },
+    };
+  </script>
+  <script src="../test-flags.js"></script>
+  <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+  <script type="module">
+    import * as shadowParts from "../../node_modules/@webcomponents/shadycss/src/shadow-parts.js";
+
+    suite("shadow parts parsing and formatting", () => {
+      test("splitPartString", () => {
+        assert.deepEqual(shadowParts.splitPartString("foo bar  foo "), [
+          "foo",
+          "bar",
+          "foo",
+        ]);
+      });
+
+      test("parseExportPartsAttribute", () => {
+        assert.deepEqual(
+          shadowParts.parseExportPartsAttribute("foo, bar:baz"),
+          [
+            { inner: "foo", outer: "foo" },
+            { inner: "bar", outer: "baz" },
+          ]
+        );
+      });
+
+      suite("parsePartSelector", () => {
+        test("minimal", () => {
+          assert.deepEqual(
+            shadowParts.parsePartSelector("my-button::part(foo)"),
+            {
+              combinators: "",
+              elementName: "my-button",
+              selectors: "",
+              parts: "foo",
+              pseudos: "",
+            }
+          );
+        });
+
+        test("all components", () => {
+          assert.deepEqual(
+            shadowParts.parsePartSelector(
+              "#parent > my-button.fancy::part(foo bar)::hover"
+            ),
+            {
+              combinators: "#parent > ",
+              elementName: "my-button",
+              selectors: ".fancy",
+              parts: "foo bar",
+              pseudos: "::hover",
+            }
+          );
+        });
+
+        test("missing ::part selector", () => {
+          assert.deepEqual(
+            shadowParts.parsePartSelector("#parent > my-button.fancy::hover"),
+            null
+          );
+        });
+
+        test("missing custom element name", () => {
+          assert.deepEqual(
+            shadowParts.parsePartSelector(
+              "#parent > .fancy::part(foo bar)::hover"
+            ),
+            null
+          );
+        });
+      });
+
+      test("formatShadyPartAttribute", () => {
+        assert.equal(
+          shadowParts.formatShadyPartAttribute("x-app", "x-btn", "prt1"),
+          "x-app:x-btn:prt1"
+        );
+      });
+
+      test("formatShadyPartSelector", () => {
+        assert.equal(
+          shadowParts.formatShadyPartSelector("x-app", "x-btn", "prt1  prt2 "),
+          '[shady-part~="x-app:x-btn:prt1"][shady-part~="x-app:x-btn:prt2"]'
+        );
+      });
+    });
+  </script>
+</body>


### PR DESCRIPTION
Start with some the parsing and formatting functions for shadow parts support in ShadyCSS.

(Note this is merging into the `shady-parts` branch, not `master`).

See https://github.com/webcomponents/polyfills/pull/306 for design.

Part of https://github.com/webcomponents/polyfills/issues/252 and https://github.com/webcomponents/polyfills/issues/311.