### PR TITLE
Move part node discovery into Shady DOM

### DIFF
--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -20,3 +20,11 @@ node many times, and compares across:
   - `before`: A fixed version of ShadyCSS before any shadow parts support was added.
   - `head`: The code at HEAD.
   - `disabled`: The code at HEAD with shadow parts support force-disabled.
+
+### `render-styled-part.json`
+
+Measures the time spent inserting many times a parent and child element, where
+the parent provides a part style to the child, and compares across:
+
+  - `native`: Polyfill disabled.
+  - `polyfill`: Polyfill enabled.

--- a/packages/benchmarks/shadycss/shadowparts/render-styled-part.html
+++ b/packages/benchmarks/shadycss/shadowparts/render-styled-part.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+
+<script>
+  const url = new URL(window.location.href);
+  if (url.searchParams.has('forcePolyfill')) {
+    window.ShadyDOM = {force: true};
+    window.ShadyCSS = {shimcssproperties: true};
+  }
+</script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+
+<template id="xParentTmpl">
+  <style>
+    x-child::part(foo) {
+      color: red;
+    }
+  </style>
+  x-parent
+  <x-child></x-child>
+</template>
+
+<template id="xChildTmpl">
+  x-child
+  <div part="foo">part</div>
+</template>
+
+<script type="module">
+  import * as shadyCss from '@webcomponents/shadycss';
+
+  const xParentTmpl = document.querySelector('#xParentTmpl');
+  class XParent extends HTMLElement {
+    connectedCallback() {
+      shadyCss.styleElement(this);
+      this.attachShadow({mode: 'open'});
+      this.shadowRoot.appendChild(document.importNode(xParentTmpl.content, true));
+    }
+  }
+  shadyCss.prepareTemplate(xParentTmpl, 'x-parent');
+  customElements.define('x-parent', XParent);
+
+  const xChildTmpl = document.querySelector('#xChildTmpl');
+  class XChild extends HTMLElement {
+    connectedCallback() {
+      shadyCss.styleElement(this);
+      this.attachShadow({mode: 'open'});
+      this.shadowRoot.appendChild(document.importNode(xChildTmpl.content, true));
+    }
+  }
+  shadyCss.prepareTemplate(xChildTmpl, 'x-child');
+  customElements.define('x-child', XChild);
+
+  performance.mark('start');
+  for (let i = 0; i < 1000; i++) {
+    const parent = document.createElement('x-parent');
+    document.body.appendChild(parent);
+  }
+  performance.measure('render-styled-part', 'start');
+</script>

--- a/packages/benchmarks/shadycss/shadowparts/render-styled-part.json
+++ b/packages/benchmarks/shadycss/shadowparts/render-styled-part.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Polymer/tachometer/master/config.schema.json",
+  "sampleSize": 100,
+  "timeout": 0,
+  "benchmarks": [
+    {
+      "name": "native",
+      "url": "shadycss/shadowparts/render-styled-part.html",
+      "browser": {
+        "name": "chrome",
+        "headless": true
+      },
+      "measurement": {
+        "mode": "performance",
+        "entryName": "render-styled-part"
+      }
+    },
+    {
+      "name": "polyfill",
+      "url": "shadycss/shadowparts/render-styled-part.html?forcePolyfill",
+      "browser": {
+        "name": "chrome",
+        "headless": true
+      },
+      "measurement": {
+        "mode": "performance",
+        "entryName": "render-styled-part"
+      }
+    }
+  ]
+}

--- a/packages/shadycss/externs/shadycss-externs.js
+++ b/packages/shadycss/externs/shadycss-externs.js
@@ -9,7 +9,7 @@
  * styleDocument: function(Object<string, string>=),
  * flushCustomStyles: function(),
  * getComputedStyleValue: function(!Element, string): string,
