### PR TITLE
Manually dispatch events for connected, unassigned targets.

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Manually dispatch events for connected, unassigned targets.
+- Manually dispatch events for connected, unassigned targets, if
+  `preferPerformance` is not enabled.
   ([#332](https://github.com/webcomponents/polyfills/pull/332))
 - Remove outdated references to `customElements.nativeHTMLElement`
   ([#234](https://github.com/webcomponents/polyfills/pull/234))

--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Manually dispatch events for connected, unassigned targets.
+  ([#332](https://github.com/webcomponents/polyfills/pull/332))
 - Remove outdated references to `customElements.nativeHTMLElement`
   ([#234](https://github.com/webcomponents/polyfills/pull/234))
 - Add README warning about polyfill ordering when using `noPatch`

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -396,6 +396,9 @@ function targetNeedsPathCheck(node) {
 /** @this {Node} */
 export function dispatchEvent(event) {
   flush();
+  // If the target is disconnected from the real document, it might still be
+  // connected in the user-facing tree. To allow its path to potentially
+  // include both connected and disconnected parts, dispatch it manually.
   if (this instanceof Node && !utils.documentContains(document, this)) {
     if (!event['__target']) {
       patchEvent(event, this);

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -396,7 +396,7 @@ function targetNeedsPathCheck(node) {
 /** @this {Node} */
 export function dispatchEvent(event) {
   flush();
-  if (this instanceof Node && !(this === document || document.documentElement[utils.NATIVE_PREFIX + 'contains'](this))) {
+  if (this instanceof Node && !utils.documentContains(document, this)) {
     if (!event['__target']) {
       patchEvent(event, this);
     }

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -584,8 +584,8 @@ const EventPatchesDescriptors = utils.getOwnPropertyDescriptors(EventPatches);
 const SHADY_PROTO = '__shady_patchedProto';
 const SHADY_SOURCE_PROTO = '__shady_sourceProto';
 
-function patchEvent(event, forcedTarget = undefined) {
-  event['__target'] = forcedTarget !== undefined ? forcedTarget : event.target;
+function patchEvent(event, target = event.target) {
+  event['__target'] = target;
   event.__relatedTarget = event.relatedTarget;
   // attempt to patch prototype (via cache)
   if (utils.settings.hasDescriptors) {

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -348,7 +348,7 @@ function shadyDispatchEvent(e) {
     }
   }
 
-  eventPhase = Event.NONE;
+  eventPhase = 0; // `Event.NONE` is not available in IE11.
   currentTarget = null;
 }
 

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -402,7 +402,8 @@ export function dispatchEvent(event) {
   // If the target is disconnected from the real document, it might still be
   // connected in the user-facing tree. To allow its path to potentially
   // include both connected and disconnected parts, dispatch it manually.
-  if (this instanceof Node && !utils.documentContains(document, this)) {
+  if (!utils.settings.preferPerformance && this instanceof Node &&
+      !utils.documentContains(document, this)) {
     if (!event['__target']) {
       patchEvent(event, this);
     }

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -324,8 +324,8 @@ function shadyDispatchEvent(e) {
     }
   }
 
-  // set the event phase to `AT_TARGET` as in spec
-  Object.defineProperty(e, 'eventPhase', {get() { return Event.AT_TARGET }});
+  let eventPhase = Event.AT_TARGET;
+  Object.defineProperty(e, 'eventPhase', {get() { return eventPhase; }});
 
   const bubbles = e.bubbles;
   // the event only needs to be fired when owner roots change when iterating the event path
@@ -337,8 +337,9 @@ function shadyDispatchEvent(e) {
     const root = nodeData && nodeData.root;
     // Listeners on the deepest node in the path and the deepest node in each
     // root of all nodes in the path should be called in the AT_TARGET phase.
-    const isRetargetedTarget = i === 0 || (root && root === lastFiredRoot);
-    if (bubbles || isRetargetedTarget) {
+    const atDeepestNodeInRoot = i === 0 || (root && root === lastFiredRoot);
+    if (bubbles || atDeepestNodeInRoot) {
+      eventPhase = atDeepestNodeInRoot ? Event.AT_TARGET : Event.BUBBLING_PHASE;
       fireHandlers(e, node, 'bubble');
       // don't bother with window, it doesn't have `getRootNode` and will be last in the path anyway
       if (node !== window) {

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -561,8 +561,7 @@ export function removeEventListener(type, fnOrObj, optionsOrCapture) {
   }
   this[utils.NATIVE_PREFIX + 'removeEventListener'](type, wrapperFn || fnOrObj,
     nativeEventOptions);
-  if (wrapperFn && nonBubblingEventsToRetarget[type] &&
-      this.__handlers && this.__handlers[type]) {
+  if (wrapperFn && this.__handlers && this.__handlers[type]) {
     const arr = this.__handlers[type][capture ? 'capture' : 'bubble'];
     const idx = arr.indexOf(wrapperFn);
     if (idx > -1) {

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -394,7 +394,7 @@ function targetNeedsPathCheck(node) {
 /** @this {Node} */
 export function dispatchEvent(event) {
   flush();
-  if (this instanceof Node && !document.documentElement[utils.NATIVE_PREFIX + 'contains'](this)) {
+  if (this instanceof Node && !(this === document || document.documentElement[utils.NATIVE_PREFIX + 'contains'](this))) {
     if (!event['__target']) {
       patchEvent(event, this);
     }

--- a/packages/shadydom/src/patches/Node.js
+++ b/packages/shadydom/src/patches/Node.js
@@ -177,12 +177,7 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     }
     // Fast path for distributed nodes.
     const ownerDocument = this.ownerDocument;
-    if (utils.hasDocumentContains) {
-      if (ownerDocument[utils.NATIVE_PREFIX + 'contains'](this)) {
-        return true;
-      }
-    } else if (ownerDocument.documentElement &&
-      ownerDocument.documentElement[utils.NATIVE_PREFIX + 'contains'](this)) {
+    if (ownerDocument === null || utils.documentContains(ownerDocument, this)) {
       return true;
     }
     // Slow path for non-distributed nodes.

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -86,9 +86,10 @@ if (utils.settings.inUse) {
     // `insertBefore` (when the node is being moved from a location where it
     // was logically positioned in the DOM); when setting `className`/`class`;
     // when calling `querySelector|All`; when setting `textContent` or
-    // `innerHTML`; `addEventListener`; and all scope specific API's like
-    // `getRootNode`, `isConnected`, `slot`, `assignedSlot`, `assignedNodes`.
-    // Note, `wrapIfNeeded` falls back to a pass through to preserve optimal
+    // `innerHTML`; `addEventListener`, `removeEventListener` and
+    // `dispatchEvent`; and all scope specific API's like `getRootNode`,
+    // `isConnected`, `slot`, `assignedSlot`, `assignedNodes`. Note,
+    // `wrapIfNeeded` falls back to a pass through to preserve optimal
     // performance.
     'wrapIfNeeded': utils.settings.noPatch === true ? wrap : n => n,
     'Wrapper': Wrapper,

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -92,14 +92,17 @@ export const microtask = (callback) => {
   twiddle.textContent = content++;
 }
 
-const hasDocumentContains = Boolean(document.contains);
-
 /** @type {function(!Document, !Node): boolean} */
-export const documentContains = (doc, node) => (
-  doc === node ||
-  (hasDocumentContains && doc[NATIVE_PREFIX + 'contains'](node)) ||
-  (doc.documentElement && doc.documentElement[NATIVE_PREFIX + 'contains'](node))
-);
+export const documentContains = (() => {
+  if (document.contains) {
+    return (doc, node) => doc[NATIVE_PREFIX + 'contains'](node);
+  } else {
+    return (doc, node) => (
+      doc === node ||
+      (doc.documentElement && doc.documentElement[NATIVE_PREFIX + 'contains'](node))
+    );
+  }
+})();
 
 export const contains = (container, node) => {
   while (node) {

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -92,7 +92,14 @@ export const microtask = (callback) => {
   twiddle.textContent = content++;
 }
 
-export const hasDocumentContains = Boolean(document.contains);
+const hasDocumentContains = Boolean(document.contains);
+
+/** @type {function(!Document, !Node): boolean} */
+export const documentContains = (doc, node) => (
+  doc === node ||
+  (hasDocumentContains && doc[NATIVE_PREFIX + 'contains'](node)) ||
+  (doc.documentElement && doc.documentElement[NATIVE_PREFIX + 'contains'](node))
+);
 
 export const contains = (container, node) => {
   while (node) {

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -1172,6 +1172,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         ShadyDOM.wrap(document.body).removeChild(container);
       });
+
+      test('removed bubbling event listeners are no longer called during manual dispatch', () => {
+        const {fixtureRoot, outerDiv, innerNoSlot, target} = getDispatchTestElement();
+        ShadyDOM.wrap(document.body).appendChild(fixtureRoot);
+        assert.strictEqual(ShadyDOM.wrap(target).assignedSlot, null);
+
+        let listenerCallCount = 0;
+        const listener = () => listenerCallCount++;
+
+        ShadyDOM.wrap(target).addEventListener('some-event', listener);
+        ShadyDOM.wrap(target).dispatchEvent(new Event('some-event'));
+        // Confirm that the listener was added.
+        assert.strictEqual(listenerCallCount, 1);
+
+        ShadyDOM.wrap(target).removeEventListener('some-event', listener);
+        ShadyDOM.wrap(target).dispatchEvent(new Event('some-event'));
+        // The event listener call count should not have changed.
+        assert.strictEqual(listenerCallCount, 1);
+
+        ShadyDOM.wrap(document.body).removeChild(fixtureRoot);
+      });
     });
   });
   </script>

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -939,11 +939,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('events dispatched to unassigned slottables bubble through the tree above them', () => {
-      const noSlot = ShadyDOM.wrapIfNeeded(document.createElement('x-no-slot'));
-      const unassignedSlottable = ShadyDOM.wrapIfNeeded(document.createElement('div'));
+      const noSlot = document.createElement('x-no-slot');
+      const unassignedSlottable = document.createElement('div');
 
       ShadyDOM.wrapIfNeeded(document.body).appendChild(noSlot);
-      noSlot.appendChild(unassignedSlottable);
+      ShadyDOM.wrapIfNeeded(noSlot).appendChild(unassignedSlottable);
       assert.equal(ShadyDOM.wrapIfNeeded(unassignedSlottable).assignedSlot, undefined);
 
       let listenerTriggered = false;

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -968,11 +968,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       const getDispatchTestElement = () => {
         const fixtureRoot = document.createElement('x-dispatch-test');
+
+        // Force the element to upgrade and create its shadow root.
         ShadyDOM.wrap(document.body).appendChild(fixtureRoot);
         ShadyDOM.wrap(document.body).removeChild(fixtureRoot);
 
         const getShadowElementById = (id) => {
-          return ShadyDOM.wrap(fixtureRoot.shadowRoot).getElementById(id);
+          return ShadyDOM.wrap(ShadyDOM.wrap(fixtureRoot).shadowRoot).getElementById(id);
         };
 
         return {

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -955,7 +955,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         ShadyDOM.wrapIfNeeded(document.body).removeChild(noSlot);
       });
 
-      test('events have the correct phase', () => {
+      test('events have the correct phase during dispatch', () => {
         const sd = node => ShadyDOM.wrapIfNeeded(node);
         /*
           <x-no-slot> <!-- outerNoSlot -->
@@ -986,16 +986,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           eventLog.push({currentTarget: e.currentTarget, eventPhase: e.eventPhase});
         };
 
-        sd(outerNoSlot).addEventListener('some-event', pushToEventLog);
         // `sd(outerNoSlot).shadowRoot` will also see this event in its path,
         // but event listeners on shadow roots are instead redirected by Shady
         // DOM to their host, causing the phase to incorrect (AT_TARGET).
+        sd(outerNoSlot).addEventListener('some-event', pushToEventLog);
+        sd(outerNoSlot).addEventListener('some-event', pushToEventLog, true);
         sd(outerDiv).addEventListener('some-event', pushToEventLog);
+        sd(outerDiv).addEventListener('some-event', pushToEventLog, true);
         sd(innerNoSlot).addEventListener('some-event', pushToEventLog);
+        sd(innerNoSlot).addEventListener('some-event', pushToEventLog, true);
         sd(target).addEventListener('some-event', pushToEventLog);
+        sd(target).addEventListener('some-event', pushToEventLog,true);
 
         sd(target).dispatchEvent(new Event('some-event', {bubbles: true, composed: true}));
         assert.deepEqual(eventLog, [
+          {currentTarget: outerNoSlot, eventPhase: Event.AT_TARGET},
+          {currentTarget: outerDiv, eventPhase: Event.CAPTURING_PHASE},
+          {currentTarget: innerNoSlot, eventPhase: Event.CAPTURING_PHASE},
+          {currentTarget: target, eventPhase: Event.AT_TARGET},
           {currentTarget: target, eventPhase: Event.AT_TARGET},
           {currentTarget: innerNoSlot, eventPhase: Event.BUBBLING_PHASE},
           {currentTarget: outerDiv, eventPhase: Event.BUBBLING_PHASE},

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -940,26 +940,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     suite('unassigned slottable targets', () => {
       test('events bubble through the tree above them', () => {
-        const wrap = node => ShadyDOM.wrapIfNeeded(node);
-
         const noSlot = document.createElement('x-no-slot');
         const unassignedSlottable = document.createElement('div');
 
-        wrap(document.body).appendChild(noSlot);
-        wrap(noSlot).appendChild(unassignedSlottable);
-        assert.strictEqual(wrap(unassignedSlottable).assignedSlot, null);
+        ShadyDOM.wrapIfNeeded(document.body).appendChild(noSlot);
+        ShadyDOM.wrapIfNeeded(noSlot).appendChild(unassignedSlottable);
+        assert.strictEqual(ShadyDOM.wrapIfNeeded(unassignedSlottable).assignedSlot, null);
 
         let listenerTriggered = false;
-        wrap(noSlot).addEventListener('some-event', () => listenerTriggered = true);
-        wrap(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
+        ShadyDOM.wrapIfNeeded(noSlot).addEventListener('some-event', () => listenerTriggered = true);
+        ShadyDOM.wrapIfNeeded(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
         assert.ok(listenerTriggered);
 
-        wrap(document.body).removeChild(noSlot);
+        ShadyDOM.wrapIfNeeded(document.body).removeChild(noSlot);
       });
 
       test('events have the correct phase during dispatch', () => {
-        const wrap = node => ShadyDOM.wrapIfNeeded(node);
-
         /*
           <x-no-slot> <!-- outerNoSlot -->
             #shadow-root
@@ -974,34 +970,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </x-no-slot>
         */
         const outerNoSlot = document.createElement('x-no-slot');
-        wrap(document.body).appendChild(outerNoSlot);
+        ShadyDOM.wrapIfNeeded(document.body).appendChild(outerNoSlot);
         const outerDiv = document.createElement('div');
-        wrap(outerNoSlot).shadowRoot.appendChild(outerDiv);
+        ShadyDOM.wrapIfNeeded(outerNoSlot).shadowRoot.appendChild(outerDiv);
         const innerNoSlot = document.createElement('x-no-slot');
-        wrap(outerDiv).appendChild(innerNoSlot);
+        ShadyDOM.wrapIfNeeded(outerDiv).appendChild(innerNoSlot);
         const target = document.createElement('div');
-        wrap(innerNoSlot).appendChild(target);
+        ShadyDOM.wrapIfNeeded(innerNoSlot).appendChild(target);
 
-        assert.strictEqual(wrap(target).assignedSlot, null);
+        assert.strictEqual(ShadyDOM.wrapIfNeeded(target).assignedSlot, null);
 
         const eventLog = [];
         const pushToEventLog = (e) => {
           eventLog.push({currentTarget: e.currentTarget, eventPhase: e.eventPhase});
         };
 
-        // `wrap(outerNoSlot).shadowRoot` will also see this event in its path,
+        // `ShadyDOM.wrapIfNeeded(outerNoSlot).shadowRoot` will also see this event in its path,
         // but event listeners on shadow roots are instead redirected by Shady
         // DOM to their host, causing the phase to incorrect (AT_TARGET).
-        wrap(outerNoSlot).addEventListener('some-event', pushToEventLog);
-        wrap(outerNoSlot).addEventListener('some-event', pushToEventLog, true);
-        wrap(outerDiv).addEventListener('some-event', pushToEventLog);
-        wrap(outerDiv).addEventListener('some-event', pushToEventLog, true);
-        wrap(innerNoSlot).addEventListener('some-event', pushToEventLog);
-        wrap(innerNoSlot).addEventListener('some-event', pushToEventLog, true);
-        wrap(target).addEventListener('some-event', pushToEventLog);
-        wrap(target).addEventListener('some-event', pushToEventLog,true);
+        ShadyDOM.wrapIfNeeded(outerNoSlot).addEventListener('some-event', pushToEventLog);
+        ShadyDOM.wrapIfNeeded(outerNoSlot).addEventListener('some-event', pushToEventLog, true);
+        ShadyDOM.wrapIfNeeded(outerDiv).addEventListener('some-event', pushToEventLog);
+        ShadyDOM.wrapIfNeeded(outerDiv).addEventListener('some-event', pushToEventLog, true);
+        ShadyDOM.wrapIfNeeded(innerNoSlot).addEventListener('some-event', pushToEventLog);
+        ShadyDOM.wrapIfNeeded(innerNoSlot).addEventListener('some-event', pushToEventLog, true);
+        ShadyDOM.wrapIfNeeded(target).addEventListener('some-event', pushToEventLog);
+        ShadyDOM.wrapIfNeeded(target).addEventListener('some-event', pushToEventLog,true);
 
-        wrap(target).dispatchEvent(new Event('some-event', {bubbles: true, composed: true}));
+        ShadyDOM.wrapIfNeeded(target).dispatchEvent(new Event('some-event', {bubbles: true, composed: true}));
         assert.deepEqual(eventLog, [
           {currentTarget: outerNoSlot, eventPhase: Event.AT_TARGET},
           {currentTarget: outerDiv, eventPhase: Event.CAPTURING_PHASE},
@@ -1013,14 +1009,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           {currentTarget: outerNoSlot, eventPhase: Event.AT_TARGET},
         ]);
 
-        wrap(document.body).removeChild(outerNoSlot);
+        ShadyDOM.wrapIfNeeded(document.body).removeChild(outerNoSlot);
       });
 
       test('events dispatched from children that are disconnected in the ' +
           'real tree but connected in the user-facing tree bubble up to ' +
           'parents that are connected in the real tree', () => {
-        const wrap = node => ShadyDOM.wrapIfNeeded(node);
-
         customElements.define('parent-listener-element', class extends HTMLElement {
           constructor() {
             super();
@@ -1028,11 +1022,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             // This elements' shadow root is empty, so all of its (non-shadow)
             // children will be removed from the real tree even though they are
             // considered connected in the user-facing tree.
-            wrap(this).attachShadow({mode: 'open'});
+            ShadyDOM.wrapIfNeeded(this).attachShadow({mode: 'open'});
             ShadyDOM.flush();
 
             this.listenerCallCount = 0;
-            wrap(this).addEventListener('some-event', () => {
+            ShadyDOM.wrapIfNeeded(this).addEventListener('some-event', () => {
               this.listenerCallCount++;
             });
           }
@@ -1041,23 +1035,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         customElements.define('child-dispatcher-element', class extends HTMLElement {
           constructor() {
             super();
-            this.dispatchEvent(new Event('some-event', {bubbles: true}));
+            ShadyDOM.wrapIfNeeded(this).dispatchEvent(new Event('some-event', {bubbles: true}));
           }
         });
 
         const container = document.createElement('div');
-        document.body.appendChild(container);
+        ShadyDOM.wrapIfNeeded(document.body).appendChild(container);
 
-        container.innerHTML = `
+        ShadyDOM.wrapIfNeeded(container).innerHTML = `
           <parent-listener-element>
             <child-dispatcher-element></child-dispatcher-element>
           </parent-listener-element>
         `;
 
-        const eventListenerElement = container.querySelector('parent-listener-element');
+        const eventListenerElement = ShadyDOM.wrapIfNeeded(container).querySelector('parent-listener-element');
         assert.strictEqual(eventListenerElement.listenerCallCount, 1);
 
-        document.body.removeChild(container);
+        ShadyDOM.wrapIfNeeded(document.body).removeChild(container);
       });
     });
   });

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -939,7 +939,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('unassigned slottable targets', () => {
-      test('events bubble through the tree above them', () => {
+      test('bubbling events bubble through the tree above them', () => {
         const noSlot = document.createElement('x-no-slot');
         const unassignedSlottable = document.createElement('div');
 
@@ -951,6 +951,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         ShadyDOM.wrap(noSlot).addEventListener('some-event', () => listenerTriggered = true);
         ShadyDOM.wrap(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
         assert.ok(listenerTriggered);
+
+        ShadyDOM.wrap(document.body).removeChild(noSlot);
+      });
+
+      test('non-bubbling events do not bubble through the tree above them', () => {
+        const noSlot = document.createElement('x-no-slot');
+        const unassignedSlottable = document.createElement('div');
+        const target = document.createElement('div');
+
+        ShadyDOM.wrap(document.body).appendChild(noSlot);
+        ShadyDOM.wrap(noSlot).appendChild(unassignedSlottable);
+        ShadyDOM.wrap(unassignedSlottable).appendChild(target);
+        assert.strictEqual(ShadyDOM.wrap(unassignedSlottable).assignedSlot, null);
+
+        let listenerTriggered = false;
+        ShadyDOM.wrap(noSlot).addEventListener('some-event', () => listenerTriggered = true);
+        ShadyDOM.wrap(unassignedSlottable).addEventListener('some-event', () => listenerTriggered = true);
+        ShadyDOM.wrap(target).dispatchEvent(new Event('some-event', {bubbles: false}));
+        assert.ok(!listenerTriggered);
 
         ShadyDOM.wrap(document.body).removeChild(noSlot);
       });

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -938,20 +938,72 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.isTrue(heardEvent);
     });
 
-    test('events dispatched to unassigned slottables bubble through the tree above them', () => {
-      const noSlot = document.createElement('x-no-slot');
-      const unassignedSlottable = document.createElement('div');
+    suite('unassigned slottable targets', () => {
+      test('events bubble through the tree above them', () => {
+        const noSlot = document.createElement('x-no-slot');
+        const unassignedSlottable = document.createElement('div');
 
-      ShadyDOM.wrapIfNeeded(document.body).appendChild(noSlot);
-      ShadyDOM.wrapIfNeeded(noSlot).appendChild(unassignedSlottable);
-      assert.equal(ShadyDOM.wrapIfNeeded(unassignedSlottable).assignedSlot, undefined);
+        ShadyDOM.wrapIfNeeded(document.body).appendChild(noSlot);
+        ShadyDOM.wrapIfNeeded(noSlot).appendChild(unassignedSlottable);
+        assert.strictEqual(ShadyDOM.wrapIfNeeded(unassignedSlottable).assignedSlot, null);
 
-      let listenerTriggered = false;
-      ShadyDOM.wrapIfNeeded(noSlot).addEventListener('some-event', () => listenerTriggered = true);
-      ShadyDOM.wrapIfNeeded(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
-      assert.ok(listenerTriggered);
+        let listenerTriggered = false;
+        ShadyDOM.wrapIfNeeded(noSlot).addEventListener('some-event', () => listenerTriggered = true);
+        ShadyDOM.wrapIfNeeded(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
+        assert.ok(listenerTriggered);
 
-      ShadyDOM.wrapIfNeeded(document.body).removeChild(noSlot);
+        ShadyDOM.wrapIfNeeded(document.body).removeChild(noSlot);
+      });
+
+      test('events have the correct phase', () => {
+        const sd = node => ShadyDOM.wrapIfNeeded(node);
+        /*
+          <x-no-slot> <!-- outerNoSlot -->
+            #shadow-root
+              <div> <!-- outerDiv -->
+                <x-no-slot> <!-- innerNoSlot -->
+                  #shadow-root
+                  #/shadow-root
+                  <div></div> <!-- target -->
+                </x-no-slot>
+              </div>
+            #/shadow-root
+          </x-no-slot>
+        */
+        const outerNoSlot = document.createElement('x-no-slot');
+        sd(document.body).appendChild(outerNoSlot);
+        const outerDiv = document.createElement('div');
+        sd(outerNoSlot).shadowRoot.appendChild(outerDiv);
+        const innerNoSlot = document.createElement('x-no-slot');
+        sd(outerDiv).appendChild(innerNoSlot);
+        const target = document.createElement('div');
+        sd(innerNoSlot).appendChild(target);
+
+        assert.strictEqual(sd(target).assignedSlot, null);
+
+        const eventLog = [];
+        const pushToEventLog = (e) => {
+          eventLog.push({currentTarget: e.currentTarget, eventPhase: e.eventPhase});
+        };
+
+        sd(outerNoSlot).addEventListener('some-event', pushToEventLog);
+        // `sd(outerNoSlot).shadowRoot` will also see this event in its path,
+        // but event listeners on shadow roots are instead redirected by Shady
+        // DOM to their host, causing the phase to incorrect (AT_TARGET).
+        sd(outerDiv).addEventListener('some-event', pushToEventLog);
+        sd(innerNoSlot).addEventListener('some-event', pushToEventLog);
+        sd(target).addEventListener('some-event', pushToEventLog);
+
+        sd(target).dispatchEvent(new Event('some-event', {bubbles: true, composed: true}));
+        assert.deepEqual(eventLog, [
+          {currentTarget: target, eventPhase: Event.AT_TARGET},
+          {currentTarget: innerNoSlot, eventPhase: Event.BUBBLING_PHASE},
+          {currentTarget: outerDiv, eventPhase: Event.BUBBLING_PHASE},
+          {currentTarget: outerNoSlot, eventPhase: Event.AT_TARGET},
+        ]);
+
+        sd(document.body).removeChild(outerNoSlot);
+      });
     });
   });
   </script>

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -985,9 +985,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           eventLog.push({currentTarget: e.currentTarget, eventPhase: e.eventPhase});
         };
 
-        // `ShadyDOM.wrapIfNeeded(outerNoSlot).shadowRoot` will also see this event in its path,
-        // but event listeners on shadow roots are instead redirected by Shady
-        // DOM to their host, causing the phase to incorrect (AT_TARGET).
+        // `ShadyDOM.wrapIfNeeded(outerNoSlot).shadowRoot` will also see this
+        // event in its path, but event listeners on shadow roots are instead
+        // redirected by Shady DOM to their host, causing the phase to be
+        // incorrect (AT_TARGET).
         ShadyDOM.wrap(outerNoSlot).addEventListener('some-event', pushToEventLog);
         ShadyDOM.wrap(outerNoSlot).addEventListener('some-event', pushToEventLog, true);
         ShadyDOM.wrap(outerDiv).addEventListener('some-event', pushToEventLog);

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -1105,12 +1105,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           eventLog.push({currentTarget: e.currentTarget, eventPhase: e.eventPhase});
         };
 
-        // `ShadyDOM.wrapIfNeeded(fixtureRoot).shadowRoot` will also see this
-        // event in its path, but event listeners on shadow roots are instead
-        // redirected by Shady DOM to their host, causing the phase to be
-        // incorrect (AT_TARGET).
         ShadyDOM.wrap(fixtureRoot).addEventListener('some-event', pushToEventLog);
         ShadyDOM.wrap(fixtureRoot).addEventListener('some-event', pushToEventLog, true);
+        ShadyDOM.wrap(ShadyDOM.wrap(fixtureRoot).shadowRoot).addEventListener('some-event', pushToEventLog);
+        ShadyDOM.wrap(ShadyDOM.wrap(fixtureRoot).shadowRoot).addEventListener('some-event', pushToEventLog, true);
         ShadyDOM.wrap(outerDiv).addEventListener('some-event', pushToEventLog);
         ShadyDOM.wrap(outerDiv).addEventListener('some-event', pushToEventLog, true);
         ShadyDOM.wrap(innerNoSlot).addEventListener('some-event', pushToEventLog);
@@ -1121,6 +1119,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         ShadyDOM.wrap(target).dispatchEvent(new Event('some-event', {bubbles: true, composed: true}));
         assert.deepEqual(eventLog, [
           {currentTarget: fixtureRoot, eventPhase: Event.AT_TARGET},
+          {currentTarget: ShadyDOM.wrap(fixtureRoot).shadowRoot, eventPhase: Event.CAPTURING_PHASE},
           {currentTarget: outerDiv, eventPhase: Event.CAPTURING_PHASE},
           {currentTarget: innerNoSlot, eventPhase: Event.CAPTURING_PHASE},
           {currentTarget: target, eventPhase: Event.AT_TARGET},
@@ -1128,6 +1127,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           {currentTarget: innerNoSlot, eventPhase: Event.BUBBLING_PHASE},
           {currentTarget: outerDiv, eventPhase: Event.BUBBLING_PHASE},
           {currentTarget: fixtureRoot, eventPhase: Event.AT_TARGET},
+          // The bubbling event listener on this shadow root is incorrectly run
+          // after the listener on its host because event listeners on shadow
+          // roots are redirected by Shady DOM to listen for the event on their
+          // host. This causes the listeners for a shadow root and its host to
+          // share, and be iterated as, a single list in both native and manual
+          // dispatch.
+          {currentTarget: ShadyDOM.wrap(fixtureRoot).shadowRoot, eventPhase: Event.BUBBLING_PHASE},
         ]);
 
         ShadyDOM.wrap(document.body).removeChild(fixtureRoot);

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -950,6 +950,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrapIfNeeded(noSlot).addEventListener('some-event', () => listenerTriggered = true);
       ShadyDOM.wrapIfNeeded(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
       assert.ok(listenerTriggered);
+
+      ShadyDOM.wrapIfNeeded(document.body).removeChild(noSlot);
     });
   });
   </script>

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -940,23 +940,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     suite('unassigned slottable targets', () => {
       test('events bubble through the tree above them', () => {
+        const wrap = node => ShadyDOM.wrapIfNeeded(node);
+
         const noSlot = document.createElement('x-no-slot');
         const unassignedSlottable = document.createElement('div');
 
-        ShadyDOM.wrapIfNeeded(document.body).appendChild(noSlot);
-        ShadyDOM.wrapIfNeeded(noSlot).appendChild(unassignedSlottable);
-        assert.strictEqual(ShadyDOM.wrapIfNeeded(unassignedSlottable).assignedSlot, null);
+        wrap(document.body).appendChild(noSlot);
+        wrap(noSlot).appendChild(unassignedSlottable);
+        assert.strictEqual(wrap(unassignedSlottable).assignedSlot, null);
 
         let listenerTriggered = false;
-        ShadyDOM.wrapIfNeeded(noSlot).addEventListener('some-event', () => listenerTriggered = true);
-        ShadyDOM.wrapIfNeeded(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
+        wrap(noSlot).addEventListener('some-event', () => listenerTriggered = true);
+        wrap(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
         assert.ok(listenerTriggered);
 
-        ShadyDOM.wrapIfNeeded(document.body).removeChild(noSlot);
+        wrap(document.body).removeChild(noSlot);
       });
 
       test('events have the correct phase during dispatch', () => {
-        const sd = node => ShadyDOM.wrapIfNeeded(node);
+        const wrap = node => ShadyDOM.wrapIfNeeded(node);
+
         /*
           <x-no-slot> <!-- outerNoSlot -->
             #shadow-root
@@ -971,34 +974,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </x-no-slot>
         */
         const outerNoSlot = document.createElement('x-no-slot');
-        sd(document.body).appendChild(outerNoSlot);
+        wrap(document.body).appendChild(outerNoSlot);
         const outerDiv = document.createElement('div');
-        sd(outerNoSlot).shadowRoot.appendChild(outerDiv);
+        wrap(outerNoSlot).shadowRoot.appendChild(outerDiv);
         const innerNoSlot = document.createElement('x-no-slot');
-        sd(outerDiv).appendChild(innerNoSlot);
+        wrap(outerDiv).appendChild(innerNoSlot);
         const target = document.createElement('div');
-        sd(innerNoSlot).appendChild(target);
+        wrap(innerNoSlot).appendChild(target);
 
-        assert.strictEqual(sd(target).assignedSlot, null);
+        assert.strictEqual(wrap(target).assignedSlot, null);
 
         const eventLog = [];
         const pushToEventLog = (e) => {
           eventLog.push({currentTarget: e.currentTarget, eventPhase: e.eventPhase});
         };
 
-        // `sd(outerNoSlot).shadowRoot` will also see this event in its path,
+        // `wrap(outerNoSlot).shadowRoot` will also see this event in its path,
         // but event listeners on shadow roots are instead redirected by Shady
         // DOM to their host, causing the phase to incorrect (AT_TARGET).
-        sd(outerNoSlot).addEventListener('some-event', pushToEventLog);
-        sd(outerNoSlot).addEventListener('some-event', pushToEventLog, true);
-        sd(outerDiv).addEventListener('some-event', pushToEventLog);
-        sd(outerDiv).addEventListener('some-event', pushToEventLog, true);
-        sd(innerNoSlot).addEventListener('some-event', pushToEventLog);
-        sd(innerNoSlot).addEventListener('some-event', pushToEventLog, true);
-        sd(target).addEventListener('some-event', pushToEventLog);
-        sd(target).addEventListener('some-event', pushToEventLog,true);
+        wrap(outerNoSlot).addEventListener('some-event', pushToEventLog);
+        wrap(outerNoSlot).addEventListener('some-event', pushToEventLog, true);
+        wrap(outerDiv).addEventListener('some-event', pushToEventLog);
+        wrap(outerDiv).addEventListener('some-event', pushToEventLog, true);
+        wrap(innerNoSlot).addEventListener('some-event', pushToEventLog);
+        wrap(innerNoSlot).addEventListener('some-event', pushToEventLog, true);
+        wrap(target).addEventListener('some-event', pushToEventLog);
+        wrap(target).addEventListener('some-event', pushToEventLog,true);
 
-        sd(target).dispatchEvent(new Event('some-event', {bubbles: true, composed: true}));
+        wrap(target).dispatchEvent(new Event('some-event', {bubbles: true, composed: true}));
         assert.deepEqual(eventLog, [
           {currentTarget: outerNoSlot, eventPhase: Event.AT_TARGET},
           {currentTarget: outerDiv, eventPhase: Event.CAPTURING_PHASE},
@@ -1010,7 +1013,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           {currentTarget: outerNoSlot, eventPhase: Event.AT_TARGET},
         ]);
 
-        sd(document.body).removeChild(outerNoSlot);
+        wrap(document.body).removeChild(outerNoSlot);
       });
     });
   });

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -254,6 +254,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   });
   </script>
 
+  <template id="x-no-slot">
+    This element has no slot.
+  </template>
+  <script>
+    defineTestElement('x-no-slot');
+  </script>
+
   <div id="globalpatch"></div>
 
   <template id="relatedtarget">
@@ -929,6 +936,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       })
       w.dispatchEvent(new Event('foo'));
       assert.isTrue(heardEvent);
+    });
+
+    test('events dispatched to unassigned slottables bubble through the tree above them', () => {
+      const noSlot = ShadyDOM.wrapIfNeeded(document.createElement('x-no-slot'));
+      const unassignedSlottable = ShadyDOM.wrapIfNeeded(document.createElement('div'));
+
+      ShadyDOM.wrapIfNeeded(document.body).appendChild(noSlot);
+      noSlot.appendChild(unassignedSlottable);
+      assert.equal(ShadyDOM.wrapIfNeeded(unassignedSlottable).assignedSlot, undefined);
+
+      let listenerTriggered = false;
+      ShadyDOM.wrapIfNeeded(noSlot).addEventListener('some-event', () => listenerTriggered = true);
+      ShadyDOM.wrapIfNeeded(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
+      assert.ok(listenerTriggered);
     });
   });
   </script>

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -1015,6 +1015,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         wrap(document.body).removeChild(outerNoSlot);
       });
+
+      test('events dispatched from children that are disconnected in the ' +
+          'real tree but connected in the user-facing tree bubble up to ' +
+          'parents that are connected in the real tree', () => {
+        const wrap = node => ShadyDOM.wrapIfNeeded(node);
+
+        customElements.define('parent-listener-element', class extends HTMLElement {
+          constructor() {
+            super();
+
+            // This elements' shadow root is empty, so all of its (non-shadow)
+            // children will be removed from the real tree even though they are
+            // considered connected in the user-facing tree.
+            wrap(this).attachShadow({mode: 'open'});
+            ShadyDOM.flush();
+
+            this.listenerCallCount = 0;
+            wrap(this).addEventListener('some-event', () => {
+              this.listenerCallCount++;
+            });
+          }
+        });
+
+        customElements.define('child-dispatcher-element', class extends HTMLElement {
+          constructor() {
+            super();
+            this.dispatchEvent(new Event('some-event', {bubbles: true}));
+          }
+        });
+
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+
+        container.innerHTML = `
+          <parent-listener-element>
+            <child-dispatcher-element></child-dispatcher-element>
+          </parent-listener-element>
+        `;
+
+        const eventListenerElement = container.querySelector('parent-listener-element');
+        assert.strictEqual(eventListenerElement.listenerCallCount, 1);
+
+        document.body.removeChild(container);
+      });
     });
   });
   </script>

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -261,6 +261,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     defineTestElement('x-no-slot');
   </script>
 
+  <template id="x-dispatch-test">
+    <div id="outerDiv">
+      <x-no-slot id="innerNoSlot">
+        <div id="target"></div>
+      </x-no-slot>
+    </div>
+  </template>
+  <script>
+    defineTestElement('x-dispatch-test');
+  </script>
+
   <div id="globalpatch"></div>
 
   <template id="relatedtarget">
@@ -939,64 +950,152 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('unassigned slottable targets', () => {
-      test('bubbling events bubble through the tree above them', () => {
-        const noSlot = document.createElement('x-no-slot');
-        const unassignedSlottable = document.createElement('div');
+      /**
+       * Generates a tree with the following structure and returns an object
+       * with references to each node:
+       *
+       * <x-dispatch-test>
+       *   #shadow-root
+       *     <div id="outerDiv">
+       *       <x-no-slot id="innerNoSlot">
+       *         #shadow-root
+       *         #/shadow-root
+       *         <div id="target"></div>
+       *       </x-no-slot>
+       *     </div>
+       *   #/shadow-root
+       * </x-dispatch-test>
+       */
+      const getDispatchTestElement = () => {
+        const fixtureRoot = document.createElement('x-dispatch-test');
+        ShadyDOM.wrap(document.body).appendChild(fixtureRoot);
+        ShadyDOM.wrap(document.body).removeChild(fixtureRoot);
 
-        ShadyDOM.wrap(document.body).appendChild(noSlot);
-        ShadyDOM.wrap(noSlot).appendChild(unassignedSlottable);
-        assert.strictEqual(ShadyDOM.wrap(unassignedSlottable).assignedSlot, null);
+        const getShadowElementById = (id) => {
+          return ShadyDOM.wrap(fixtureRoot.shadowRoot).getElementById(id);
+        };
 
-        let listenerTriggered = false;
-        ShadyDOM.wrap(noSlot).addEventListener('some-event', () => listenerTriggered = true);
-        ShadyDOM.wrap(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
-        assert.ok(listenerTriggered);
+        return {
+          fixtureRoot,
+          outerDiv: getShadowElementById('outerDiv'),
+          innerNoSlot: getShadowElementById('innerNoSlot'),
+          target: getShadowElementById('target'),
+        };
+      };
 
-        ShadyDOM.wrap(document.body).removeChild(noSlot);
+      test('bubbling, non-composed events', () => {
+        const {fixtureRoot, outerDiv, innerNoSlot, target} = getDispatchTestElement();
+        ShadyDOM.wrap(document.body).appendChild(fixtureRoot);
+        assert.strictEqual(ShadyDOM.wrap(target).assignedSlot, null);
+
+        let fixtureRootListenerTriggered = false;
+        ShadyDOM.wrap(fixtureRoot).addEventListener('some-event', () => {
+          fixtureRootListenerTriggered = true;
+        });
+
+        let outerDivListenerTriggered = false;
+        ShadyDOM.wrap(outerDiv).addEventListener('some-event', () => {
+          outerDivListenerTriggered = true;
+        });
+
+        ShadyDOM.wrap(target).dispatchEvent(new Event('some-event', {
+          bubbles: true,
+          composed: false,
+        }));
+        // The event shouldn't escape the target's root.
+        assert.ok(!fixtureRootListenerTriggered);
+        // The event should bubble up to ancestors of the target.
+        assert.ok(outerDivListenerTriggered);
+
+        ShadyDOM.wrap(document.body).removeChild(fixtureRoot);
       });
 
-      test('non-bubbling events do not bubble through the tree above them', () => {
-        const noSlot = document.createElement('x-no-slot');
-        const unassignedSlottable = document.createElement('div');
-        const target = document.createElement('div');
+      test('non-bubbling, non-composed events', () => {
+        const {fixtureRoot, outerDiv, innerNoSlot, target} = getDispatchTestElement();
+        ShadyDOM.wrap(document.body).appendChild(fixtureRoot);
+        assert.strictEqual(ShadyDOM.wrap(target).assignedSlot, null);
 
-        ShadyDOM.wrap(document.body).appendChild(noSlot);
-        ShadyDOM.wrap(noSlot).appendChild(unassignedSlottable);
-        ShadyDOM.wrap(unassignedSlottable).appendChild(target);
-        assert.strictEqual(ShadyDOM.wrap(unassignedSlottable).assignedSlot, null);
+        let fixtureRootListenerTriggered = false;
+        ShadyDOM.wrap(fixtureRoot).addEventListener('some-event', () => {
+          fixtureRootListenerTriggered = true;
+        });
 
-        let listenerTriggered = false;
-        ShadyDOM.wrap(noSlot).addEventListener('some-event', () => listenerTriggered = true);
-        ShadyDOM.wrap(unassignedSlottable).addEventListener('some-event', () => listenerTriggered = true);
-        ShadyDOM.wrap(target).dispatchEvent(new Event('some-event', {bubbles: false}));
-        assert.ok(!listenerTriggered);
+        let outerDivListenerTriggered = false;
+        ShadyDOM.wrap(outerDiv).addEventListener('some-event', () => {
+          outerDivListenerTriggered = true;
+        });
 
-        ShadyDOM.wrap(document.body).removeChild(noSlot);
+        ShadyDOM.wrap(target).dispatchEvent(new Event('some-event', {
+          bubbles: false,
+          composed: false,
+        }));
+        // The event shouldn't escape the target's root.
+        assert.ok(!fixtureRootListenerTriggered);
+        // The event shouldn't bubble up to (non-shadow-including) ancestors of
+        // target.
+        assert.ok(!outerDivListenerTriggered);
+
+        ShadyDOM.wrap(document.body).removeChild(fixtureRoot);
+      });
+
+      test('non-bubbling, composed events', () => {
+        const {fixtureRoot, outerDiv, innerNoSlot, target} = getDispatchTestElement();
+        ShadyDOM.wrap(document.body).appendChild(fixtureRoot);
+        assert.strictEqual(ShadyDOM.wrap(target).assignedSlot, null);
+
+        let fixtureRootListenerTriggered = false;
+        ShadyDOM.wrap(fixtureRoot).addEventListener('some-event', () => {
+          fixtureRootListenerTriggered = true;
+        });
+
+        let outerDivListenerTriggered = false;
+        ShadyDOM.wrap(outerDiv).addEventListener('some-event', () => {
+          outerDivListenerTriggered = true;
+        });
+
+        ShadyDOM.wrap(target).dispatchEvent(new Event('some-event', {
+          bubbles: false,
+          composed: true,
+        }));
+        // The event should escape the target's root.
+        assert.ok(fixtureRootListenerTriggered);
+        // The event shouldn't bubble up to (non-shadow-including) ancestors of
+        // target.
+        assert.ok(!outerDivListenerTriggered);
+
+        ShadyDOM.wrap(document.body).removeChild(fixtureRoot);
+      });
+
+      test('bubbling, composed events', () => {
+        const {fixtureRoot, outerDiv, innerNoSlot, target} = getDispatchTestElement();
+        ShadyDOM.wrap(document.body).appendChild(fixtureRoot);
+        assert.strictEqual(ShadyDOM.wrap(target).assignedSlot, null);
+
+        let fixtureRootListenerTriggered = false;
+        ShadyDOM.wrap(fixtureRoot).addEventListener('some-event', () => {
+          fixtureRootListenerTriggered = true;
+        });
+
+        let outerDivListenerTriggered = false;
+        ShadyDOM.wrap(outerDiv).addEventListener('some-event', () => {
+          outerDivListenerTriggered = true;
+        });
+
+        ShadyDOM.wrap(target).dispatchEvent(new Event('some-event', {
+          bubbles: true,
+          composed: true,
+        }));
+        // The event should escape the target's root.
+        assert.ok(fixtureRootListenerTriggered);
+        // The event should bubble up to ancestors of the target.
+        assert.ok(outerDivListenerTriggered);
+
+        ShadyDOM.wrap(document.body).removeChild(fixtureRoot);
       });
 
       test('events have the correct phase during dispatch', () => {
-        /*
-          <x-no-slot> <!-- outerNoSlot -->
-            #shadow-root
-              <div> <!-- outerDiv -->
-                <x-no-slot> <!-- innerNoSlot -->
-                  #shadow-root
-                  #/shadow-root
-                  <div></div> <!-- target -->
-                </x-no-slot>
-              </div>
-            #/shadow-root
-          </x-no-slot>
-        */
-        const outerNoSlot = document.createElement('x-no-slot');
-        ShadyDOM.wrap(document.body).appendChild(outerNoSlot);
-        const outerDiv = document.createElement('div');
-        ShadyDOM.wrapIfNeeded(outerNoSlot).shadowRoot.appendChild(outerDiv);
-        const innerNoSlot = document.createElement('x-no-slot');
-        ShadyDOM.wrap(outerDiv).appendChild(innerNoSlot);
-        const target = document.createElement('div');
-        ShadyDOM.wrap(innerNoSlot).appendChild(target);
-
+        const {fixtureRoot, outerDiv, innerNoSlot, target} = getDispatchTestElement();
+        ShadyDOM.wrap(document.body).appendChild(fixtureRoot);
         assert.strictEqual(ShadyDOM.wrap(target).assignedSlot, null);
 
         const eventLog = [];
@@ -1004,12 +1103,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           eventLog.push({currentTarget: e.currentTarget, eventPhase: e.eventPhase});
         };
 
-        // `ShadyDOM.wrapIfNeeded(outerNoSlot).shadowRoot` will also see this
+        // `ShadyDOM.wrapIfNeeded(fixtureRoot).shadowRoot` will also see this
         // event in its path, but event listeners on shadow roots are instead
         // redirected by Shady DOM to their host, causing the phase to be
         // incorrect (AT_TARGET).
-        ShadyDOM.wrap(outerNoSlot).addEventListener('some-event', pushToEventLog);
-        ShadyDOM.wrap(outerNoSlot).addEventListener('some-event', pushToEventLog, true);
+        ShadyDOM.wrap(fixtureRoot).addEventListener('some-event', pushToEventLog);
+        ShadyDOM.wrap(fixtureRoot).addEventListener('some-event', pushToEventLog, true);
         ShadyDOM.wrap(outerDiv).addEventListener('some-event', pushToEventLog);
         ShadyDOM.wrap(outerDiv).addEventListener('some-event', pushToEventLog, true);
         ShadyDOM.wrap(innerNoSlot).addEventListener('some-event', pushToEventLog);
@@ -1019,17 +1118,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         ShadyDOM.wrap(target).dispatchEvent(new Event('some-event', {bubbles: true, composed: true}));
         assert.deepEqual(eventLog, [
-          {currentTarget: outerNoSlot, eventPhase: Event.AT_TARGET},
+          {currentTarget: fixtureRoot, eventPhase: Event.AT_TARGET},
           {currentTarget: outerDiv, eventPhase: Event.CAPTURING_PHASE},
           {currentTarget: innerNoSlot, eventPhase: Event.CAPTURING_PHASE},
           {currentTarget: target, eventPhase: Event.AT_TARGET},
           {currentTarget: target, eventPhase: Event.AT_TARGET},
           {currentTarget: innerNoSlot, eventPhase: Event.BUBBLING_PHASE},
           {currentTarget: outerDiv, eventPhase: Event.BUBBLING_PHASE},
-          {currentTarget: outerNoSlot, eventPhase: Event.AT_TARGET},
+          {currentTarget: fixtureRoot, eventPhase: Event.AT_TARGET},
         ]);
 
-        ShadyDOM.wrap(document.body).removeChild(outerNoSlot);
+        ShadyDOM.wrap(document.body).removeChild(fixtureRoot);
       });
 
       test('events dispatched from children that are disconnected in the ' +

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -950,6 +950,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('unassigned slottable targets', () => {
+      suiteSetup(function() {
+        // These cases are handled only if `preferPerformance` is not enabled.
+        if (ShadyDOM.settings.preferPerformance) {
+          this.skip();
+        }
+      });
+
       /**
        * Generates a tree with the following structure and returns an object
        * with references to each node:

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -943,16 +943,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         const noSlot = document.createElement('x-no-slot');
         const unassignedSlottable = document.createElement('div');
 
-        ShadyDOM.wrapIfNeeded(document.body).appendChild(noSlot);
-        ShadyDOM.wrapIfNeeded(noSlot).appendChild(unassignedSlottable);
-        assert.strictEqual(ShadyDOM.wrapIfNeeded(unassignedSlottable).assignedSlot, null);
+        ShadyDOM.wrap(document.body).appendChild(noSlot);
+        ShadyDOM.wrap(noSlot).appendChild(unassignedSlottable);
+        assert.strictEqual(ShadyDOM.wrap(unassignedSlottable).assignedSlot, null);
 
         let listenerTriggered = false;
-        ShadyDOM.wrapIfNeeded(noSlot).addEventListener('some-event', () => listenerTriggered = true);
-        ShadyDOM.wrapIfNeeded(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
+        ShadyDOM.wrap(noSlot).addEventListener('some-event', () => listenerTriggered = true);
+        ShadyDOM.wrap(unassignedSlottable).dispatchEvent(new Event('some-event', {bubbles: true}));
         assert.ok(listenerTriggered);
 
-        ShadyDOM.wrapIfNeeded(document.body).removeChild(noSlot);
+        ShadyDOM.wrap(document.body).removeChild(noSlot);
       });
 
       test('events have the correct phase during dispatch', () => {
@@ -970,15 +970,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </x-no-slot>
         */
         const outerNoSlot = document.createElement('x-no-slot');
-        ShadyDOM.wrapIfNeeded(document.body).appendChild(outerNoSlot);
+        ShadyDOM.wrap(document.body).appendChild(outerNoSlot);
         const outerDiv = document.createElement('div');
         ShadyDOM.wrapIfNeeded(outerNoSlot).shadowRoot.appendChild(outerDiv);
         const innerNoSlot = document.createElement('x-no-slot');
-        ShadyDOM.wrapIfNeeded(outerDiv).appendChild(innerNoSlot);
+        ShadyDOM.wrap(outerDiv).appendChild(innerNoSlot);
         const target = document.createElement('div');
-        ShadyDOM.wrapIfNeeded(innerNoSlot).appendChild(target);
+        ShadyDOM.wrap(innerNoSlot).appendChild(target);
 
-        assert.strictEqual(ShadyDOM.wrapIfNeeded(target).assignedSlot, null);
+        assert.strictEqual(ShadyDOM.wrap(target).assignedSlot, null);
 
         const eventLog = [];
         const pushToEventLog = (e) => {
@@ -988,16 +988,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // `ShadyDOM.wrapIfNeeded(outerNoSlot).shadowRoot` will also see this event in its path,
         // but event listeners on shadow roots are instead redirected by Shady
         // DOM to their host, causing the phase to incorrect (AT_TARGET).
-        ShadyDOM.wrapIfNeeded(outerNoSlot).addEventListener('some-event', pushToEventLog);
-        ShadyDOM.wrapIfNeeded(outerNoSlot).addEventListener('some-event', pushToEventLog, true);
-        ShadyDOM.wrapIfNeeded(outerDiv).addEventListener('some-event', pushToEventLog);
-        ShadyDOM.wrapIfNeeded(outerDiv).addEventListener('some-event', pushToEventLog, true);
-        ShadyDOM.wrapIfNeeded(innerNoSlot).addEventListener('some-event', pushToEventLog);
-        ShadyDOM.wrapIfNeeded(innerNoSlot).addEventListener('some-event', pushToEventLog, true);
-        ShadyDOM.wrapIfNeeded(target).addEventListener('some-event', pushToEventLog);
-        ShadyDOM.wrapIfNeeded(target).addEventListener('some-event', pushToEventLog,true);
+        ShadyDOM.wrap(outerNoSlot).addEventListener('some-event', pushToEventLog);
+        ShadyDOM.wrap(outerNoSlot).addEventListener('some-event', pushToEventLog, true);
+        ShadyDOM.wrap(outerDiv).addEventListener('some-event', pushToEventLog);
+        ShadyDOM.wrap(outerDiv).addEventListener('some-event', pushToEventLog, true);
+        ShadyDOM.wrap(innerNoSlot).addEventListener('some-event', pushToEventLog);
+        ShadyDOM.wrap(innerNoSlot).addEventListener('some-event', pushToEventLog, true);
+        ShadyDOM.wrap(target).addEventListener('some-event', pushToEventLog);
+        ShadyDOM.wrap(target).addEventListener('some-event', pushToEventLog,true);
 
-        ShadyDOM.wrapIfNeeded(target).dispatchEvent(new Event('some-event', {bubbles: true, composed: true}));
+        ShadyDOM.wrap(target).dispatchEvent(new Event('some-event', {bubbles: true, composed: true}));
         assert.deepEqual(eventLog, [
           {currentTarget: outerNoSlot, eventPhase: Event.AT_TARGET},
           {currentTarget: outerDiv, eventPhase: Event.CAPTURING_PHASE},
@@ -1009,7 +1009,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           {currentTarget: outerNoSlot, eventPhase: Event.AT_TARGET},
         ]);
 
-        ShadyDOM.wrapIfNeeded(document.body).removeChild(outerNoSlot);
+        ShadyDOM.wrap(document.body).removeChild(outerNoSlot);
       });
 
       test('events dispatched from children that are disconnected in the ' +
@@ -1026,7 +1026,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ShadyDOM.flush();
 
             this.listenerCallCount = 0;
-            ShadyDOM.wrapIfNeeded(this).addEventListener('some-event', () => {
+            ShadyDOM.wrap(this).addEventListener('some-event', () => {
               this.listenerCallCount++;
             });
           }
@@ -1035,23 +1035,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         customElements.define('child-dispatcher-element', class extends HTMLElement {
           constructor() {
             super();
-            ShadyDOM.wrapIfNeeded(this).dispatchEvent(new Event('some-event', {bubbles: true}));
+            ShadyDOM.wrap(this).dispatchEvent(new Event('some-event', {bubbles: true}));
           }
         });
 
         const container = document.createElement('div');
-        ShadyDOM.wrapIfNeeded(document.body).appendChild(container);
+        ShadyDOM.wrap(document.body).appendChild(container);
 
-        ShadyDOM.wrapIfNeeded(container).innerHTML = `
+        ShadyDOM.wrap(container).innerHTML = `
           <parent-listener-element>
             <child-dispatcher-element></child-dispatcher-element>
           </parent-listener-element>
         `;
 
-        const eventListenerElement = ShadyDOM.wrapIfNeeded(container).querySelector('parent-listener-element');
+        const eventListenerElement = ShadyDOM.wrap(container).querySelector('parent-listener-element');
         assert.strictEqual(eventListenerElement.listenerCallCount, 1);
 
-        ShadyDOM.wrapIfNeeded(document.body).removeChild(container);
+        ShadyDOM.wrap(document.body).removeChild(container);
       });
     });
   });


### PR DESCRIPTION
This PR causes Shady DOM to manually dispatch all events with targets that are disconnected in the real tree. This causes events to propagate correctly if their path is split between connected and disconnected trees (in the real tree), which can happen if the target (or one of its ancestors) is connected but not assigned to a slot (in the user-facing tree).

~~- [ ] Merge Polymer/polymer#5663~~ (Assuming this passes internal tests, we're considering this low-risk enough to not require that Polymer's `...-changed` events go through this path.)

Fixes #95.