### PR TITLE
formdata: Capture browser APIs used in `dispatchFormdataForSubmission`.

### DIFF
--- a/packages/formdata-event/CHANGELOG.md
+++ b/packages/formdata-event/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Capture browser APIs used in `dispatchFormdataForSubmission`.
+  ([#370](https://github.com/webcomponents/polyfills/pull/370))
 - Modify the existing form to submit data from the FormData object.
   ([#361](https://github.com/webcomponents/polyfills/pull/361))
 - formdata event polyfill: Add support for legacy browsers.

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -19,6 +19,7 @@ import {methods as DocumentMethods} from './environment/document.js';
 import {document} from './environment/globals.js';
 import {descriptors as HTMLInputElementDescriptors} from './environment/html_input_element.js';
 import {appendChild, getParentNode, insertBefore} from './environment_api/node.js';
+import {hasAttribute, getAttribute, removeAttribute, setAttribute} from './environment_api/element.js';
 import {getElements} from './environment_api/html_form_element.js';
 import {getEntries} from './wrappers/form_data.js';
 
@@ -77,12 +78,12 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
     const elements = getElements(form);
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i];
-      if (element.getAttribute('name') === name) {
+      if (getAttribute(element, 'name') === name) {
         if (!disabledInitialValue.has(element)) {
-          disabledInitialValue.set(element, element.getAttribute('disabled'));
+          disabledInitialValue.set(element, getAttribute(element, 'disabled'));
         }
 
-        element.setAttribute('disabled', '');
+        setAttribute(element, 'disabled', '');
       }
     }
   };
@@ -94,7 +95,7 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
     const elements = getElements(form);
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i];
-      if (element.getAttribute('name') === name && !element.hasAttribute('disabled')) {
+      if (getAttribute(element, 'name') === name && !hasAttribute(element, 'disabled')) {
         return element;
       }
     }
@@ -149,11 +150,11 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
 
     // Restore the 'disabled' attribute state of any modified form elements.
     for (const [element, value] of disabledInitialValue) {
-      if (element.getAttribute('disabled') !== value) {
+      if (getAttribute(element, 'disabled') !== value) {
         if (value === null) {
-          element.removeAttribute('disabled');
+          removeAttribute(element, 'disabled');
         } else {
-          element.setAttribute('disabled', value);
+          setAttribute(element, 'disabled', value);
         }
       }
     }

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -17,7 +17,7 @@
 
 import {methods as DocumentMethods} from './environment/document.js';
 import {document} from './environment/globals.js';
-import {getParentNode} from './environment_api/node.js';
+import {getParentNode, insertBefore} from './environment_api/node.js';
 import {descriptors as HTMLInputElementDescriptors} from './environment/html_input_element.js';
 import {getEntries} from './wrappers/form_data.js';
 
@@ -54,7 +54,7 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
     HTMLInputElementDescriptors.value.set!.call(input, value);
 
     if (beforeNode !== undefined) {
-      getParentNode(beforeNode)!.insertBefore(input, beforeNode);
+      insertBefore(getParentNode(beforeNode)!, input, beforeNode);
     } else {
       form.appendChild(input);
     }

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -20,6 +20,7 @@ import {document} from './environment/globals.js';
 import {descriptors as HTMLInputElementDescriptors} from './environment/html_input_element.js';
 import {appendChild, getParentNode, insertBefore, removeChild} from './environment_api/node.js';
 import {hasAttribute, getAttribute, removeAttribute, setAttribute} from './environment_api/element.js';
+import {getLength} from './environment_api/html_collection.js';
 import {getElements} from './environment_api/html_form_element.js';
 import {getEntries} from './wrappers/form_data.js';
 
@@ -76,7 +77,8 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
    */
   const disableExistingEntries = (name: string) => {
     const elements = getElements(form);
-    for (let i = 0; i < elements.length; i++) {
+    const length = getLength(elements);
+    for (let i = 0; i < length; i++) {
       const element = elements[i];
       if (getAttribute(element, 'name') === name) {
         if (!disabledInitialValue.has(element)) {
@@ -93,7 +95,8 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
    */
   const findFirstEnabledElement = (name: string): Element | undefined => {
     const elements = getElements(form);
-    for (let i = 0; i < elements.length; i++) {
+    const length = getLength(elements);
+    for (let i = 0; i < length; i++) {
       const element = elements[i];
       if (getAttribute(element, 'name') === name && !hasAttribute(element, 'disabled')) {
         return element;

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -18,7 +18,7 @@
 import {methods as DocumentMethods} from './environment/document.js';
 import {document} from './environment/globals.js';
 import {descriptors as HTMLInputElementDescriptors} from './environment/html_input_element.js';
-import {appendChild, getParentNode, insertBefore} from './environment_api/node.js';
+import {appendChild, getParentNode, insertBefore, removeChild} from './environment_api/node.js';
 import {hasAttribute, getAttribute, removeAttribute, setAttribute} from './environment_api/element.js';
 import {getElements} from './environment_api/html_form_element.js';
 import {getEntries} from './wrappers/form_data.js';
@@ -145,7 +145,10 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
   setTimeout(() => {
     // Remove any inserted inputs.
     for (const input of insertedInputs) {
-      getParentNode(input)?.removeChild(input);
+      const parent = getParentNode(input);
+      if (parent) {
+        removeChild(parent, input);
+      }
     }
 
     // Restore the 'disabled' attribute state of any modified form elements.

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -17,6 +17,7 @@
 
 import {methods as DocumentMethods} from './environment/document.js';
 import {document} from './environment/globals.js';
+import {descriptors as HTMLInputElementDescriptors} from './environment/html_input_element.js';
 import {getEntries} from './wrappers/form_data.js';
 
 /**
@@ -47,9 +48,9 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
    */
   const insertEntry = (name: string, value: string, beforeNode?: Node) => {
     const input = DocumentMethods.createElement.call(document, 'input') as HTMLInputElement;
-    input.type = 'hidden';
-    input.name = name;
-    input.value = value;
+    HTMLInputElementDescriptors.type.set!.call(input, 'hidden');
+    HTMLInputElementDescriptors.name.set!.call(input, name);
+    HTMLInputElementDescriptors.value.set!.call(input, value);
 
     if (beforeNode !== undefined) {
       beforeNode.parentNode!.insertBefore(input, beforeNode);

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -17,6 +17,7 @@
 
 import {methods as DocumentMethods} from './environment/document.js';
 import {document} from './environment/globals.js';
+import {getParentNode} from './environment_api/node.js';
 import {descriptors as HTMLInputElementDescriptors} from './environment/html_input_element.js';
 import {getEntries} from './wrappers/form_data.js';
 
@@ -53,7 +54,7 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
     HTMLInputElementDescriptors.value.set!.call(input, value);
 
     if (beforeNode !== undefined) {
-      beforeNode.parentNode!.insertBefore(input, beforeNode);
+      getParentNode.call(beforeNode)!.insertBefore(input, beforeNode);
     } else {
       form.appendChild(input);
     }
@@ -140,7 +141,7 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
   setTimeout(() => {
     // Remove any inserted inputs.
     for (const input of insertedInputs) {
-      input.parentNode?.removeChild(input);
+      getParentNode.call(input)?.removeChild(input);
     }
 
     // Restore the 'disabled' attribute state of any modified form elements.

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -17,8 +17,9 @@
 
 import {methods as DocumentMethods} from './environment/document.js';
 import {document} from './environment/globals.js';
-import {appendChild, getParentNode, insertBefore} from './environment_api/node.js';
 import {descriptors as HTMLInputElementDescriptors} from './environment/html_input_element.js';
+import {appendChild, getParentNode, insertBefore} from './environment_api/node.js';
+import {getElements} from './environment_api/html_form_element.js';
 import {getEntries} from './wrappers/form_data.js';
 
 /**
@@ -73,8 +74,9 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
    * those inserted by `insertEntry`.
    */
   const disableExistingEntries = (name: string) => {
-    for (let i = 0; i < form.elements.length; i++) {
-      const element = form.elements[i];
+    const elements = getElements(form);
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
       if (element.getAttribute('name') === name) {
         if (!disabledInitialValue.has(element)) {
           disabledInitialValue.set(element, element.getAttribute('disabled'));
@@ -89,8 +91,9 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
    * Finds the first non-disabled form-associated element with a given name.
    */
   const findFirstEnabledElement = (name: string): Element | undefined => {
-    for (let i = 0; i < form.elements.length; i++) {
-      const element = form.elements[i];
+    const elements = getElements(form);
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
       if (element.getAttribute('name') === name && !element.hasAttribute('disabled')) {
         return element;
       }

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -22,7 +22,7 @@ import {appendChild, getParentNode, insertBefore, removeChild} from './environme
 import {hasAttribute, getAttribute, removeAttribute, setAttribute} from './environment_api/element.js';
 import {getLength} from './environment_api/html_collection.js';
 import {getElements} from './environment_api/html_form_element.js';
-import {getEntries} from './wrappers/form_data.js';
+import {FormData, getEntries} from './wrappers/form_data.js';
 
 /**
  * Dispatches a 'formdata' event to `form` and modifies the form to reflect any

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -15,6 +15,7 @@
  * object passed along with the event.
  */
 
+import {document} from './environment/globals.js';
 import {getEntries} from './wrappers/form_data.js';
 
 /**

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -17,7 +17,7 @@
 
 import {methods as DocumentMethods} from './environment/document.js';
 import {document} from './environment/globals.js';
-import {getParentNode, insertBefore} from './environment_api/node.js';
+import {appendChild, getParentNode, insertBefore} from './environment_api/node.js';
 import {descriptors as HTMLInputElementDescriptors} from './environment/html_input_element.js';
 import {getEntries} from './wrappers/form_data.js';
 
@@ -56,7 +56,7 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
     if (beforeNode !== undefined) {
       insertBefore(getParentNode(beforeNode)!, input, beforeNode);
     } else {
-      form.appendChild(input);
+      appendChild(form, input);
     }
     insertedInputs.push(input);
   };

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -51,7 +51,7 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
    * `insertBeforeNode` will insert the new input before that node.
    */
   const insertEntry = (name: string, value: string, beforeNode?: Node) => {
-    const input = createElement(document, 'input') as HTMLInputElement;
+    const input = createElement(document, 'input');
     setType(input, 'hidden');
     setName(input, name);
     setValue(input, value);

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -15,6 +15,7 @@
  * object passed along with the event.
  */
 
+import {methods as DocumentMethods} from './environment/document.js';
 import {document} from './environment/globals.js';
 import {getEntries} from './wrappers/form_data.js';
 
@@ -45,7 +46,7 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
    * `insertBeforeNode` will insert the new input before that node.
    */
   const insertEntry = (name: string, value: string, beforeNode?: Node) => {
-    const input = document.createElement('input');
+    const input = DocumentMethods.createElement.call(document, 'input') as HTMLInputElement;
     input.type = 'hidden';
     input.name = name;
     input.value = value;

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -17,7 +17,7 @@
 
 import {methods as DocumentMethods} from './environment/document.js';
 import {document} from './environment/globals.js';
-import {descriptors as HTMLInputElementDescriptors} from './environment/html_input_element.js';
+import {setType, setName, setValue} from './environment_api/html_input_element.js';
 import {appendChild, getParentNode, insertBefore, removeChild} from './environment_api/node.js';
 import {hasAttribute, getAttribute, removeAttribute, setAttribute} from './environment_api/element.js';
 import {getLength} from './environment_api/html_collection.js';
@@ -52,9 +52,9 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
    */
   const insertEntry = (name: string, value: string, beforeNode?: Node) => {
     const input = DocumentMethods.createElement.call(document, 'input') as HTMLInputElement;
-    HTMLInputElementDescriptors.type.set!.call(input, 'hidden');
-    HTMLInputElementDescriptors.name.set!.call(input, name);
-    HTMLInputElementDescriptors.value.set!.call(input, value);
+    setType(input, 'hidden');
+    setName(input, name);
+    setValue(input, value);
 
     if (beforeNode !== undefined) {
       insertBefore(getParentNode(beforeNode)!, input, beforeNode);

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -54,7 +54,7 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
     HTMLInputElementDescriptors.value.set!.call(input, value);
 
     if (beforeNode !== undefined) {
-      getParentNode.call(beforeNode)!.insertBefore(input, beforeNode);
+      getParentNode(beforeNode)!.insertBefore(input, beforeNode);
     } else {
       form.appendChild(input);
     }
@@ -141,7 +141,7 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
   setTimeout(() => {
     // Remove any inserted inputs.
     for (const input of insertedInputs) {
-      getParentNode.call(input)?.removeChild(input);
+      getParentNode(input)?.removeChild(input);
     }
 
     // Restore the 'disabled' attribute state of any modified form elements.

--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -15,8 +15,8 @@
  * object passed along with the event.
  */
 
-import {methods as DocumentMethods} from './environment/document.js';
 import {document} from './environment/globals.js';
+import {createElement} from './environment_api/document.js';
 import {setType, setName, setValue} from './environment_api/html_input_element.js';
 import {appendChild, getParentNode, insertBefore, removeChild} from './environment_api/node.js';
 import {hasAttribute, getAttribute, removeAttribute, setAttribute} from './environment_api/element.js';
@@ -51,7 +51,7 @@ export const dispatchFormdataForSubmission = (form: HTMLFormElement) => {
    * `insertBeforeNode` will insert the new input before that node.
    */
   const insertEntry = (name: string, value: string, beforeNode?: Node) => {
-    const input = DocumentMethods.createElement.call(document, 'input') as HTMLInputElement;
+    const input = createElement(document, 'input') as HTMLInputElement;
     setType(input, 'hidden');
     setName(input, name);
     setValue(input, value);

--- a/packages/formdata-event/ts_src/environment/document.ts
+++ b/packages/formdata-event/ts_src/environment/document.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved. This
+ * code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be
+ * found at http://polymer.github.io/AUTHORS.txt The complete set of
+ * contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt Code
+ * distributed by Google as part of the polymer project is also subject to an
+ * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+export const constructor = window.Document;
+
+export const prototype = constructor.prototype;
+
+export const methods = {
+  createElement: prototype.createElement,
+  createEvent: prototype.createEvent,
+};

--- a/packages/formdata-event/ts_src/environment/element.ts
+++ b/packages/formdata-event/ts_src/environment/element.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved. This
+ * code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be
+ * found at http://polymer.github.io/AUTHORS.txt The complete set of
+ * contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt Code
+ * distributed by Google as part of the polymer project is also subject to an
+ * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+export const constructor = window.Element;
+
+export const prototype = constructor.prototype;
+
+export const methods = {
+  getAttribute: prototype.getAttribute,
+  hasAttribute: prototype.hasAttribute,
+  removeAttribute: prototype.removeAttribute,
+  setAttribute: prototype.setAttribute,
+};

--- a/packages/formdata-event/ts_src/environment/event.ts
+++ b/packages/formdata-event/ts_src/environment/event.ts
@@ -13,6 +13,10 @@ export const constructor = window.Event;
 
 export const prototype = constructor.prototype;
 
+export const methods = {
+  initEvent: prototype.initEvent,
+};
+
 export const descriptors = {
   target: Object.getOwnPropertyDescriptor(prototype, 'target')!,
   defaultPrevented: Object.getOwnPropertyDescriptor(prototype, 'defaultPrevented')!,

--- a/packages/formdata-event/ts_src/environment/globals.ts
+++ b/packages/formdata-event/ts_src/environment/globals.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved. This
+ * code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be
+ * found at http://polymer.github.io/AUTHORS.txt The complete set of
+ * contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt Code
+ * distributed by Google as part of the polymer project is also subject to an
+ * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+export const document = window.document;

--- a/packages/formdata-event/ts_src/environment/html_collection.ts
+++ b/packages/formdata-event/ts_src/environment/html_collection.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved. This
+ * code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be
+ * found at http://polymer.github.io/AUTHORS.txt The complete set of
+ * contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt Code
+ * distributed by Google as part of the polymer project is also subject to an
+ * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+export const constructor = window.HTMLCollection;
+
+export const prototype = constructor.prototype;
+
+export const descriptors = {
+  length: Object.getOwnPropertyDescriptor(prototype, 'length'),
+};

--- a/packages/formdata-event/ts_src/environment/html_input_element.ts
+++ b/packages/formdata-event/ts_src/environment/html_input_element.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved. This
+ * code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be
+ * found at http://polymer.github.io/AUTHORS.txt The complete set of
+ * contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt Code
+ * distributed by Google as part of the polymer project is also subject to an
+ * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+export const constructor = window.HTMLInputElement;
+
+export const prototype = constructor.prototype;
+
+export const descriptors = {
+  name: Object.getOwnPropertyDescriptor(prototype, 'name')!,
+  type: Object.getOwnPropertyDescriptor(prototype, 'type')!,
+  value: Object.getOwnPropertyDescriptor(prototype, 'value')!,
+};

--- a/packages/formdata-event/ts_src/environment/html_input_element.ts
+++ b/packages/formdata-event/ts_src/environment/html_input_element.ts
@@ -14,7 +14,7 @@ export const constructor = window.HTMLInputElement;
 export const prototype = constructor.prototype;
 
 export const descriptors = {
-  name: Object.getOwnPropertyDescriptor(prototype, 'name')!,
-  type: Object.getOwnPropertyDescriptor(prototype, 'type')!,
-  value: Object.getOwnPropertyDescriptor(prototype, 'value')!,
+  name: Object.getOwnPropertyDescriptor(prototype, 'name'),
+  type: Object.getOwnPropertyDescriptor(prototype, 'type'),
+  value: Object.getOwnPropertyDescriptor(prototype, 'value'),
 };

--- a/packages/formdata-event/ts_src/environment/node.ts
+++ b/packages/formdata-event/ts_src/environment/node.ts
@@ -15,6 +15,7 @@ export const prototype = constructor.prototype;
 
 export const methods = {
   addEventListener: prototype.addEventListener,
+  appendChild: prototype.appendChild,
   dispatchEvent: prototype.dispatchEvent,
   getRootNode: prototype.getRootNode,
   insertBefore: prototype.insertBefore,

--- a/packages/formdata-event/ts_src/environment/node.ts
+++ b/packages/formdata-event/ts_src/environment/node.ts
@@ -19,6 +19,7 @@ export const methods = {
   dispatchEvent: prototype.dispatchEvent,
   getRootNode: prototype.getRootNode,
   insertBefore: prototype.insertBefore,
+  removeChild: prototype.removeChild,
   removeEventListener: prototype.removeEventListener,
 };
 

--- a/packages/formdata-event/ts_src/environment/node.ts
+++ b/packages/formdata-event/ts_src/environment/node.ts
@@ -15,9 +15,10 @@ export const prototype = constructor.prototype;
 
 export const methods = {
   addEventListener: prototype.addEventListener,
-  removeEventListener: prototype.removeEventListener,
   dispatchEvent: prototype.dispatchEvent,
   getRootNode: prototype.getRootNode,
+  insertBefore: prototype.insertBefore,
+  removeEventListener: prototype.removeEventListener,
 };
 
 export const descriptors = {

--- a/packages/formdata-event/ts_src/environment_api/document.ts
+++ b/packages/formdata-event/ts_src/environment_api/document.ts
@@ -11,10 +11,10 @@
 
 import {methods as DocumentMethods} from '../environment/document.js';
 
-export const createElement = (
+export const createElement = <K extends keyof HTMLElementTagNameMap>(
   doc: Document,
-  localName: string,
+  localName: K,
   options?: ElementCreationOptions,
-): Element => {
-  return DocumentMethods.createElement.call(doc, localName, options);
+): HTMLElementTagNameMap[K] => {
+  return DocumentMethods.createElement.call(doc, localName, options) as HTMLElementTagNameMap[K];
 };

--- a/packages/formdata-event/ts_src/environment_api/document.ts
+++ b/packages/formdata-event/ts_src/environment_api/document.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved. This
+ * code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be
+ * found at http://polymer.github.io/AUTHORS.txt The complete set of
+ * contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt Code
+ * distributed by Google as part of the polymer project is also subject to an
+ * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {methods as DocumentMethods} from '../environment/document.js';
+
+export const createElement = (
+  doc: Document,
+  localName: string,
+  options?: ElementCreationOptions,
+): Element => {
+  return DocumentMethods.createElement.call(doc, localName, options);
+};

--- a/packages/formdata-event/ts_src/environment_api/element.ts
+++ b/packages/formdata-event/ts_src/environment_api/element.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved. This
+ * code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be
+ * found at http://polymer.github.io/AUTHORS.txt The complete set of
+ * contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt Code
+ * distributed by Google as part of the polymer project is also subject to an
+ * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {methods as ElementMethods} from '../environment/element.js';
+
+export const hasAttribute = (element: Element, name: string): boolean => {
+  return ElementMethods.hasAttribute.call(element, name);
+};
+
+export const getAttribute = (element: Element, name: string): string | null => {
+  return ElementMethods.getAttribute.call(element, name);
+};
+
+export const removeAttribute = (element: Element, name: string): void => {
+  ElementMethods.removeAttribute.call(element, name);
+};
+
+export const setAttribute = (element: Element, name: string, value: string): void => {
+  ElementMethods.setAttribute.call(element, name, value);
+};

--- a/packages/formdata-event/ts_src/environment_api/event.ts
+++ b/packages/formdata-event/ts_src/environment_api/event.ts
@@ -9,7 +9,7 @@
  * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import {descriptors as EventDescriptors} from '../environment/event.js';
+import {descriptors as EventDescriptors, methods as EventMethods} from '../environment/event.js';
 
 // `Object.getOwnPropertyDescriptor(Event.prototype, 'target')` is undefined
 // in Chrome 41.
@@ -28,3 +28,12 @@ const defaultPreventedGetter = EventDescriptors.defaultPrevented?.get;
 export const getDefaultPrevented = defaultPreventedGetter !== undefined
     ? (e: Event) => { return defaultPreventedGetter.call(e); }
     : (e: Event) => { return e.defaultPrevented; };
+
+export const initEvent = (
+  event: Event,
+  type: string,
+  bubbles: boolean = false,
+  cancelable: boolean = false,
+) => {
+  EventMethods.initEvent.call(event, type, bubbles, cancelable);
+};

--- a/packages/formdata-event/ts_src/environment_api/html_collection.ts
+++ b/packages/formdata-event/ts_src/environment_api/html_collection.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved. This
+ * code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be
+ * found at http://polymer.github.io/AUTHORS.txt The complete set of
+ * contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt Code
+ * distributed by Google as part of the polymer project is also subject to an
+ * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {descriptors as HTMLCollectionDescriptors} from '../environment/html_collection.js';
+
+const lengthDescriptor = HTMLCollectionDescriptors.length ?? {};
+const lengthGetter = lengthDescriptor.get ?? function(this: HTMLCollection) { return this.length; };
+export const getLength = (collection: HTMLCollection): number => lengthGetter.call(collection);

--- a/packages/formdata-event/ts_src/environment_api/html_form_element.ts
+++ b/packages/formdata-event/ts_src/environment_api/html_form_element.ts
@@ -9,14 +9,8 @@
  * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-export const constructor = window.HTMLFormElement;
+import {descriptors as HTMLFormElementDescriptors} from '../environment/html_form_element.js';
 
-export const prototype = constructor.prototype;
-
-export const methods = {
-  submit: prototype.submit,
-};
-
-export const descriptors = {
-  elements: Object.getOwnPropertyDescriptor(prototype, 'elements')!,
+export const getElements = (form: HTMLFormElement) => {
+  return HTMLFormElementDescriptors.elements.get!.call(form);
 };

--- a/packages/formdata-event/ts_src/environment_api/html_input_element.ts
+++ b/packages/formdata-event/ts_src/environment_api/html_input_element.ts
@@ -11,9 +11,12 @@
 
 import {descriptors as HTMLInputElementDescriptors} from '../environment/html_input_element.js';
 
+// `type` is an own property with a data descriptor on each HTMLInputElement in
+// Chrome 41.
+const typeDescriptor = HTMLInputElementDescriptors.type ?? {};
 // `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'type').set` is
 // undefined in Safari 9.
-const typeSetter = HTMLInputElementDescriptors.type.set ??
+const typeSetter = typeDescriptor.set ??
     function(this: HTMLInputElement, type: string) {
   this.type = type;
 };
@@ -21,9 +24,12 @@ export const setType = (input: HTMLInputElement, type: string) => {
   return typeSetter.call(input, type);
 };
 
+// `name` is an own property with a data descriptor on each HTMLInputElement in
+// Chrome 41.
+const nameDescriptor = HTMLInputElementDescriptors.name ?? {};
 // `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'name').set` is
 // undefined in Safari 9.
-const nameSetter = HTMLInputElementDescriptors.name.set ??
+const nameSetter = nameDescriptor.set ??
     function(this: HTMLInputElement, name: string) {
   this.name = name;
 };
@@ -31,9 +37,12 @@ export const setName = (input: HTMLInputElement, name: string) => {
   return nameSetter.call(input, name);
 };
 
+// `value` is an own property with a data descriptor on each HTMLInputElement in
+// Chrome 41.
+const valueDescriptor = HTMLInputElementDescriptors.value ?? {};
 // `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set` is
 // undefined in Safari 9.
-const valueSetter = HTMLInputElementDescriptors.value.set ??
+const valueSetter = valueDescriptor.set ??
     function(this: HTMLInputElement, value: string) {
   this.value = value;
 };

--- a/packages/formdata-event/ts_src/environment_api/html_input_element.ts
+++ b/packages/formdata-event/ts_src/environment_api/html_input_element.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved. This
+ * code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be
+ * found at http://polymer.github.io/AUTHORS.txt The complete set of
+ * contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt Code
+ * distributed by Google as part of the polymer project is also subject to an
+ * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {descriptors as HTMLInputElementDescriptors} from '../environment/html_input_element.js';
+
+// `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'type').set` is
+// undefined in Safari 9.
+const typeSetter = HTMLInputElementDescriptors.type.set ??
+    function(this: HTMLInputElement, type: string) {
+  this.type = type;
+};
+export const setType = (input: HTMLInputElement, type: string) => {
+  return typeSetter.call(input, type);
+};
+
+// `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'name').set` is
+// undefined in Safari 9.
+const nameSetter = HTMLInputElementDescriptors.name.set ??
+    function(this: HTMLInputElement, name: string) {
+  this.name = name;
+};
+export const setName = (input: HTMLInputElement, name: string) => {
+  return nameSetter.call(input, name);
+};
+
+// `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set` is
+// undefined in Safari 9.
+const valueSetter = HTMLInputElementDescriptors.value.set ??
+    function(this: HTMLInputElement, value: string) {
+  this.value = value;
+};
+export const setValue = (input: HTMLInputElement, value: string) => {
+  return valueSetter.call(input, value);
+};

--- a/packages/formdata-event/ts_src/environment_api/node.ts
+++ b/packages/formdata-event/ts_src/environment_api/node.ts
@@ -35,6 +35,10 @@ export const getRootNode =
   return current;
 };
 
+export const removeChild = (node: Node, child: Node): Node => {
+  return NodeMethods.removeChild.call(node, child);
+};
+
 export const appendChild = (node: Node, child: Node): Node | null => {
   return NodeMethods.appendChild.call(node, child);
 };

--- a/packages/formdata-event/ts_src/environment_api/node.ts
+++ b/packages/formdata-event/ts_src/environment_api/node.ts
@@ -34,3 +34,8 @@ export const getRootNode =
   }
   return current;
 };
+
+export const insertBefore =
+    (node: Node, newNode: Node, refNode: Node | null): Node | null => {
+  return NodeMethods.insertBefore.call(node, newNode, refNode);
+};

--- a/packages/formdata-event/ts_src/environment_api/node.ts
+++ b/packages/formdata-event/ts_src/environment_api/node.ts
@@ -17,20 +17,20 @@ import {methods as NodeMethods, descriptors as NodeDescriptors} from '../environ
 // undefined in Safari 9.
 const parentNodeGetter = NodeDescriptors.parentNode?.get;
 export const getParentNode = parentNodeGetter !== undefined
-    ? function(this: Node) { return parentNodeGetter.call(this); }
-    : function(this: Node) { return this.parentNode; };
+    ? (node: Node) => { return parentNodeGetter.call(node); }
+    : (node: Node) => { return node.parentNode; };
 
-export const getRootNode: Node['getRootNode'] = function(
-    this: Node, options: GetRootNodeOptions | undefined = undefined) {
+export const getRootNode =
+    (node: Node, options: GetRootNodeOptions | undefined = undefined) => {
   if (NodeMethods.getRootNode !== undefined) {
-    return NodeMethods.getRootNode.call(this, options);
+    return NodeMethods.getRootNode.call(node, options);
   }
 
-  let current = this;
-  let parent = getParentNode.call(current);
+  let current = node;
+  let parent = getParentNode(current);
   while (parent !== null) {
     current = parent;
-    parent = getParentNode.call(parent);
+    parent = getParentNode(parent);
   }
   return current;
 };

--- a/packages/formdata-event/ts_src/environment_api/node.ts
+++ b/packages/formdata-event/ts_src/environment_api/node.ts
@@ -35,6 +35,10 @@ export const getRootNode =
   return current;
 };
 
+export const appendChild = (node: Node, child: Node): Node | null => {
+  return NodeMethods.appendChild.call(node, child);
+};
+
 export const insertBefore =
     (node: Node, newNode: Node, refNode: Node | null): Node | null => {
   return NodeMethods.insertBefore.call(node, newNode, refNode);

--- a/packages/formdata-event/ts_src/environment_api/node.ts
+++ b/packages/formdata-event/ts_src/environment_api/node.ts
@@ -16,9 +16,9 @@ import {methods as NodeMethods, descriptors as NodeDescriptors} from '../environ
 // `Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode').get` is
 // undefined in Safari 9.
 const parentNodeGetter = NodeDescriptors.parentNode?.get;
-const getParentNode = parentNodeGetter !== undefined
-    ? (node: Node) => { return parentNodeGetter.call(node); }
-    : (node: Node) => { return node.parentNode; };
+export const getParentNode = parentNodeGetter !== undefined
+    ? function(this: Node) { return parentNodeGetter.call(this); }
+    : function(this: Node) { return this.parentNode; };
 
 export const getRootNode: Node['getRootNode'] = function(
     this: Node, options: GetRootNodeOptions | undefined = undefined) {
@@ -27,10 +27,10 @@ export const getRootNode: Node['getRootNode'] = function(
   }
 
   let current = this;
-  let parent = getParentNode(current);
+  let parent = getParentNode.call(current);
   while (parent !== null) {
     current = parent;
-    parent = getParentNode(parent);
+    parent = getParentNode.call(parent);
   }
   return current;
 };

--- a/packages/formdata-event/ts_src/formdata_listener_added.ts
+++ b/packages/formdata-event/ts_src/formdata_listener_added.ts
@@ -130,7 +130,7 @@ export const submitCallback = (capturingEvent: Event) => {
     return;
   }
 
-  const shallowRoot = getRootNode.call(target);
+  const shallowRoot = getRootNode(target);
 
   // Listen for the bubbling phase of any 'submit' event that reaches the root
   // node of the tree containing the target form.

--- a/packages/formdata-event/ts_src/wrappers/event.ts
+++ b/packages/formdata-event/ts_src/wrappers/event.ts
@@ -9,6 +9,7 @@
  * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+import {methods as DocumentMethods} from '../environment/document.js';
 import {constructor as EventConstructor, prototype as EventPrototype} from '../environment/event.js';
 import {document} from '../environment/globals.js';
 import {prepareWrapper, installWrapper} from './wrap_constructor.js';
@@ -30,7 +31,7 @@ export const Event: typeof window.Event = function Event(this: Event, type: stri
   try {
     _this = new EventConstructor(type, eventInit);
   } catch {
-    _this = document.createEvent('Event');
+    _this = DocumentMethods.createEvent.call(document, 'Event');
     _this.initEvent(type, eventInit.bubbles, eventInit.cancelable);
   }
   Object.setPrototypeOf(_this, Object.getPrototypeOf(this));

--- a/packages/formdata-event/ts_src/wrappers/event.ts
+++ b/packages/formdata-event/ts_src/wrappers/event.ts
@@ -12,6 +12,7 @@
 import {methods as DocumentMethods} from '../environment/document.js';
 import {constructor as EventConstructor, prototype as EventPrototype} from '../environment/event.js';
 import {document} from '../environment/globals.js';
+import {initEvent} from '../environment_api/event.js';
 import {prepareWrapper, installWrapper} from './wrap_constructor.js';
 
 // This wrapper makes Event constructible / extensible in ES5 (the compilation
@@ -32,7 +33,7 @@ export const Event: typeof window.Event = function Event(this: Event, type: stri
     _this = new EventConstructor(type, eventInit);
   } catch {
     _this = DocumentMethods.createEvent.call(document, 'Event');
-    _this.initEvent(type, eventInit.bubbles, eventInit.cancelable);
+    initEvent(_this, type, eventInit.bubbles, eventInit.cancelable);
   }
   Object.setPrototypeOf(_this, Object.getPrototypeOf(this));
   return _this;

--- a/packages/formdata-event/ts_src/wrappers/event.ts
+++ b/packages/formdata-event/ts_src/wrappers/event.ts
@@ -10,6 +10,7 @@
  */
 
 import {constructor as EventConstructor, prototype as EventPrototype} from '../environment/event.js';
+import {document} from '../environment/globals.js';
 import {prepareWrapper, installWrapper} from './wrap_constructor.js';
 
 // This wrapper makes Event constructible / extensible in ES5 (the compilation


### PR DESCRIPTION
In #361 I wrote `dispatchFormdataForSubmission` using the DOM/HTML API directly from each object. This PR captures any new API used in that function in `environment/` and `environment_api/` and uses those instead. This helps prevent the polyfill from triggering behavior of other polyfills that are added after it.