### PR TITLE
Support exportparts in ShadyCSS

### DIFF
--- a/packages/shadycss/src/shadow-parts.js
+++ b/packages/shadycss/src/shadow-parts.js
@@ -173,7 +173,7 @@ export function formatShadyPartSelector(
  *   #document
  *     <x-a exportparts="foo">
  *       #shadow-root
- *         <x-b exportparts="foo,bar:bar2">
+ *         <x-b exportparts="foo,bar:bar2,bar:bar3">
  *           #shadow-root
  *             <x-c>
  *
@@ -186,6 +186,7 @@ export function formatShadyPartSelector(
  *     ],
  *     bar: [
  *       ["x-a", "x-b", "bar2"],
+ *       ["x-a", "x-b", "bar3"],
  *     ],
  *  }
  *
@@ -219,12 +220,13 @@ export function findExportedPartMappings(host) {
     // attribute.
     if (superHost === undefined) {
       const root = host.getRootNode();
-      if (!root || root === document) {
-        // exportparts doesn't mean anything here; there is nothing beyond the
-        // document scope.
+      if (root === document || root === host) {
+        // When document, there's nothing beyond the document scope where styles
+        // could be exported from. When host, we're not attached to the DOM.
         break;
       }
       superHost = root.host;
+
       if (!superHost) {
         break;
       }

--- a/packages/shadycss/src/shadow-parts.js
+++ b/packages/shadycss/src/shadow-parts.js
@@ -36,14 +36,11 @@ export function splitPartString(str) {
  *     {inner:"bar", outer:"baz"},
  *   ]
  *
- * @param {?string} attr The "exportparts" attribute value.
+ * @param {!string} attr The "exportparts" attribute value.
  * @return {!Array<{inner: !string, outer: !string}>} The inner/outer mapping.
  * Order and duplicates are preserved.
  */
 export function parseExportPartsAttribute(attr) {
-  if (!attr) {
-    return [];
-  }
   const parts = [];
   for (const part of attr.split(/\s*,\s*/)) {
     const split = part.split(/\s*:\s*/);
@@ -166,6 +163,134 @@ export function formatShadyPartSelector(
     .join('');
 }
 
+/**
+ * Build a forwarding map from part names in the given host, to part names in
+ * all ancestor scopes that also provide styles for those parts, by walking up
+ * the DOM following "exportparts" attributes on each host element.
+ *
+ * For example, given the <x-c> node from the following tree:
+ *
+ *   #document
+ *     <x-a exportparts="foo">
+ *       #shadow-root
+ *         <x-b exportparts="foo,bar:bar2">
+ *           #shadow-root
+ *             <x-c>
+ *
+ * Then return:
+ *
+ *   {
+ *     foo: [
+ *       ["x-a", "x-b", "foo"],
+ *       ["document", "x-a", "foo"],
+ *     ],
+ *     bar: [
+ *       ["x-a", "x-b", "bar2"],
+ *     ],
+ *  }
+ *
+ * @param {!HTMLElement} host The element whose shadow parts we are evaluating.
+ * @return {!Object<!string, !Array<string>>} An object that maps from part name
+ * in the given `host` to an array of `[providerScope, receiverScope, partName]`
+ * triplets describing additional style sources for that part.
+ *
+ * TODO(aomarks) Cache each host's exportparts mapping so that we don't need to
+ * walk any hosts twice.
+ */
+export function findExportedPartMappings(host) {
+  // The mapping we will return.
+  const result = {};
+
+  // As we walk up the tree, this object always maintains a mapping from part
+  // names in the previously walked scope, to part names in the base host scope.
+  let forwarding;
+
+  let superHost;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const attr = host.getAttribute('exportparts');
+    if (!attr) {
+      break;
+    }
+
+    // Initialize superHost on the first iteration. Done here, inside the loop,
+    // so that we can return as quickly as possible when there is no exportparts
+    // attribute.
+    if (superHost === undefined) {
+      const root = host.getRootNode();
+      if (!root || root === document) {
+        // exportparts doesn't mean anything here; there is nothing beyond the
+        // document scope.
+        break;
+      }
+      superHost = root.host;
+      if (!superHost) {
+        break;
+      }
+    }
+
+    const receiverScope = superHost.localName;
+    const superRoot = superHost.getRootNode();
+    if (!superRoot) {
+      break;
+    }
+
+    let providerScope;
+    let superSuperHost;
+    if (superRoot === document) {
+      providerScope = 'document';
+    } else {
+      superSuperHost = superRoot.host;
+      if (!superSuperHost) {
+        break;
+      }
+      providerScope = superSuperHost.localName;
+    }
+
+    const parsed = parseExportPartsAttribute(attr);
+    if (parsed.length === 0) {
+      // This could happen if the attribute was set to something non-empty, but
+      // it was entirely invalid.
+      break;
+    }
+
+    const newForwarding = {};
+    for (const {inner, outer} of parsed) {
+      let basePart;
+      if (forwarding === undefined) {
+        // We're in the immediate parent scope (since we haven't initialized the
+        // forwarding map yet), so the name parsed from the "exportparts"
+        // attribute is already the right one.
+        basePart = inner;
+      } else {
+        basePart = forwarding[inner];
+        if (basePart === undefined) {
+          // We don't care about this exported part, because it doesn't
+          // ultimately forward down to a part in our base scope.
+          continue;
+        }
+      }
+      let arr = result[basePart];
+      if (arr === undefined) {
+        arr = result[basePart] = [];
+      }
+      arr.push([providerScope, receiverScope, outer]);
+      newForwarding[outer] = basePart;
+    }
+
+    if (superRoot === document) {
+      break;
+    }
+
+    host = superHost;
+    superHost = superSuperHost;
+    forwarding = newForwarding;
+  }
+
+  return result;
+}
+
 /*  eslint-disable no-unused-vars */
 /**
  * Add "shady-part" attributes to new nodes on insertion.
@@ -212,18 +337,29 @@ export function onInsertBefore(parentNode, newNode, referenceNode) {
   if (parts.length === 0) {
     return;
   }
-  const receiverScope = host.localName;
+  const hostScope = host.localName;
   const superRoot = host.getRootNode();
-  const providerScope =
+  const parentScope =
     superRoot === document ? 'document' : superRoot.host.localName;
-  for (const part of parts) {
-    part.setAttribute(
-      'shady-part',
-      formatShadyPartAttribute(
-        providerScope,
-        receiverScope,
-        part.getAttribute('part')
-      )
-    );
+  const exportMap = findExportedPartMappings(host);
+
+  for (const node of parts) {
+    const shadyParts = [];
+    for (const name of splitPartString(node.getAttribute('part'))) {
+      // Styles from our immediate parent scope.
+      shadyParts.push(formatShadyPartAttribute(parentScope, hostScope, name));
+
+      // Styles from grand-parent and higher ancestor scopes, via the forwarding
+      // map defined by "exportparts" attributes.
+      const exported = exportMap[name];
+      if (exported !== undefined) {
+        for (const [providerScope, receiverScope, exportedName] of exported) {
+          shadyParts.push(
+            formatShadyPartAttribute(providerScope, receiverScope, exportedName)
+          );
+        }
+      }
+    }
+    node.setAttribute('shady-part', shadyParts.join(' '));
   }
 }

--- a/packages/tests/shadycss/shadow-parts/exports.html
+++ b/packages/tests/shadycss/shadow-parts/exports.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<title>shadycss/shadow-parts/exports</title>
+
+<script src="../test-flags.js"></script>
+<script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/template/template.js"></script>
+<script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
+<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+<script src="../../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
+<script src="../../node_modules/@webcomponents/shadycss/custom-style-interface.min.js"></script>
+<script src="../module/generated/make-element.js"></script>
+
+<style id="testDocumentStyle">
+  x-a::part(foo) {
+    color: red;
+  }
+  x-a::part(bar4) {
+    color: green;
+  }
+</style>
+
+<template id="x-a">
+  <x-b exportparts="foo,bar3:bar4"></x-b>
+</template>
+
+<template id="x-b">
+  <style>
+    x-c::part(baz2) {
+      color: blue;
+    }
+  </style>
+  <x-c exportparts="foo,bar2:bar3"></x-c>
+</template>
+
+<template id="x-c">
+  <x-d exportparts="foo,bar:bar2,baz:baz2"></x-d>
+</template>
+
+<template id="x-d">
+  <div part="foo">foo</div>
+  <div part="bar">bar</div>
+  <div part="baz">baz</div>
+</template>
+
+<script type="module">
+  import {pierce, color, red, green, blue} from './test-utils.js';
+
+  suite('exported shadow parts', () => {
+    suiteSetup(() => {
+      makeElement('x-a');
+      makeElement('x-b');
+      makeElement('x-c');
+      makeElement('x-d');
+      const style = document.querySelector('#testDocumentStyle');
+      window.ShadyCSS.CustomStyleInterface.addCustomStyle(style);
+    });
+
+    let xa, foo, bar, baz;
+
+    setup(() => {
+      xa = document.createElement('x-a');
+      document.body.appendChild(xa);
+      const xd = pierce(xa, 'x-b', 'x-c', 'x-d');
+      foo = pierce(xd, '[part=foo]');
+      bar = pierce(xd, '[part=bar]');
+      baz = pierce(xd, '[part=baz]');
+    });
+
+    teardown(() => {
+      document.body.removeChild(xa);
+    });
+
+    test('foo receives style from document', () => {
+      assert.equal(color(foo), red);
+    });
+
+    test('bar receives style from document', () => {
+      assert.equal(color(bar), green);
+    });
+
+    test('baz receives style from grand-parent', () => {
+      assert.equal(color(baz), blue);
+    });
+
+    if (!window.ShadyCSS.nativeShadow) {
+      test('bar gets shady-parts attribute for all scopes', () => {
+        assert.equal(
+          bar.getAttribute('shady-part'),
+          [
+            'x-c:x-d:bar',
+            'x-b:x-c:bar2',
+            'x-a:x-b:bar3',
+            'document:x-a:bar4',
+          ].join(' ')
+        );
+      });
+    }
+  });
+</script>

--- a/packages/tests/shadycss/shadow-parts/exports.html
+++ b/packages/tests/shadycss/shadow-parts/exports.html
@@ -26,13 +26,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   x-a::part(foo) {
     color: red;
   }
+  /** fooalt is the same part as foo, but exported under a different name */
+  x-a::part(fooalt) {
+    background-color: blue;
+  }
   x-a::part(bar4) {
     color: green;
   }
 </style>
 
 <template id="x-a">
-  <x-b exportparts="foo,bar3:bar4"></x-b>
+  <x-b exportparts="foo,foo:fooalt,bar3:bar4"></x-b>
 </template>
 
 <template id="x-b">
@@ -49,13 +53,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </template>
 
 <template id="x-d">
-  <div part="foo">foo</div>
+  <div part="foo">foo1</div>
+  <div part="foo">foo2</div>
   <div part="bar">bar</div>
   <div part="baz">baz</div>
 </template>
 
 <script type="module">
-  import {pierce, color, red, green, blue} from './test-utils.js';
+  import {pierce, style, color, red, green, blue} from './test-utils.js';
 
   suite('exported shadow parts', () => {
     suiteSetup(() => {
@@ -67,13 +72,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       window.ShadyCSS.CustomStyleInterface.addCustomStyle(style);
     });
 
-    let xa, foo, bar, baz;
+    let xa, foo1, foo2, bar, baz;
 
     setup(() => {
       xa = document.createElement('x-a');
       document.body.appendChild(xa);
       const xd = pierce(xa, 'x-b', 'x-c', 'x-d');
-      foo = pierce(xd, '[part=foo]');
+      [foo1, foo2] = xd.shadowRoot.querySelectorAll('[part=foo]');
       bar = pierce(xd, '[part=bar]');
       baz = pierce(xd, '[part=baz]');
     });
@@ -82,8 +87,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       document.body.removeChild(xa);
     });
 
-    test('foo receives style from document', () => {
-      assert.equal(color(foo), red);
+    test('foo parts receive style from document via name foo', () => {
+      assert.equal(color(foo1), red);
+      assert.equal(color(foo2), red);
+    });
+
+    test('foo parts receive style from document via name fooalt', () => {
+      assert.equal(style(foo1).backgroundColor, blue);
+      assert.equal(style(foo2).backgroundColor, blue);
     });
 
     test('bar receives style from document', () => {

--- a/packages/tests/shadycss/shadow-parts/find-exported-part-mappings.html
+++ b/packages/tests/shadycss/shadow-parts/find-exported-part-mappings.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<title>shadycss/shadow-parts/find-export-parts</title>
+
+<script src="../test-flags.js"></script>
+<script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/template/template.js"></script>
+<script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
+<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+<script src="../../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
+<script src="../module/generated/make-element.js"></script>
+
+<template id="x-a">
+  <x-b exportparts="foo,bar3:bar4"></x-b>
+</template>
+
+<template id="x-b">
+  <x-c exportparts="foo,bar2:bar3"></x-c>
+</template>
+
+<template id="x-c">
+  <x-d exportparts="foo,bar:bar2,foo:foo2"></x-d>
+</template>
+
+<template id="x-d"></template>
+
+<script type="module">
+  import {pierce} from './test-utils.js';
+  import {findExportedPartMappings} from '../../node_modules/@webcomponents/shadycss/src/shadow-parts.js';
+
+  /**
+   * assert.deepEqual just prints `{ Object (... ) }` instead of something
+   * readable. JSON lets us see what's wrong on failure.
+   */
+  const assertJsonEqual = (actual, expected) =>
+    assert.equal(JSON.stringify(actual), JSON.stringify(expected));
+
+  suite('findExportedPartMappings', () => {
+    suiteSetup(() => {
+      makeElement('x-a');
+      makeElement('x-b');
+      makeElement('x-c');
+      makeElement('x-d');
+    });
+
+    let xa, xb, xc, xd;
+
+    setup(() => {
+      xa = document.createElement('x-a');
+      document.body.appendChild(xa);
+      xb = pierce('x-a', 'x-b');
+      xc = pierce('x-a', 'x-b', 'x-c');
+      xd = pierce('x-a', 'x-b', 'x-c', 'x-d');
+    });
+
+    teardown(() => {
+      document.body.removeChild(xa);
+    });
+
+    test('finds export parts of x-a', () => {
+      const expected = {};
+      const actual = findExportedPartMappings(xa);
+      assertJsonEqual(actual, expected);
+    });
+
+    test('finds export parts of x-b', () => {
+      const expected = {
+        foo: [['document', 'x-a', 'foo']],
+        bar3: [['document', 'x-a', 'bar4']],
+      };
+      const actual = findExportedPartMappings(xb);
+      assertJsonEqual(actual, expected);
+    });
+
+    test('finds export parts of x-c', () => {
+      const expected = {
+        foo: [
+          ['x-a', 'x-b', 'foo'],
+          ['document', 'x-a', 'foo'],
+        ],
+        bar2: [
+          ['x-a', 'x-b', 'bar3'],
+          ['document', 'x-a', 'bar4'],
+        ],
+      };
+      const actual = findExportedPartMappings(xc);
+      assertJsonEqual(actual, expected);
+    });
+
+    test('finds export parts of x-d', () => {
+      const expected = {
+        foo: [
+          ['x-b', 'x-c', 'foo'],
+          ['x-b', 'x-c', 'foo2'],
+          ['x-a', 'x-b', 'foo'],
+          ['document', 'x-a', 'foo'],
+        ],
+        bar: [
+          ['x-b', 'x-c', 'bar2'],
+          ['x-a', 'x-b', 'bar3'],
+          ['document', 'x-a', 'bar4'],
+        ],
+      };
+      const actual = findExportedPartMappings(xd);
+      assertJsonEqual(actual, expected);
+    });
+  });
+</script>

--- a/packages/tests/shadycss/shadow-parts/suites.js
+++ b/packages/tests/shadycss/shadow-parts/suites.js
@@ -16,6 +16,8 @@ export const suites = [
   'basic.html',
   'disable.html',
   'document.html',
+  'exports.html',
+  'find-exported-part-mappings.html',
   'insertions.html',
   'parsing-formatting.html',
 ];


### PR DESCRIPTION
Adds support for walking up the tree of shadow hosts following `exportparts` attributes to find additional shady-part attributes to add to each part so that they can receive styles from ancestor scopes that they have been forwarded to.

Does not yet include a caching optimization I think we should include here, will do in a follow up (maybe with a benchmark?).

Part of #311 and #252. Fixes https://github.com/webcomponents/polyfills/issues/336.