### PR TITLE
Handle `stopPropagation` and `stopImmediatePropagation` calls on the 'submit' event.

### DIFF
--- a/packages/formdata-event/CHANGELOG.md
+++ b/packages/formdata-event/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Handle `stopPropagation` and `stopImmediatePropagation` calls on the 'submit'
+  event. ([#379](https://github.com/webcomponents/polyfills/pull/379))
 - Capture browser APIs used in `dispatchFormdataForSubmission`.
   ([#370](https://github.com/webcomponents/polyfills/pull/370))
 - Modify the existing form to submit data from the FormData object.

--- a/packages/formdata-event/ts_src/environment/event.ts
+++ b/packages/formdata-event/ts_src/environment/event.ts
@@ -15,6 +15,8 @@ export const prototype = constructor.prototype;
 
 export const methods = {
   initEvent: prototype.initEvent,
+  stopImmediatePropagation: prototype?.stopImmediatePropagation,
+  stopPropagation: prototype?.stopPropagation,
 };
 
 export const descriptors = {

--- a/packages/formdata-event/ts_src/environment/event.ts
+++ b/packages/formdata-event/ts_src/environment/event.ts
@@ -20,6 +20,7 @@ export const methods = {
 };
 
 export const descriptors = {
-  target: Object.getOwnPropertyDescriptor(prototype, 'target')!,
   defaultPrevented: Object.getOwnPropertyDescriptor(prototype, 'defaultPrevented')!,
+  target: Object.getOwnPropertyDescriptor(prototype, 'target')!,
+  type: Object.getOwnPropertyDescriptor(prototype, 'type')!,
 };

--- a/packages/formdata-event/ts_src/environment_api/event.ts
+++ b/packages/formdata-event/ts_src/environment_api/event.ts
@@ -20,6 +20,8 @@ export const getTarget = targetGetter !== undefined
     ? (e: Event) => { return targetGetter.call(e); }
     : (e: Event) => { return e.target; };
 
+export const getType = (e: Event) => EventDescriptors.type.get!.call(e);
+
 // `Object.getOwnPropertyDescriptor(Event.prototype, 'defaultPrevented')` is undefined
 // in Chrome 41.
 // `Object.getOwnPropertyDescriptor(Event.prototype, 'defaultPrevented').get` is undefined

--- a/packages/formdata-event/ts_src/event_listener_array.ts
+++ b/packages/formdata-event/ts_src/event_listener_array.ts
@@ -34,6 +34,30 @@ export class EventListenerArray {
 
   get bubblingCount() { return this._listeners.filter(record => !record.capture).length; }
 
+  get lastCapturingCallback() {
+    const listeners = this._listeners;
+    for (let i = listeners.length - 1; i >= 0; i--) {
+      const item = listeners[i];
+      if (item.capture) {
+        return item.callback;
+      }
+    }
+
+    return undefined;
+  }
+
+  get lastBubblingCallback() {
+    const listeners = this._listeners;
+    for (let i = listeners.length - 1; i >= 0; i--) {
+      const item = listeners[i];
+      if (!item.capture) {
+        return item.callback;
+      }
+    }
+
+    return undefined;
+  }
+
   push(record: EventListenerRecord) {
     const {callback, capture} = record;
 

--- a/packages/formdata-event/ts_src/event_listener_array.ts
+++ b/packages/formdata-event/ts_src/event_listener_array.ts
@@ -17,7 +17,7 @@ interface EventListenerRecord {
 /**
  * EventListenerArray keeps track of an array of event listeners, including
  * enough information to determine if they would be deduplicated by the browser:
- * type (always 'formdata' here), the callback itself, and capture flag. See
+ * type, the callback itself, and capture flag. See
  * https://dom.spec.whatwg.org/#add-an-event-listener for a full description of
  * the deduplicating behavior.
  */
@@ -28,12 +28,25 @@ export class EventListenerArray {
     this._listeners = new Array<EventListenerRecord>();
   }
 
+  /**
+   * Returns the total number of listeners in the array.
+   */
   get length() { return this._listeners.length; }
 
+  /**
+   * Returns the number of capturing listeners in the array.
+   */
   get capturingCount() { return this._listeners.filter(record => record.capture).length; }
 
+  /**
+   * Returns the number of bubbling listeners in the array.
+   */
   get bubblingCount() { return this._listeners.filter(record => !record.capture).length; }
 
+  /**
+   * Returns the last capturing listener's callback, or `undefined` if no
+   * capturing listeners are in the array.
+   */
   get lastCapturingCallback() {
     const listeners = this._listeners;
     for (let i = listeners.length - 1; i >= 0; i--) {
@@ -46,6 +59,10 @@ export class EventListenerArray {
     return undefined;
   }
 
+  /**
+   * Returns the last bubbling listener's callback, or `undefined` if no
+   * capturing listeners are in the array.
+   */
   get lastBubblingCallback() {
     const listeners = this._listeners;
     for (let i = listeners.length - 1; i >= 0; i--) {
@@ -58,6 +75,12 @@ export class EventListenerArray {
     return undefined;
   }
 
+  /**
+   * Adds a new listener to the array. Listeners are deduplicated such that only
+   * the first listener with a particular callback (or callback object) and
+   * capturing option will be added to the array, any others will be ignored.
+   * See https://dom.spec.whatwg.org/#add-an-event-listener for more info.
+   */
   push(record: EventListenerRecord) {
     const {callback, capture} = record;
 
@@ -72,6 +95,10 @@ export class EventListenerArray {
     this._listeners.push(record);
   }
 
+  /**
+   * Adds the listener in the array having a given callback and capturing
+   * option, if any.
+   */
   delete(record: EventListenerRecord) {
     const {callback, capture} = record;
 

--- a/packages/formdata-event/ts_src/formdata_listener_added.ts
+++ b/packages/formdata-event/ts_src/formdata_listener_added.ts
@@ -194,7 +194,6 @@ export const wrapSubmitListener = (listener: EventListenerOrEventListenerObject)
         const submitListeners = targetToSubmitListeners.get(this)!;
         const {lastBubblingCallback} = submitListeners;
 
-        console.log(wrapper, lastBubblingCallback);
         if (wrapper === lastBubblingCallback) {
           maybeDispatchFormdataForEvent(e);
         }

--- a/packages/formdata-event/ts_src/formdata_listener_added.ts
+++ b/packages/formdata-event/ts_src/formdata_listener_added.ts
@@ -18,7 +18,7 @@
 import {getTarget, getDefaultPrevented} from './environment_api/event.js';
 import {addEventListener, removeEventListener} from './environment_api/event_target.js';
 import {getRootNode} from './environment_api/node.js';
-import {setSubmitEventPropagationStopped} from './wrappers/event.js';
+import {setSubmitEventPropagationStoppedCallback} from './wrappers/event.js';
 import {dispatchFormdataForSubmission} from './dispatch_formdata_for_submission.js';
 
 interface FormdataEventListenerRecord {
@@ -170,10 +170,10 @@ export const submitCallback = (capturingEvent: Event) => {
 };
 
 /**
- * This function should be called when any 'submit' event's propagation is
+ * This function will be called when any 'submit' event's propagation is
  * stopped, either through `stopPropagation` or `stopImmediatePropagation`.
  */
-export const submitEventPropagationStopped = (event: Event) => {
+setSubmitEventPropagationStoppedCallback((event: Event) => {
   const listenerInfo = submitEventToListenerInfo.get(event);
   if (listenerInfo === undefined) {
     return;
@@ -181,6 +181,4 @@ export const submitEventPropagationStopped = (event: Event) => {
 
   const {target, callback} = listenerInfo;
   removeEventListener.call(target, 'submit', callback);
-};
-
-setSubmitEventPropagationStopped(submitEventPropagationStopped);
+});

--- a/packages/formdata-event/ts_src/formdata_listener_added.ts
+++ b/packages/formdata-event/ts_src/formdata_listener_added.ts
@@ -15,7 +15,7 @@
  * submissions that should dispatch a 'formdata' event.
  */
 
-import {setSubmitEventPropagationStoppedCallback, setSubmitEventPropagationImmediatelyStoppedCallback} from './wrappers/event.js';
+import {getEventPropagationStopped, getEventPropagationImmediatelyStopped} from './wrappers/event.js';
 import {getTarget, getDefaultPrevented} from './environment_api/event.js';
 import {addEventListener, removeEventListener} from './environment_api/event_target.js';
 import {getRootNode} from './environment_api/node.js';
@@ -154,25 +154,6 @@ const removeBubblingCallback = (event: Event) => {
   }
 };
 
-const eventToPropagationStopped = new WeakMap<Event, true>();
-const eventToPropagationImmediatelyStopped = new WeakMap<Event, true>();
-
-/**
- * This function will be called when any 'submit' event's propagation is stopped
- * by `stopPropagation`.
- */
-setSubmitEventPropagationStoppedCallback((event: Event) => {
-  eventToPropagationStopped.set(event, true);
-});
-
-/**
- * This function will be called when any 'submit' event's propagation is stopped
- * by `stopImmediatePropagation`.
- */
-setSubmitEventPropagationImmediatelyStoppedCallback((event: Event) => {
-  eventToPropagationImmediatelyStopped.set(event, true);
-});
-
 export const wrapSubmitListener = (listener: EventListenerOrEventListenerObject): EventListener => {
   return function wrapper(this: EventTarget, e: Event, ...rest) {
     const result: any = typeof listener === "function" ?
@@ -181,9 +162,9 @@ export const wrapSubmitListener = (listener: EventListenerOrEventListenerObject)
 
     const listenerInfo = submitEventToListenerInfo.get(e);
     if (listenerInfo !== undefined) {
-      if (eventToPropagationImmediatelyStopped.has(e)) {
+      if (getEventPropagationImmediatelyStopped(e)) {
         maybeDispatchFormdataForEvent(e);
-      } else if (eventToPropagationStopped.has(e)) {
+      } else if (getEventPropagationStopped(e)) {
         const submitListeners = targetToSubmitListeners.get(this)!;
         const {lastCapturingCallback, lastBubblingCallback} = submitListeners;
 

--- a/packages/formdata-event/ts_src/formdata_listener_added.ts
+++ b/packages/formdata-event/ts_src/formdata_listener_added.ts
@@ -130,8 +130,8 @@ const submitCallback = (capturingEvent: Event) => {
 
   const shallowRoot = getRootNode(target);
 
-  // The wrapper generated here will handle dispatching the event if it bubbles
-  // all the way to `shallowRoot`.
+  // The wrapper generated here will dispatch a 'formdata' event if this
+  // 'submit' event bubbles all the way to `shallowRoot`.
   const bubblingCallback = wrapSubmitListener(() => {});
   submitEventToListenerInfo.set(capturingEvent, {
     target: shallowRoot,
@@ -144,6 +144,12 @@ const submitCallback = (capturingEvent: Event) => {
   submitListenerAdded(shallowRoot, bubblingCallback);
 };
 
+/**
+ * All 'submit' event listeners added by the user or polyfill (_except_ the
+ * bubbling listener above) should be wrapped by this function. All 'formdata'
+ * events dispatched as a result of observing a 'submit' event are dispatched by
+ * one of these wrappers.
+ */
 export const wrapSubmitListener = (listener: EventListenerOrEventListenerObject): EventListener => {
   return function wrapper(this: EventTarget, e: Event, ...rest) {
     const result: any = typeof listener === "function" ?
@@ -189,6 +195,10 @@ export const wrapSubmitListener = (listener: EventListenerOrEventListenerObject)
   };
 };
 
+/**
+ * Dispatches a 'formdata' event for a 'submit' event that has finished
+ * propagating through the tree, if the 'submit' wasn't cancelled.
+ */
 const maybeDispatchFormdataForEvent = (e: Event) => {
   // Remove the bubbling 'submit' event listener, if one was added for this
   // event (i.e. if the capturing listener saw the event).

--- a/packages/formdata-event/ts_src/formdata_listener_added.ts
+++ b/packages/formdata-event/ts_src/formdata_listener_added.ts
@@ -186,9 +186,9 @@ export const wrapSubmitListener = (listener: EventListenerOrEventListenerObject)
 };
 
 const maybeDispatchFormdataForEvent = (e: Event) => {
-  // Ignore any cancelled events.
+  removeBubblingCallback(e);
+
   if (!getDefaultPrevented(e)) {
-    removeBubblingCallback(e);
     dispatchFormdataForSubmission(getTarget(e));
   }
 };

--- a/packages/formdata-event/ts_src/wrappers/event.ts
+++ b/packages/formdata-event/ts_src/wrappers/event.ts
@@ -18,9 +18,9 @@ import {prepareWrapper, installWrapper} from './wrap_constructor.js';
 /**
  * A callback that is called whenever an Event's propagation is stopped.
  *
- * Q: Why doesn't this file just import and call `submitEventPropagationStopped`
- * from 'formdata_listener_added.ts' directly, given that this value is set to
- * that function and never changed?
+ * Q: Why doesn't this file just import and call the callback from
+ * 'formdata_listener_added.ts' directly, given that this value is set to that
+ * function and never changed?
  *
  * A: The way Closure compiles classes down to ES5 (which involves modifying the
  * constructor function's prototype) paired with the prototype modifications
@@ -30,13 +30,13 @@ import {prepareWrapper, installWrapper} from './wrap_constructor.js';
  * dependency cycle which reorders these two calls and breaks the
  * `FormDataEvent` prototype.
  */
-let submitEventPropagationStopped: ((e: Event) => void) | undefined = undefined;
+let submitEventPropagationStoppedCallback: ((e: Event) => void) | undefined = undefined;
 
 /**
  * Sets the callback to be called whenever an Event's propagation is stopped.
  */
-export const setSubmitEventPropagationStopped = (fn: (e: Event) => void) => {
-  submitEventPropagationStopped = fn;
+export const setSubmitEventPropagationStoppedCallback = (fn: (e: Event) => void) => {
+  submitEventPropagationStoppedCallback = fn;
 };
 
 // This wrapper makes Event constructible / extensible in ES5 (the compilation
@@ -74,14 +74,14 @@ export const install = () => {
 
   Event.prototype['stopImmediatePropagation'] = function() {
     if (this.type === 'submit') {
-      submitEventPropagationStopped?.(this);
+      submitEventPropagationStoppedCallback?.(this);
     }
     return EventMethods.stopImmediatePropagation.call(this);
   };
 
   Event.prototype['stopPropagation'] = function() {
     if (this.type === 'submit') {
-      submitEventPropagationStopped?.(this);
+      submitEventPropagationStoppedCallback?.(this);
     }
     return EventMethods.stopPropagation.call(this);
   };

--- a/packages/formdata-event/ts_src/wrappers/event.ts
+++ b/packages/formdata-event/ts_src/wrappers/event.ts
@@ -10,7 +10,7 @@
  */
 
 import {methods as DocumentMethods} from '../environment/document.js';
-import {constructor as EventConstructor, prototype as EventPrototype} from '../environment/event.js';
+import {constructor as EventConstructor, prototype as EventPrototype, methods as EventMethods} from '../environment/event.js';
 import {document} from '../environment/globals.js';
 import {initEvent} from '../environment_api/event.js';
 import {prepareWrapper, installWrapper} from './wrap_constructor.js';
@@ -47,6 +47,14 @@ export const install = () => {
   // In IE11, `Object.getPrototypeOf(window.Event) === Object.prototype`, which
   // was copied by `prepareWrapper` from `window.Event` to `Event` above.
   Object.setPrototypeOf(Event, Function.prototype);
+
+  Event.prototype['stopImmediatePropagation'] = function() {
+    return EventMethods.stopImmediatePropagation.call(this);
+  };
+
+  Event.prototype['stopPropagation'] = function() {
+    return EventMethods.stopPropagation.call(this);
+  };
 
   window.Event = Event;
 };

--- a/packages/formdata-event/ts_src/wrappers/event.ts
+++ b/packages/formdata-event/ts_src/wrappers/event.ts
@@ -12,7 +12,7 @@
 import {methods as DocumentMethods} from '../environment/document.js';
 import {constructor as EventConstructor, prototype as EventPrototype, methods as EventMethods} from '../environment/event.js';
 import {document} from '../environment/globals.js';
-import {initEvent} from '../environment_api/event.js';
+import {getType, initEvent} from '../environment_api/event.js';
 import {prepareWrapper, installWrapper} from './wrap_constructor.js';
 
 /**
@@ -73,14 +73,14 @@ export const install = () => {
   Object.setPrototypeOf(Event, Function.prototype);
 
   Event.prototype['stopImmediatePropagation'] = function() {
-    if (this.type === 'submit') {
+    if (getType(this) === 'submit') {
       submitEventPropagationStoppedCallback?.(this);
     }
     return EventMethods.stopImmediatePropagation.call(this);
   };
 
   Event.prototype['stopPropagation'] = function() {
-    if (this.type === 'submit') {
+    if (getType(this) === 'submit') {
       submitEventPropagationStoppedCallback?.(this);
     }
     return EventMethods.stopPropagation.call(this);

--- a/packages/formdata-event/ts_src/wrappers/event_target.ts
+++ b/packages/formdata-event/ts_src/wrappers/event_target.ts
@@ -12,9 +12,8 @@
 import {prototype as EventTargetPrototype, methods as EventTargetMethods} from '../environment/event_target.js';
 import {prototype as NodePrototype, methods as NodeMethods} from '../environment/node.js';
 import {prototype as WindowPrototype, methods as WindowMethods} from '../environment/window.js';
-import {formdataListenerAdded, formdataListenerRemoved} from '../formdata_listener_added.js';
+import {formdataListenerAdded, formdataListenerRemoved, wrapSubmitListener} from '../formdata_listener_added.js';
 import {submitListenerAdded, submitListenerRemoved} from '../submit_listener_added.js';
-import {wrapSubmitListener} from '../submit_listener_added.js';
 
 const submitListenerToWrapper = new WeakMap<EventListenerOrEventListenerObject, EventListener>();
 

--- a/packages/tests/formdata-event/formdata_listener_added.html
+++ b/packages/tests/formdata-event/formdata_listener_added.html
@@ -164,7 +164,7 @@ suite('formdataListenerAdded', () => {
   });
 
   test('Calling `stopPropagation` on a "submit" event should not cancel the ' +
-      '"formdata" event.', () => {
+      '"formdata" event and the form should still be updated.', (done) => {
     const form = iframeDoc.createElement('form');
     iframeDoc.body.appendChild(form);
 
@@ -177,19 +177,24 @@ suite('formdataListenerAdded', () => {
       e.stopPropagation();
     });
 
-    let callCount = 0;
     iframeDoc.defaultView.addEventListener('formdata', (e) => {
-      callCount++;
+      e.formData.set('name', 'value');
     });
 
     submitButton.click();
-    assert.strictEqual(callCount, 1);
 
-    iframeDoc.body.removeChild(form);
+    iframe.addEventListener('load', () => {
+      // Explicitly retrieve `iframe.contentDocument` again because the
+      // document was replaced when submitting the form.
+      const newSearch = iframe.contentDocument.defaultView.location.search;
+      assert.strictEqual(newSearch, '?name=value');
+      done();
+    });
   });
 
   test('Calling `stopImmediatePropagation` on a "submit" event should not ' +
-      'cancel the "formdata" event.', () => {
+      'cancel the "formdata" event and the form should still be updated.',
+      (done) => {
     const form = iframeDoc.createElement('form');
     iframeDoc.body.appendChild(form);
 
@@ -202,15 +207,19 @@ suite('formdataListenerAdded', () => {
       e.stopImmediatePropagation();
     });
 
-    let callCount = 0;
     iframeDoc.defaultView.addEventListener('formdata', (e) => {
-      callCount++;
+      e.formData.set('name', 'value');
     });
 
     submitButton.click();
-    assert.strictEqual(callCount, 1);
 
-    iframeDoc.body.removeChild(form);
+    iframe.addEventListener('load', () => {
+      // Explicitly retrieve `iframe.contentDocument` again because the
+      // document was replaced when submitting the form.
+      const newSearch = iframe.contentDocument.defaultView.location.search;
+      assert.strictEqual(newSearch, '?name=value');
+      done();
+    });
   });
 });
 </script>

--- a/packages/tests/formdata-event/formdata_listener_added.html
+++ b/packages/tests/formdata-event/formdata_listener_added.html
@@ -162,6 +162,56 @@ suite('formdataListenerAdded', () => {
 
     iframeDoc.body.removeChild(form);
   });
+
+  test('Calling `stopPropagation` on a "submit" event should not cancel the ' +
+      '"formdata" event.', () => {
+    const form = iframeDoc.createElement('form');
+    iframeDoc.body.appendChild(form);
+
+    // See note above.
+    const submitButton = iframeDoc.createElement('input');
+    submitButton.type = 'submit';
+    form.appendChild(submitButton);
+
+    form.addEventListener('submit', (e) => {
+      e.stopPropagation();
+    });
+
+    let callCount = 0;
+    iframeDoc.defaultView.addEventListener('formdata', (e) => {
+      callCount++;
+    });
+
+    submitButton.click();
+    assert.strictEqual(callCount, 1);
+
+    iframeDoc.body.removeChild(form);
+  });
+
+  test('Calling `stopImmediatePropagation` on a "submit" event should not ' +
+      'cancel the "formdata" event.', () => {
+    const form = iframeDoc.createElement('form');
+    iframeDoc.body.appendChild(form);
+
+    // See note above.
+    const submitButton = iframeDoc.createElement('input');
+    submitButton.type = 'submit';
+    form.appendChild(submitButton);
+
+    form.addEventListener('submit', (e) => {
+      e.stopImmediatePropagation();
+    });
+
+    let callCount = 0;
+    iframeDoc.defaultView.addEventListener('formdata', (e) => {
+      callCount++;
+    });
+
+    submitButton.click();
+    assert.strictEqual(callCount, 1);
+
+    iframeDoc.body.removeChild(form);
+  });
 });
 </script>
 </body>

--- a/packages/tests/formdata-event/formdata_listener_added.html
+++ b/packages/tests/formdata-event/formdata_listener_added.html
@@ -221,6 +221,70 @@ suite('formdataListenerAdded', () => {
       done();
     });
   });
+
+  test('Calling `stopPropagation` on a "submit" event before it has reached ' +
+      'the capturing listener should still dispatch a "formdata" event.',
+      (done) => {
+    const container = iframeDoc.createElement('div');
+    iframeDoc.body.appendChild(container);
+
+    container.addEventListener('submit', (e) => {
+      e.stopPropagation();
+    }, true);
+
+    const form = iframeDoc.createElement('form');
+    container.appendChild(form);
+
+    form.addEventListener('formdata', (e) => {
+      e.formData.append('name', 'value');
+    });
+
+    // See note above.
+    const submitButton = iframeDoc.createElement('input');
+    submitButton.type = 'submit';
+    form.appendChild(submitButton);
+    submitButton.click();
+
+    iframe.addEventListener('load', () => {
+      // Explicitly retrieve `iframe.contentDocument` again because the
+      // document was replaced when submitting the form.
+      const newSearch = iframe.contentDocument.defaultView.location.search;
+      assert.strictEqual(newSearch, '?name=value');
+      done();
+    });
+  });
+
+  test('Calling `stopImmediatePropagation` on a "submit" event before it has ' +
+      'reached the capturing listener should still dispatch a "formdata" ' +
+      'event.', (done) => {
+    const container = iframeDoc.createElement('div');
+    iframeDoc.body.appendChild(container);
+
+    container.addEventListener('submit', (e) => {
+      e.stopImmediatePropagation();
+    }, true);
+
+    const form = iframeDoc.createElement('form');
+    container.appendChild(form);
+
+    form.addEventListener('formdata', (e) => {
+      e.formData.append('name', 'value');
+    });
+
+    // See note above.
+    const submitButton = iframeDoc.createElement('input');
+    submitButton.type = 'submit';
+    form.appendChild(submitButton);
+    submitButton.click();
+
+    iframe.addEventListener('load', () => {
+      // Explicitly retrieve `iframe.contentDocument` again because the
+      // document was replaced when submitting the form.
+      const newSearch = iframe.contentDocument.defaultView.location.search;
+      assert.strictEqual(newSearch, '?name=value');
+      done();
+    });
+  });
 });
 </script>
 </body>

--- a/packages/tests/formdata-event/index.html
+++ b/packages/tests/formdata-event/index.html
@@ -19,6 +19,7 @@ WCT.loadSuites([
   './dispatch_formdata_for_submission.html',
   './form_data_event.html',
   './formdata_listener_added.html',
+  './submit_listener_added.html',
   './wrappers/index.html',
 ]);
 </script>

--- a/packages/tests/formdata-event/submit_listener_added.html
+++ b/packages/tests/formdata-event/submit_listener_added.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved. This code
+may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+at http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google
+as part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+<script src="../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+<script>
+suite('submitListenerAdded', () => {
+  let iframe = undefined;
+  let iframeDoc = undefined;
+  let Event = undefined;
+
+  setup(done => {
+    iframe = document.createElement('iframe');
+    iframe.src = './test_environment.html';
+    iframe.addEventListener('load', function listener() {
+      iframe.removeEventListener('load', listener);
+      iframeDoc = iframe.contentDocument;
+      Event = iframe.contentDocument.defaultView.Event;
+      done();
+    });
+    document.body.appendChild(iframe);
+  });
+
+  teardown(() => {
+    document.body.removeChild(iframe);
+    iframe = undefined;
+  });
+
+  test('Modifications made in a "formdata" listener after having called ' +
+      '`stopImmediatePropagation` inside a "submit" listener should not be ' +
+      'visible in the form during the remainder of the "submit" listener.',
+      (done) => {
+    const form = iframeDoc.createElement('form');
+    iframeDoc.body.appendChild(form);
+
+    // Submitting a form by calling the `<form>`'s `submit` method causes the UA
+    // not to dispatch a 'submit' event. To work around this, we create a submit
+    // button and call it's `click` method instead.
+    //
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit
+    const submitButton = iframeDoc.createElement('input');
+    submitButton.type = 'submit';
+    form.appendChild(submitButton);
+
+    form.addEventListener('submit', (e) => {
+      e.stopImmediatePropagation();
+
+      const inputs = form.querySelectorAll('input');
+      assert.strictEqual(inputs.length, 1);
+      assert.strictEqual(inputs[0], submitButton);
+    });
+
+    form.addEventListener('formdata', (e) => {
+      e.formData.append('name', 'value');
+    });
+
+    submitButton.click()
+
+    iframe.addEventListener('load', () => {
+      // Explicitly retrieve `iframe.contentDocument` again because the
+      // document was replaced when submitting the form.
+      const newSearch = iframe.contentDocument.defaultView.location.search;
+      assert.strictEqual(newSearch, '?name=value');
+      done();
+    });
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
In the polyfill's normal flow, the 'formdata' event is dispatched when a 'submit' event dispatched to a form propagates up to a bubbling listener on the root containing the form. However, if a user calls `stopPropagation` or `stopImmediatePropagation` on the 'submit' event, then that event will never reach the listener at the root. To work around this problem, this PR wraps all 'submit' event listeners and checks after each listener if the 'formdata' event should be dispatched based on whether or not these methods have been called and if the wrapped listener would be the last to be called for that event.