- * styleShadowParts: function(!HTMLElement, !Array<!HTMLElement>, !Array<!HTMLElement>): void,
+ * styleShadowParts: function(!HTMLElement, !Array<!HTMLElement>, (!Array<!HTMLElement>|undefined)): void,
  * onSetAttribute: function(!HTMLElement, !string, !string, ?string): void,
  * onRemoveAttribute: function(!HTMLElement, !string): void,
  * shadowPartsActive: function(): !boolean,

--- a/packages/shadycss/externs/shadycss-externs.js
+++ b/packages/shadycss/externs/shadycss-externs.js
@@ -9,7 +9,7 @@
  * styleDocument: function(Object<string, string>=),
  * flushCustomStyles: function(),
  * getComputedStyleValue: function(!Element, string): string,
- * onInsertBefore: function(!HTMLElement, !HTMLElement, ?HTMLElement): void,
+ * styleShadowParts: function(!HTMLElement, !Array<!HTMLElement>, !Array<!HTMLElement>): void,
  * onSetAttribute: function(!HTMLElement, !string, !string, ?string): void,
  * onRemoveAttribute: function(!HTMLElement, !string): void,
  * shadowPartsActive: function(): !boolean,

--- a/packages/shadycss/src/scoping-shim.js
+++ b/packages/shadycss/src/scoping-shim.js
@@ -294,7 +294,7 @@ export default class ScopingShim {
    * @param {!Array<!HTMLElement>} partNodes "part" nodes in the given host's
    * shadow root. Each of these will have its "shady-part" attribute updated
    * according to the host's scope.
-   * @param {!Array<!HTMLElement>} exportPartsNodes "exportparts" nodes in this
+   * @param {!Array<!HTMLElement>|undefined} exportPartsNodes "exportparts" nodes in this
    * host's shadow root. The shadow roots of each of these will be walked, and
    * any relevant descendant "part" nodes will have their "shady-part"
    * attributes updated.
@@ -304,11 +304,13 @@ export default class ScopingShim {
     if (partNodes.length > 0) {
       shadowParts.styleShadowParts(host, partNodes);
     }
-    for (const exporter of exportPartsNodes) {
-      const exports = shadowParts.parseExportPartsAttribute(
-        exporter.getAttribute('exportparts')
-      ).map(({inner}) => inner);
-      shadowParts.refreshShadyPartAttributes(exporter, exports);
+    if (exportPartsNodes) {
+      for (const exporter of exportPartsNodes) {
+        const exports = shadowParts.parseExportPartsAttribute(
+          exporter.getAttribute('exportparts')
+        ).map(({inner}) => inner);
+        shadowParts.refreshShadyPartAttributes(exporter, exports);
+      }
     }
   }
 

--- a/packages/shadycss/src/scoping-shim.js
+++ b/packages/shadycss/src/scoping-shim.js
@@ -282,16 +282,33 @@ export default class ScopingShim {
   }
 
   /**
-   * Hook for performing ShadyCSS behavior for each ShadyDOM insertBefore call.
+   * Update the given host to account for any changes that affect the scope of
+   * its descendant shadow parts.
    *
-   * @param {!HTMLElement} parentNode
-   * @param {!HTMLElement} newNode
-   * @param {?HTMLElement} referenceNode
+   * Note the caller is responsible for providing the changed "part" and
+   * "exportparts" nodes here, because the caller may have the ability to find
+   * them more efficiently than an intrinsic walk or querySelectorAll would
+   * (e.g. ShadyDOM already walks all inserted trees).
+   *
+   * @param {!HTMLElement} host The host element.
+   * @param {!Array<!HTMLElement>} partNodes "part" nodes in the given host's
+   * shadow root. Each of these will have its "shady-part" attribute updated
+   * according to the host's scope.
+   * @param {!Array<!HTMLElement>} exportPartsNodes "exportparts" nodes in this
+   * host's shadow root. The shadow roots of each of these will be walked, and
+   * any relevant descendant "part" nodes will have their "shady-part"
+   * attributes updated.
    * @return {void}
    */
-  onInsertBefore(parentNode, newNode, referenceNode) {
-    if (shadowParts.shadowPartsActive()) {
-      shadowParts.onInsertBefore(parentNode, newNode, referenceNode);
+  styleShadowParts(host, partNodes, exportPartsNodes) {
+    if (partNodes.length > 0) {
+      shadowParts.styleShadowParts(host, partNodes);
+    }
+    for (const exporter of exportPartsNodes) {
+      const exports = shadowParts.parseExportPartsAttribute(
+        exporter.getAttribute('exportparts')
+      ).map(({inner}) => inner);
+      shadowParts.refreshShadyPartAttributes(exporter, exports);
     }
   }
 

--- a/packages/shadycss/src/shadow-parts.js
+++ b/packages/shadycss/src/shadow-parts.js
@@ -413,7 +413,7 @@ export function onRemoveExportPartsAttribute(element, oldValue) {
  * @param {!Array<!string>} staleNames The part names which have changed.
  * @return {void}
  */
-function refreshShadyPartAttributes(host, staleNames) {
+export function refreshShadyPartAttributes(host, staleNames) {
   if (staleNames.length === 0) {
     return;
   }
@@ -449,72 +449,6 @@ function refreshShadyPartAttributes(host, staleNames) {
     }
     if (staleInnerNames.length > 0) {
       refreshShadyPartAttributes(exporter, staleInnerNames);
-    }
-  }
-}
-
-/* eslint-disable no-unused-vars */
-/**
- * Add "shady-part" attributes to new nodes on insertion.
- *
- * This function will be called by ShadyDOM during any insertBefore call,
- * before the native insert has occured.
- *
- * @param {!HTMLElement} parentNode
- * @param {!HTMLElement} newNode
- * @param {?HTMLElement} referenceNode
- * @return {void}
- */
-export function onInsertBefore(parentNode, newNode, referenceNode) {
-  /* eslint-enable no-unused-vars */
-  if (newNode instanceof Text || newNode instanceof Comment) {
-    // No parts in text or comments.
-    return;
-  }
-  if (!parentNode.getRootNode) {
-    // TODO(aomarks) We're in noPatch mode. Wrap where needed and add tests.
-    // https://github.com/webcomponents/polyfills/issues/343
-    return;
-  }
-  const root = parentNode.getRootNode();
-  if (root === document) {
-    // Parts in the document scope would never have any effect. Return early so
-    // we don't waste time querying it.
-    return;
-  }
-  const host = root.host;
-  if (!host) {
-    // If there's no host, we're not connected, so no part styles could apply
-    // here.
-    return;
-  }
-  let partNodes = newNode.querySelectorAll('[part]');
-  // TODO(aomarks) We should be able to get much better performance over the
-  // querySelectorAll calls here by integrating the part check into the walk
-  // that ShadyDOM already does to find slots.
-  // https://github.com/webcomponents/polyfills/issues/345
-  if (newNode instanceof HTMLElement && newNode.hasAttribute('part')) {
-    partNodes = [newNode, ...partNodes];
-  }
-  if (partNodes.length > 0) {
-    styleShadowParts(host, partNodes);
-  }
-  // Handle "exportparts" nodes moving from one root to another. In this case,
-  // any descendant part nodes have already been inserted, so we can't rely on
-  // the upwards-walk that we would normally get from an insert call. We can
-  // skip this work if we're inserting from a DocumentFragment, though, because
-  // it's safe to assume in that case that the children have never been
-  // connected anywhere else.
-  if (!(newNode instanceof DocumentFragment)) {
-    let exporters = newNode.querySelectorAll('[exportparts]');
-    if (newNode instanceof HTMLElement && newNode.hasAttribute('exportparts')) {
-      exporters = [newNode, ...exporters];
-    }
-    for (const exporter of exporters) {
-      const exports = parseExportPartsAttribute(
-        exporter.getAttribute('exportparts')
-      ).map(({inner}) => inner);
-      refreshShadyPartAttributes(exporter, exports);
     }
   }
 }

--- a/packages/shadydom/src/patches/Node.js
+++ b/packages/shadydom/src/patches/Node.js
@@ -308,7 +308,33 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
         !currentScopeIsCorrect(node, newScopeName);
     const needsSlotFinding = ownerRoot && !node['__noInsertionPoint'] &&
         (!preferPerformance || node.nodeType === Node.DOCUMENT_FRAGMENT_NODE);
-    if (needsSlotFinding || needsScoping) {
+
+    const partNodes = [];
+    const needsPartFinding =
+      // Only look for parts if there are known ::part rules active on the page,
+      // and if shadow parts support hasn't been forced off.
+      shadowPartsActive() &&
+      // ownerRoot is undefined if we're inserting into the main document, and
+      // host is undefined if we're not connected. Part rules can't apply in
+      // either case.
+      ownerRoot && ownerRoot.host &&
+      // Comments etc. can't contain part nodes.
+      (node.nodeType === Node.ELEMENT_NODE ||
+        node.nodeType === Node.DOCUMENT_FRAGMENT_NODE);
+
+    const exportpartsNodes = [];
+    const needsExportpartsFinding = needsPartFinding &&
+      // There's no need to look for exportparts nodes when we're inserting a
+      // fragment, because its not possible for any child custom elements to
+      // themselves have a shadow DOM yet. Once those custom elements render,
+      // this function will be invoked for them, and if any parts are found,
+      // we'll walk back _up_ the tree to find any relevant exportsparts. The
+      // only reason we need to sometimes search for exportparts here is to
+      // cover the case where an exportparts node has moved from one shadow root
+      // to another.
+      node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE;
+
+    if (needsSlotFinding || needsScoping || needsPartFinding) {
       // NOTE: avoid node.removeChild as this *can* trigger another patched
       // method (e.g. custom elements) and we want only the shady method to run.
       // The following table describes what style scoping actions should happen as a result of this insertion.
@@ -328,6 +354,12 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
         }
         if (needsScoping) {
           replaceShadyScoping(node, newScopeName, oldScopeName);
+        }
+        if (needsPartFinding && node.hasAttribute('part')) {
+          partNodes.push(node);
+        }
+        if (needsExportpartsFinding && node.hasAttribute('exportparts')) {
+          exportpartsNodes.push(node);
         }
       });
     }
@@ -357,15 +389,6 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
         ownerRoot._asyncRender();
       }
     }
-    if (shadowPartsActive()) {
-      const shim = getScopingShim();
-      if (shim) {
-        // Note that we do want to call this before the actual native insert,
-        // because in the case that we're inserting from a DocumentFragment,
-        // we want to know exactly which new child nodes are being inserted.
-        shim['onInsertBefore'](this, node, ref_node);
-      }
-    }
     if (allowNativeInsert) {
       // if adding to a shadyRoot, add to host instead
       let container = utils.isShadyRoot(this) ?
@@ -383,6 +406,12 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     // We correct this by calling `adoptNode`.
     } else if (node.ownerDocument !== this.ownerDocument) {
       this.ownerDocument.adoptNode(node);
+    }
+    if (partNodes.length > 0 || exportpartsNodes.length > 0) {
+      const shim = getScopingShim();
+      if (shim) {
+        shim['styleShadowParts'](ownerRoot.host, partNodes, exportpartsNodes);
+      }
     }
     return node;
   },


### PR DESCRIPTION
Before this change, any mutation to a shimmed shadow root triggered a `querySelectorAll` for `part` nodes that might be contained by it.

Now, we instead piggy-back on the existing walk that Shady DOM already does on mutations (e.g. to look for slots), and look for `part` attributes there.

This gives us a 10-13% performance improvement in a benchmark (also in this PR) where we insert 1000 elements, where each element provides some part rule to a child.

![Screen Shot 2020-07-28 at 1 43 17 PM](https://user-images.githubusercontent.com/48894/88719823-ba940e80-d0d8-11ea-97bb-ecefe1cbcef5.png)

Fixes https://github.com/webcomponents/polyfills/issues/345
