### PR TITLE
Transform ::part rule declarations to !important

### DIFF
--- a/packages/tests/shadycss/shadow-parts/all-polyfilled.html
+++ b/packages/tests/shadycss/shadow-parts/all-polyfilled.html
@@ -17,10 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script type="module">
   import {suites} from './suites';
 
-  WCT.loadSuites(
-    suites.map(
-      (url) =>
-        url + "?wc-register=true&wc-shadydom=true&wc-shimcssproperties=true"
-    )
-  );
+  WCT.loadSuites([
+    ...suites.map((url) => url + '?wc-register=true&wc-shadydom=true&wc-shimcssproperties=true'),
+    ...suites.map((url) => url + '?wc-register=true&wc-shadydom=true'),
+  ]);
 </script>

--- a/packages/tests/shadycss/shadow-parts/basic.html
+++ b/packages/tests/shadycss/shadow-parts/basic.html
@@ -82,7 +82,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         const style = document.querySelector('style[scope=x-a]');
         assert.equal(
           style.textContent.replace(/\n/gm, ' ').replace(/\s+/g, ' ').trim(),
-          `x-a x-b [shady-part~="x-a:x-b:pa"] { color: red; }`
+          `x-a x-b [shady-part~="x-a:x-b:pa"] { color: red !important; }`
         );
       });
     }

--- a/packages/tests/shadycss/shadow-parts/specificity.html
+++ b/packages/tests/shadycss/shadow-parts/specificity.html
@@ -9,7 +9,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<title>shadycss/shadow-parts/basic</title>
+<title>shadycss/shadow-parts/specificity</title>
 
 <script src="../test-flags.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
@@ -18,57 +18,64 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script src="../../node_modules/@webcomponents/template/template.js"></script>
 <script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
-<script src="../../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
 <script src="../../node_modules/@webcomponents/shadycss/custom-style-interface.min.js"></script>
+<script src="../../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
 <script src="../module/generated/make-element.js"></script>
 
 <style id="testDocumentStyle">
-  x-a::part(pa) {
-    color: red;
+  x-parent::part(foo) {
+    background-color: red;
   }
 </style>
 
-<template id="x-a">
-  <div part="pa">pa</div>
+<template id="x-parent">
+  <style>
+    x-child::part(foo) {
+      color: red;
+    }
+  </style>
+  <x-child exportparts="foo"></x-child>
+</template>
+
+<template id="x-child">
+  <style>
+    #foo {
+      color: blue;
+      background-color: blue;
+    }
+  </style>
+  <div id="foo" part="foo">foo</div>
 </template>
 
 <script type="module">
-  import {pierce, color, red} from './test-utils.js';
+  import {pierce, style, red} from './test-utils.js';
 
-  suite('document style', () => {
-    let style, xa, pa;
-
+  suite('specificity', function() {
     suiteSetup(() => {
-      makeElement('x-a');
-      style = document.querySelector('#testDocumentStyle');
+      makeElement('x-parent');
+      makeElement('x-child');
+      const style = document.querySelector('#testDocumentStyle');
       window.ShadyCSS.CustomStyleInterface.addCustomStyle(style);
     });
 
+    let parent, part;
+
     setup(() => {
-      xa = document.createElement('x-a');
-      document.body.appendChild(xa);
-      pa = pierce('x-a', '[part=pa]');
+      parent = document.createElement('x-parent');
+      document.body.appendChild(parent);
+      part = pierce(parent, 'x-child', '[part]');
     });
 
     teardown(() => {
-      document.body.removeChild(xa);
+      document.body.removeChild(parent);
     });
 
-    test('part receives style', () => {
-      assert.equal(color(pa), red);
+    test('parent part rule beats local id rule', () => {
+      assert.equal(style(part).color, red);
     });
 
-    if (!window.ShadyCSS.nativeShadow) {
-      test('part gets shady-part attribute', () => {
-        assert.equal(pa.getAttribute('shady-part'), 'document:x-a:pa');
-      });
-
-      test('document style transformed with shady-part attribute', () => {
-        assert.equal(
-          style.textContent.replace(/\n/gm, ' ').replace(/\s+/g, ' ').trim(),
-          `x-a [shady-part~="document:x-a:pa"] { color: red !important; }`
-        );
-      });
-    }
+    test('document part rule beats local id rule', () => {
+      assert.equal(style(part).backgroundColor, red);
+    });
   });
 </script>

--- a/packages/tests/shadycss/shadow-parts/suites.js
+++ b/packages/tests/shadycss/shadow-parts/suites.js
@@ -32,4 +32,5 @@ export const suites = [
   'property-selector-group.html',
   'property-within-provider.html',
   'selector-group.html',
+  'specificity.html',
 ];


### PR DESCRIPTION
As described in the [design doc](https://github.com/webcomponents/polyfills/blob/shady-parts/packages/shadycss/shadow-parts.md#2-specificity-is-crude), transform all `::part` rule declarations to `!important`.

We do this to all `::part` rules as a crude way to improve the specificity behavior of shadow parts for the (hopefully) common simple use-case of a part node that has some local default styles that should be overridable by some `::part` rule. For example:

```html
<x-parent>
   #shadow-root
     <!-- This color should have precendence. Unless we transform it to
          !important, though it would not beat out the #foo selector
          from the <x-child> default part styles. -->
     <style>
       x-child::part(foo) { color: red; }
     </style>

     <x-child>
       #shadow-root
         <style>
           #foo { color: green; }
         </style>
         <div id="foo" part="foo">Hello</div>
```
 
Since this is all we do to help `::part` rule specificity, there are many patterns that still won't behave correctly. For example, adding a grand-parent scope to the above case:

```html
 <x-grandparent>
   #shadow-root
     <!-- This color should have precedence over both the <x-parent>
          and <x-child> ones, but we don't guarantee this. -->
     <style>
       x-parent::part(foo) { color: blue; }
     </style>
     <x-parent>...</x-parent>
```

This is because the 3 transformed selectors will look as below, so precedence is determined by template processing order:

```css
x-grandparent x-parent [shady-part~="x-grandparent:x-parent:foo"] {}
x-parent      x-child  [shady-part~="x-parent:x-child:foo"] {}
.x-child#foo {}
```
To workaround specificity issues like this, the user will need to manually increase the weight of rules that they want to take precedence (e.g. adding an `#id` selector to the `<x-grandparent>` rule).

Fixes https://github.com/webcomponents/polyfills/issues/351
Part of https://github.com/webcomponents/polyfills/issues/252