### PR TITLE
Support shadow parts consuming custom properties

### DIFF
--- a/packages/shadycss/src/scoping-shim.js
+++ b/packages/shadycss/src/scoping-shim.js
@@ -109,6 +109,9 @@ export default class ScopingShim {
         this._applyShim['transformRules'](ast, elementName);
       }
       template['_styleAst'] = ast;
+      if (!disableShadowParts && ast) {
+        shadowParts.analyzeTemplatePartRules(elementName, ast);
+      }
     }
     let ownPropertyNames = [];
     if (!nativeCssVariables) {
@@ -404,7 +407,12 @@ export default class ScopingShim {
   }
   _applyStyleProperties(host, styleInfo) {
     let is = StyleUtil.getIsExtends(host).is;
-    let cacheEntry = styleCache.fetch(is, styleInfo.styleProperties, styleInfo.ownStylePropertyNames);
+    let cacheEntry = styleCache.fetch(
+      is,
+      styleInfo.styleProperties,
+      styleInfo.ownStylePropertyNames,
+      styleInfo.customPropertyPartRules
+    );
     let cachedScopeSelector = cacheEntry && cacheEntry.scopeSelector;
     let cachedStyle = cacheEntry ? cacheEntry.styleElement : null;
     let oldScopeSelector = styleInfo.scopeSelector;
@@ -415,7 +423,13 @@ export default class ScopingShim {
       StyleProperties.applyElementScopeSelector(host, styleInfo.scopeSelector, oldScopeSelector);
     }
     if (!cacheEntry) {
-      styleCache.store(is, styleInfo.styleProperties, style, styleInfo.scopeSelector);
+      styleCache.store(
+        is,
+        styleInfo.styleProperties,
+        style,
+        styleInfo.scopeSelector,
+        styleInfo.customPropertyPartRules
+      );
     }
     return style;
   }

--- a/packages/shadycss/src/shadow-parts.js
+++ b/packages/shadycss/src/shadow-parts.js
@@ -471,7 +471,7 @@ function rescopeForCustomProperties(host, newStyleNodes, newProperties) {
  * A map from "providerScope:receiverScope" compound string key to an array of
  * ::part rules that were found during template preparation.
  *
- * We only populate this map if a ::part rule consumes a custom property and we
+ * We only populate this map if a ::part rule consumes a custom property and 
  * native custom properties are not available.
  *
  * This map is used to quickly lookup whether a given ::part rule being applied

--- a/packages/shadycss/src/shadow-parts.js
+++ b/packages/shadycss/src/shadow-parts.js
@@ -456,13 +456,13 @@ function rescopeForCustomProperties(host, newStyleNodes, newProperties) {
     // Inject this ::part rule into the array of style rules managed by this
     // instance. This way, the standard ShadyCSS mechanism for evaluating
     // per-instance styles will take effect.
-    if (!styleInfo.styleRules.rules.includes(styleNode)) {
+    if (styleInfo.styleRules.rules.indexOf(styleNode) === -1) {
       styleInfo.styleRules.rules.push(styleNode);
     }
 
     // We need to explicitly enumerate the active part rules on the styleInfo,
     // because that is used as part of the per-instance style cache lookup.
-    if (!styleInfo.customPropertyPartRules.includes(styleNode)) {
+    if (styleInfo.customPropertyPartRules.indexOf(styleNode) === -1) {
       styleInfo.customPropertyPartRules.push(styleNode);
     }
   }
@@ -470,7 +470,7 @@ function rescopeForCustomProperties(host, newStyleNodes, newProperties) {
   // Augment the array of CSS custom properties consumed by this instance,
   // because that is also used in the per-instance style cache lookup.
   for (const property of newProperties) {
-    if (!styleInfo.ownStylePropertyNames.includes(property)) {
+    if (styleInfo.ownStylePropertyNames.indexOf(property) === -1) {
       styleInfo.ownStylePropertyNames.push(property);
     }
   }
@@ -547,8 +547,8 @@ export function analyzeTemplatePartRules(providerScope, styleAst) {
   }
   for (const styleNode of styleAst.rules) {
     const selector = styleNode['selector'];
-    if (!selector || !selector.includes('::part')) {
-      // TODO(aomarks) We do the `includes` check here to make the case where no
+    if (!selector || selector.indexOf('::part') === -1) {
+      // TODO(aomarks) We do the `indexOf` check here to make the case where no
       // `::part` rules are used is as fast as possible, but we could get away
       // with just the `parsePartSelector` call we're doing next if the
       // difference is negligible. Needs benchmarking.
@@ -608,7 +608,7 @@ function lookupMatchingPartRules(scopeKey, partNames) {
   for (const entry of entries) {
     let matches = true;
     for (const partName of entry.partNames) {
-      if (!partNames.includes(partName)) {
+      if (partNames.indexOf(partName) === -1) {
         matches = false;
         break;
       }

--- a/packages/shadycss/src/shadow-parts.js
+++ b/packages/shadycss/src/shadow-parts.js
@@ -8,6 +8,12 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+/* eslint-disable-next-line no-unused-vars */
+import {StyleNode} from './css-parse.js';
+import StyleInfo from './style-info.js';
+import StyleProperties from './style-properties.js';
+import {nativeCssVariables} from './style-settings.js';
+
 /**
  * Parse a CSS Shadow Parts "part" attribute into an array of part names.
  *
@@ -293,7 +299,7 @@ export function findExportedPartMappings(host) {
   return result;
 }
 
-/*  eslint-disable no-unused-vars */
+/* eslint-disable no-unused-vars */
 /**
  * Add "shady-part" attributes to new nodes on insertion.
  *
@@ -345,11 +351,29 @@ export function onInsertBefore(parentNode, newNode, referenceNode) {
     superRoot === document ? 'document' : superRoot.host.localName;
   const exportMap = findExportedPartMappings(host);
 
+  // Things to keep track of that determine if and how we need to update this
+  // host to account for ::part rules that consume custom properties.
+  let needsRescoping = false;
+  let newStyleNodes, newProperties;
+
   for (const node of parts) {
     const shadyParts = [];
-    for (const name of splitPartString(node.getAttribute('part'))) {
+    const partNames = splitPartString(node.getAttribute('part'));
+    if (partNames.length === 0) {
+      continue;
+    }
+
+    let scopeKeys;
+    if (!nativeCssVariables) {
+      scopeKeys = new Set();
+    }
+
+    for (const name of partNames) {
       // Styles from our immediate parent scope.
       shadyParts.push(formatShadyPartAttribute(parentScope, hostScope, name));
+      if (!nativeCssVariables) {
+        scopeKeys.add(parentScope + ':' + hostScope);
+      }
 
       // Styles from grand-parent and higher ancestor scopes, via the forwarding
       // map defined by "exportparts" attributes.
@@ -359,9 +383,212 @@ export function onInsertBefore(parentNode, newNode, referenceNode) {
           shadyParts.push(
             formatShadyPartAttribute(providerScope, receiverScope, exportedName)
           );
+          if (!nativeCssVariables) {
+            scopeKeys.add(providerScope + ':' + receiverScope);
+          }
         }
       }
     }
     node.setAttribute('shady-part', shadyParts.join(' '));
+
+    if (!nativeCssVariables) {
+      // Find the part rules that match this node and that consume custom
+      // properties. We'll need to switch to per-instance styling if we find any
+      // within this host.
+      for (const scopeKey of scopeKeys.values()) {
+        const rules = lookupMatchingPartRules(scopeKey, partNames);
+        for (const rule of rules) {
+          if (!needsRescoping) {
+            needsRescoping = true;
+            newStyleNodes = new Set();
+            newProperties = new Set();
+          }
+          newStyleNodes.add(rule.styleNode);
+          newProperties.add(...rule.consumedProperties);
+        }
+      }
+    }
   }
+
+  if (needsRescoping) {
+    rescopeForCustomProperties(host, newStyleNodes, newProperties);
+  }
+}
+/* eslint-enable no-unused-vars */
+
+/**
+ * Update a host to account for it receiving part styles which consume custom
+ * properties
+ *
+ * @param host {!HTMLElement} The host to re-scope.
+ * @param newStyleNodes {!Array<!StyleNode>} New part rules that need to be
+ * adopted by this instance.
+ * @param newProperties {!Array<!string>} New custom properties that this
+ * instance now needs to track.
+ * @return {void}
+ */
+function rescopeForCustomProperties(host, newStyleNodes, newProperties) {
+  const styleInfo = StyleInfo.get(host);
+
+  // These arrays aren't always initialized.
+  if (!styleInfo.styleRules.rules) {
+    styleInfo.styleRules.rules = [];
+  }
+  if (!styleInfo.customPropertyPartRules) {
+    styleInfo.customPropertyPartRules = [];
+  }
+
+  for (const styleNode of newStyleNodes) {
+    // Inject this ::part rule into the array of style rules managed by this
+    // instance. This way, the standard ShadyCSS mechanism for evaluating
+    // per-instance styles will take effect.
+    if (!styleInfo.styleRules.rules.includes(styleNode)) {
+      styleInfo.styleRules.rules.push(styleNode);
+    }
+
+    // We need to explicitly enumerate the active part rules on the styleInfo,
+    // because that is used as part of the per-instance style cache lookup.
+    if (!styleInfo.customPropertyPartRules.includes(styleNode)) {
+      styleInfo.customPropertyPartRules.push(styleNode);
+    }
+  }
+
+  // Augment the array of CSS custom properties consumed by this instance,
+  // because that is also used in the per-instance style cache lookup.
+  for (const property of newProperties) {
+    if (!styleInfo.ownStylePropertyNames.includes(property)) {
+      styleInfo.ownStylePropertyNames.push(property);
+    }
+  }
+
+  // Re-scope this host. This creates a new <style> for this instance, or
+  // re-uses an existing one by checking the cache, and updates "scope" classes
+  // in this host's shadow root.
+  window.ShadyCSS.ScopingShim._applyStyleProperties(host, styleInfo);
+}
+
+/**
+ * A map from "providerScope:receiverScope" compound string key to an array of
+ * ::part rules that were found during template preparation.
+ *
+ * We only populate this map if a ::part rule consumes a custom property and we
+ * native custom properties are not available.
+ *
+ * This map is used to quickly lookup whether a given ::part rule being applied
+ * to an instance of a part node needs special handling for custom properties.
+ *
+ * @type {!Map<string, !Array<!PartRulesMapEntry>>}
+ */
+const partRulesMap = new Map();
+
+/* eslint-disable no-unused-vars */
+/**
+ * An entry in the part rules map. Note this class is just used as a type; it
+ * will be dead-code removed.
+ * @record
+ */
+class PartRulesMapEntry {
+  constructor() {
+    /**
+     * The ShadyCSS StyleNode for this ::part rule.
+     * @type {!StyleNode}
+     */
+    this.styleNode;
+
+    /**
+     * The CSS custom property names consumed by this ::part rule.
+     * @type {!Array<!string>}
+     */
+    this.consumedProperties;
+
+    /**
+     * The parsed part names that this ::part rule targets.
+     * @type {!Array<!string>}
+     */
+    this.partNames;
+  }
+}
+/* eslint-enable no-unused-vars */
+
+/**
+ * Look for any ::part rules in the given AST that consume custom properties,
+ * and load those into the part rules map.
+ *
+ * @param {!string} providerScope Lower-case tag name of the element whose
+ *     template this is.
+ * @param {!StyleNode} styleAst Parsed CSS for this template.
+ */
+export function analyzeTemplatePartRules(providerScope, styleAst) {
+  if (nativeCssVariables || !styleAst.rules) {
+    return;
+  }
+  for (const styleNode of styleAst.rules) {
+    const selector = styleNode['selector'];
+    if (!selector || selector.indexOf('::part') === -1) {
+      continue;
+    }
+    const consumedProperties = findConsumedCustomProperties(
+      styleNode['cssText']
+    );
+    if (consumedProperties.length === 0) {
+      continue;
+    }
+    const parsed = parsePartSelector(selector);
+    if (parsed === null) {
+      continue;
+    }
+    const {elementName: receiverScope, parts} = parsed;
+    if (parts.length === 0) {
+      continue;
+    }
+    const key = [providerScope, receiverScope].join(':');
+    let entries = partRulesMap.get(key);
+    if (entries === undefined) {
+      entries = [];
+      partRulesMap.set(key, entries);
+    }
+    entries.push({
+      styleNode,
+      consumedProperties,
+      partNames: splitPartString(parts),
+    });
+  }
+}
+
+/**
+ * Extract the CSS custom property names that are consumed by the given CSS
+ * text.
+ *
+ * @param {!string} cssText The CSS text.
+ * @return {!Array<!string>}>} The CSS Custom Property names.
+ */
+function findConsumedCustomProperties(cssText) {
+  const obj = {};
+  StyleProperties.collectPropertiesInCssText(cssText, obj);
+  return Object.getOwnPropertyNames(obj);
+}
+
+/**
+ * Return entries from the partRulesMap that match the given scopes and all of
+ * the given part names.
+ */
+function lookupMatchingPartRules(scopeKey, partNames) {
+  const entries = partRulesMap.get(scopeKey);
+  if (entries === undefined) {
+    return [];
+  }
+  const matching = [];
+  for (const entry of entries) {
+    let matches = true;
+    for (const partName of entry.partNames) {
+      if (partNames.indexOf(partName) === -1) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches === true) {
+      matching.push(entry);
+    }
+  }
+  return matching;
 }

--- a/packages/shadycss/src/style-cache.js
+++ b/packages/shadycss/src/style-cache.js
@@ -11,32 +11,59 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 export default class StyleCache {
   constructor(typeMax = 100) {
-    // map element name -> [{properties, styleElement, scopeSelector}]
+    // map element name -> [{properties, styleElement, scopeSelector, partRules}]
     this.cache = {};
     /** @type {number} */
     this.typeMax = typeMax;
   }
 
-  _validate(cacheEntry, properties, ownPropertyNames) {
+  _validate(cacheEntry, properties, ownPropertyNames, partRules) {
     for (let idx = 0; idx < ownPropertyNames.length; idx++) {
       let pn = ownPropertyNames[idx];
       if (cacheEntry.properties[pn] !== properties[pn]) {
         return false;
       }
     }
+
+    if (partRules) {
+      if (
+        !cacheEntry.partRules ||
+        cacheEntry.partRules.length !== partRules.length
+      ) {
+        return false;
+      }
+      for (let idx = 0; idx < partRules.length; idx++) {
+        if (cacheEntry.partRules[idx] !== partRules[idx]) {
+          return false;
+        }
+      }
+    } else if (cacheEntry.partRules) {
+      return false;
+    }
+
     return true;
   }
 
-  store(tagname, properties, styleElement, scopeSelector) {
+  store(tagname, properties, styleElement, scopeSelector, partRules) {
+    const entry = {
+      properties,
+      styleElement,
+      scopeSelector,
+    };
+    if (partRules !== undefined) {
+      // Slice to make a copy so that in-place updates to this array invalidate
+      // the cache.
+      entry.partRules = partRules.slice();
+    }
     let list = this.cache[tagname] || [];
-    list.push({properties, styleElement, scopeSelector});
+    list.push(entry);
     if (list.length > this.typeMax) {
       list.shift();
     }
     this.cache[tagname] = list;
   }
 
-  fetch(tagname, properties, ownPropertyNames) {
+  fetch(tagname, properties, ownPropertyNames, partRules) {
     let list = this.cache[tagname];
     if (!list) {
       return;
@@ -44,7 +71,7 @@ export default class StyleCache {
     // reverse list for most-recent lookups
     for (let idx = list.length - 1; idx >= 0; idx--) {
       let entry = list[idx];
-      if (this._validate(entry, properties, ownPropertyNames)) {
+      if (this._validate(entry, properties, ownPropertyNames, partRules)) {
         return entry;
       }
     }

--- a/packages/shadycss/src/style-info.js
+++ b/packages/shadycss/src/style-info.js
@@ -65,6 +65,13 @@ export default class StyleInfo {
     this.scopeSelector = null;
     /** @type {HTMLStyleElement} */
     this.customStyle = null;
+    /**
+     * Shadow part rules that are currently applied to this node, if those part
+     * rules consume a CSS custom property, and we don't have native custom
+     * property support.
+     * @type {!Array<!StyleNode>|undefined}
+     */
+    this.customPropertyPartRules;
   }
   _getStyleRules() {
     return this.styleRules;

--- a/packages/shadycss/src/style-properties.js
+++ b/packages/shadycss/src/style-properties.js
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 'use strict';
 
 import {removeCustomPropAssignment, StyleNode} from './css-parse.js'; // eslint-disable-line no-unused-vars
-import {nativeShadow} from './style-settings.js';
+import {nativeShadow, disableShadowParts} from './style-settings.js';
 import StyleTransformer from './style-transformer.js';
 import * as StyleUtil from './style-util.js';
 import * as RX from './common-regex.js';
@@ -495,9 +495,20 @@ class StyleProperties {
     let scope = '.' + scopeId;
     let parts = StyleUtil.splitSelectorList(selector);
     for (let i=0, l=parts.length, p; (i<l) && (p=parts[i]); i++) {
-      parts[i] = p.match(hostRx) ?
-        p.replace(hostSelector, scope) :
-        scope + ' ' + p;
+      if (p.match(hostRx)) {
+        parts[i] = p.replace(hostSelector, scope);
+      } else if (!disableShadowParts && p.indexOf('[shady-part') !== -1) {
+        // Kind of hacky! This is the case where a part rule is being applied to
+        // a node, where that part rule comes from the grandparent of the node
+        // or higher, through the exportparts tree. In this case, we're
+        // x-child-n, and we start with something like "x-parent
+        // [shady-part...]", and we want to transform that to "x-parent
+        // x-child-n [shady-part...]" (and NOT "x-child-n x-parent
+        // [shady-part...]" as we would if we didn't have this special case).
+        parts[i] = p.replace('[shady-part', scope + ' [shady-part');
+      } else {
+        parts[i] = scope + ' ' + p;
+      }
     }
     rule['selector'] = parts.join(',');
   }

--- a/packages/shadycss/src/style-properties.js
+++ b/packages/shadycss/src/style-properties.js
@@ -493,11 +493,11 @@ class StyleProperties {
         /** @type {?} */ (rule.transformedSelector) || rule['selector'];
     let selector = rule.transformedSelector;
     let scope = '.' + scopeId;
-    let parts = StyleUtil.splitSelectorList(selector);
-    for (let i=0, l=parts.length, p; (i<l) && (p=parts[i]); i++) {
-      if (p.match(hostRx)) {
-        parts[i] = p.replace(hostSelector, scope);
-      } else if (!disableShadowParts && p.indexOf('[shady-part') !== -1) {
+    let segments = StyleUtil.splitSelectorList(selector);
+    for (let i=0, l=segments.length, s; (i<l) && (s=segments[i]); i++) {
+      if (s.match(hostRx)) {
+        segments[i] = s.replace(hostSelector, scope);
+      } else if (!disableShadowParts && s.indexOf('[shady-part') !== -1) {
         // Kind of hacky! This is the case where a part rule is being applied to
         // a node, where that part rule comes from the grandparent of the node
         // or higher, through the exportparts tree. In this case, we're
@@ -505,12 +505,12 @@ class StyleProperties {
         // [shady-part...]", and we want to transform that to "x-parent
         // x-child-n [shady-part...]" (and NOT "x-child-n x-parent
         // [shady-part...]" as we would if we didn't have this special case).
-        parts[i] = p.replace('[shady-part', scope + ' [shady-part');
+        segments[i] = s.replace('[shady-part', scope + ' [shady-part');
       } else {
-        parts[i] = scope + ' ' + p;
+        segments[i] = scope + ' ' + s;
       }
     }
-    rule['selector'] = parts.join(',');
+    rule['selector'] = segments.join(',');
   }
 
   /**

--- a/packages/tests/shadycss/shadow-parts/part-intersection.html
+++ b/packages/tests/shadycss/shadow-parts/part-intersection.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<title>shadycss/shadow-parts/part-intersection</title>
+
+<script src="../test-flags.js"></script>
+<script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/template/template.js"></script>
+<script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
+<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+<script src="../../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
+<script src="../module/generated/make-element.js"></script>
+
+<template id="x-a">
+  <style>
+    x-b::part(p1 p2) {
+      color: red;
+    }
+  </style>
+  <x-b></x-b>
+</template>
+
+<template id="x-b">
+  <div part="p1"></div>
+  <div part="p2"></div>
+  <!-- Only this part should be red, because the ::part selector selects the
+       intersection of p1 and p2 (not the union!). -->
+  <div part="p1 p2"></div>
+</template>
+
+<x-a></x-a>
+
+<script type="module">
+  import {pierce, color, black, red} from './test-utils.js';
+
+  suite('part selector with intersection', () => {
+    let p1, p2, p1p2;
+
+    suiteSetup(() => {
+      makeElement('x-a');
+      makeElement('x-b');
+      p1 = pierce('x-a', 'x-b', '[part=p1]');
+      p2 = pierce('x-a', 'x-b', '[part=p2]');
+      p1p2 = pierce('x-a', 'x-b', '[part~=p1][part~=p2]');
+    });
+
+    test('node with both parts receives style', () => {
+      assert.equal(color(p1p2), red);
+    });
+
+    test('nodes with only one part does not receive style', () => {
+      assert.equal(color(p1), black);
+      assert.equal(color(p2), black);
+    });
+  });
+</script>

--- a/packages/tests/shadycss/shadow-parts/property-above-provider.html
+++ b/packages/tests/shadycss/shadow-parts/property-above-provider.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<title>shadycss/shadow-parts/property-above-provider</title>
+
+<script src="../test-flags.js"></script>
+<script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/template/template.js"></script>
+<script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
+<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+<script src="../../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
+<script src="../module/generated/make-element.js"></script>
+
+<template id="x-a">
+  <style>
+    :host {
+      --color: red;
+    }
+  </style>
+  <x-b></x-b>
+</template>
+
+<template id="x-b">
+  <style>
+    x-c::part(p1) {
+      color: var(--color);
+    }
+  </style>
+  <x-c></x-c>
+</template>
+
+<template id="x-c">
+  <div part="p1"></div>
+</template>
+
+<x-a></x-a>
+
+<script type="module">
+  import {pierce, color, red} from './test-utils.js';
+
+  suite('property set above part style provider', () => {
+    let p1;
+    suiteSetup(() => {
+      makeElement('x-a');
+      makeElement('x-b');
+      makeElement('x-c');
+      p1 = pierce('x-a', 'x-b', 'x-c', '[part=p1]');
+    });
+
+    test('part receives property value', () => {
+      assert.equal(color(p1), red);
+    });
+  });
+</script>

--- a/packages/tests/shadycss/shadow-parts/property-below-provider.html
+++ b/packages/tests/shadycss/shadow-parts/property-below-provider.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<title>shadycss/shadow-parts/property-below-providerd</title>
+
+<script src="../test-flags.js"></script>
+<script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/template/template.js"></script>
+<script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
+<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+<script src="../../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
+<script src="../module/generated/make-element.js"></script>
+
+<template id="x-a">
+  <style>
+    x-b::part(p1) {
+      color: var(--color);
+    }
+  </style>
+  <x-b></x-b>
+</template>
+
+<template id="x-b">
+  <style>
+    :host {
+      --color: red;
+    }
+  </style>
+  <x-c exportparts="p1"></x-c>
+</template>
+
+<template id="x-c">
+  <div part="p1"></div>
+</template>
+
+<x-a></x-a>
+
+<script type="module">
+  import {pierce, color, red} from './test-utils.js';
+
+  suite('property set below part style provider', () => {
+    let p1;
+    suiteSetup(() => {
+      makeElement('x-a');
+      makeElement('x-b');
+      makeElement('x-c');
+      p1 = pierce('x-a', 'x-b', 'x-c', '[part=p1]');
+    });
+
+    test('part receives property value', () => {
+      assert.equal(color(p1), red);
+    });
+  });
+</script>

--- a/packages/tests/shadycss/shadow-parts/property-part-intersection.html
+++ b/packages/tests/shadycss/shadow-parts/property-part-intersection.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<title>shadycss/shadow-parts/property-part-intersection</title>
+
+<script src="../test-flags.js"></script>
+<script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/template/template.js"></script>
+<script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
+<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+<script src="../../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
+<script src="../module/generated/make-element.js"></script>
+
+<template id="x-a">
+  <style>
+    x-b::part(p1 p2) {
+      color: var(--color);
+    }
+  </style>
+  <x-b></x-b>
+</template>
+
+<template id="x-b">
+  <style>
+    :host {
+      --color: red;
+    }
+  </style>
+  <x-c exportparts="p1,p2"></x-c>
+</template>
+
+<template id="x-c">
+  <div part="p1"></div>
+  <div part="p2"></div>
+  <!-- Only this part should be red, because the ::part selector selects the
+       intersection of p1 and p2 (not the union!). -->
+  <div part="p1 p2"></div>
+</template>
+
+<x-a></x-a>
+
+<script type="module">
+  import {pierce, color, black, red} from './test-utils.js';
+
+  suite('part selector with intersection and custom property', () => {
+    let p1, p2, p1p2;
+
+    suiteSetup(() => {
+      makeElement('x-a');
+      makeElement('x-b');
+      makeElement('x-c');
+      p1 = pierce('x-a', 'x-b', 'x-c', '[part=p1]');
+      p2 = pierce('x-a', 'x-b', 'x-c', '[part=p2]');
+      p1p2 = pierce('x-a', 'x-b', 'x-c', '[part~=p1][part~=p2]');
+    });
+
+    test('node with both parts receives style', () => {
+      assert.equal(color(p1p2), red);
+    });
+
+    test('nodes with only one part does not receive style', () => {
+      assert.equal(color(p1), black);
+      assert.equal(color(p2), black);
+    });
+  });
+</script>

--- a/packages/tests/shadycss/shadow-parts/property-within-provider.html
+++ b/packages/tests/shadycss/shadow-parts/property-within-provider.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<title>shadycss/shadow-parts/property-within-provider</title>
+
+<script src="../test-flags.js"></script>
+<script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/template/template.js"></script>
+<script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
+<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+<script src="../../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
+<script src="../module/generated/make-element.js"></script>
+
+<template id="x-a">
+  <style>
+    x-b::part(p1) {
+      color: var(--color);
+      --color: red;
+    }
+  </style>
+  <x-b></x-b>
+</template>
+
+<template id="x-b">
+  <div part="p1"></div>
+</template>
+
+<x-a></x-a>
+
+<script type="module">
+  import {pierce, color, red} from './test-utils.js';
+
+  suite('property set within part style provider', () => {
+    let p1;
+    suiteSetup(() => {
+      makeElement('x-a');
+      makeElement('x-b');
+      p1 = pierce('x-a', 'x-b', '[part=p1]');
+    });
+
+    test.skip('part receives property value', () => {
+      // TODO(aomarks) This still doesn't work because when we evaluate the
+      // property values and create the style, we aren't taking into account
+      // properties being set in the part rule itself. We probably need special
+      // handling for this.
+      assert.equal(color(p1), red);
+    });
+  });
+</script>

--- a/packages/tests/shadycss/shadow-parts/suites.js
+++ b/packages/tests/shadycss/shadow-parts/suites.js
@@ -20,4 +20,9 @@ export const suites = [
   'find-exported-part-mappings.html',
   'insertions.html',
   'parsing-formatting.html',
+  'property-above-provider.html',
+  'property-below-provider.html',
+  'part-intersection.html',
+  'property-part-intersection.html',
+  'property-within-provider.html',
 ];


### PR DESCRIPTION
When a `::part` rule consumes a custom property, the value of that property is determined at each scope where that rule is _received_, not where the rule was defined.

This means that, unless we have native custom properties (which already work fine here with no changes), any time we find a part node that is receiving a style that consumes a custom property, we need to switch that part's host to per-instance styling, just as though it was consuming a custom property in its own styles.

There is still a known issue where property values set in the exact same rule that they are consumed are not supported. I included a skipped test for this and will address in a follow up, since I need to do some more digging to find the fix.

Part of https://github.com/webcomponents/polyfills/issues/252 and https://github.com/webcomponents/polyfills/issues/311. Fixes https://github.com/webcomponents/polyfills/issues/338.