### PR TITLE
Object.assign polyfill: exclude non-enumerable

### DIFF
--- a/packages/tests/webcomponentsjs_/object-assign.html
+++ b/packages/tests/webcomponentsjs_/object-assign.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+
+<head>
+  <title>Object.assign Polyfill</title>
+  <script>Object.assign = undefined;</script>
+  <script id="loader" src="../node_modules/@webcomponents/webcomponentsjs/src/platform/es6-misc.js"></script>
+  <script src="./wct-config.js"></script>
+  <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+  <script>
+    suite('Object.assign', function() {
+      test('exists on window', function() {
+        assert(Object.assign);
+      });
+
+      test('copies enumerable own properties', function() {
+        const target = {};
+        const source = {};
+        Object.defineProperty(source, 'foo', {enumerable: true, value: 'foo'});
+        Object.defineProperty(source, 'bar', {enumerable: true, value: 'bar'});
+        Object.assign(target, source);
+        assert.equal(target.foo, 'foo');
+        assert.equal(target.bar, 'bar');
+      });
+
+      test('does not copy non-enumerable own property', function() {
+        const target = {};
+        const source = {};
+        Object.defineProperty(source, 'foo', {enumerable: false, value: 'foo'});
+        Object.assign(target, source);
+        assert.equal(target.foo, undefined);
+      });
+
+      test('source beats target, and later source beats earlier source', function() {
+        const target = {};
+        Object.defineProperty(target, 'foo', {enumerable: true, value: 'foo0', writable: true});
+        const source1 = {};
+        const source2 = {};
+        Object.defineProperty(source1, 'foo', {enumerable: true, value: 'foo1'});
+        Object.defineProperty(source2, 'foo', {enumerable: true, value: 'foo2'});
+        Object.assign(target, source1, source2);
+        assert.equal(target.foo, 'foo2');
+      });
+
+      test('ignores null and undefined sources', function() {
+        const target = {};
+        const source = {};
+        Object.defineProperty(source, 'foo', {enumerable: true, value: 'foo'});
+        Object.assign(target, null, undefined, source);
+        assert.equal(target.foo, 'foo');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/packages/tests/webcomponentsjs_/runner.html
+++ b/packages/tests/webcomponentsjs_/runner.html
@@ -32,7 +32,8 @@
     'symbol.html',
     'bundle-after-load.html',
     'loader-after-load.html',
-    'baseuri.html'
+    'baseuri.html',
+    'object-assign.html'
   ];
 </script>
 <script>

--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fixed bug where Object.assign polyfill would copy non-enumerable properties.
 - Convert platform (`Array.from`, `CustomEvent`, `Promise` etc.) polyfills to
   TypeScript ([#292](https://github.com/webcomponents/polyfills/pull/292))
 - Improve types for JSCompiler compatibility

--- a/packages/webcomponentsjs/package.json
+++ b/packages/webcomponentsjs/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "build": "tsc && gulp",
-    "build:watch": "chokidar --initial --follow-symlinks 'src/**/*.js' 'node_modules/@webcomponents/**/*.js' -c 'npm run build'",
+    "build:watch": "chokidar --initial --follow-symlinks 'src/entrypoints/**/*.js' 'ts_src/**/*.ts' 'node_modules/@webcomponents/**/*.js' -c 'npm run build'",
     "lint": "eslint src",
     "regen-package-lock": "rm -rf node_modules package-lock.json; npm install",
     "prepack": "npm run build",

--- a/packages/webcomponentsjs/ts_src/platform/es6-misc.ts
+++ b/packages/webcomponentsjs/ts_src/platform/es6-misc.ts
@@ -19,7 +19,7 @@ if (!Array.from) {
 
 if (!Object.assign) {
   const assign = (target: object, source: object) => {
-    const n$ = Object.getOwnPropertyNames(source);
+    const n$ = Object.keys(source);
     for (let i = 0; i < n$.length; i++) {
       const p = n$[i];
       // tslint:disable-next-line:no-any


### PR DESCRIPTION
`Object.assign` should copy all enumerable own properties. We were getting keys from `Object.getOwnPropertyName`, which includes non-enumerable properties. Now we use `Object.keys` instead.

Fixes https://github.com/webcomponents/polyfills/issues/4