### PR TITLE
Update platform package references in tests.

### DIFF
--- a/packages/tests/custom-elements/html/Document/createElement.html
+++ b/packages/tests/custom-elements/html/Document/createElement.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Document/createElementNS.html
+++ b/packages/tests/custom-elements/html/Document/createElementNS.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Document/importNode.html
+++ b/packages/tests/custom-elements/html/Document/importNode.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/DocumentConstructionObserver.html
+++ b/packages/tests/custom-elements/html/DocumentConstructionObserver.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script>

--- a/packages/tests/custom-elements/html/Element/attachShadow.html
+++ b/packages/tests/custom-elements/html/Element/attachShadow.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Element/innerHTML.html
+++ b/packages/tests/custom-elements/html/Element/innerHTML.html
@@ -17,7 +17,7 @@
     };
   })();
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Element/insertAdjacentElement.html
+++ b/packages/tests/custom-elements/html/Element/insertAdjacentElement.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Element/insertAdjacentHTML.html
+++ b/packages/tests/custom-elements/html/Element/insertAdjacentHTML.html
@@ -16,7 +16,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/@webcomponents/template/template.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>

--- a/packages/tests/custom-elements/html/Element/outerHTML.html
+++ b/packages/tests/custom-elements/html/Element/outerHTML.html
@@ -17,7 +17,7 @@
         Node.prototype.insertBefore,
   };
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/@webcomponents/template/template.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>

--- a/packages/tests/custom-elements/html/Element/removeAttribute.html
+++ b/packages/tests/custom-elements/html/Element/removeAttribute.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Element/removeAttributeNS.html
+++ b/packages/tests/custom-elements/html/Element/removeAttributeNS.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Element/setAttribute.html
+++ b/packages/tests/custom-elements/html/Element/setAttribute.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Element/setAttributeNS.html
+++ b/packages/tests/custom-elements/html/Element/setAttributeNS.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/HTMLElement/constructor.html
+++ b/packages/tests/custom-elements/html/HTMLElement/constructor.html
@@ -15,7 +15,7 @@ rights grant found at http://polymer.github.io/PATENTS.txt
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Interface/ChildNode/index.html
+++ b/packages/tests/custom-elements/html/Interface/ChildNode/index.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Interface/ParentNode/index.html
+++ b/packages/tests/custom-elements/html/Interface/ParentNode/index.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/Node/appendChild.html
+++ b/packages/tests/custom-elements/html/Node/appendChild.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/Node/cloneNode.html
+++ b/packages/tests/custom-elements/html/Node/cloneNode.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/Node/insertBefore.html
+++ b/packages/tests/custom-elements/html/Node/insertBefore.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/Node/removeChild.html
+++ b/packages/tests/custom-elements/html/Node/removeChild.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/Node/replaceChild.html
+++ b/packages/tests/custom-elements/html/Node/replaceChild.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/Node/textContent.html
+++ b/packages/tests/custom-elements/html/Node/textContent.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/babel.html
+++ b/packages/tests/custom-elements/html/babel.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/closure.html
+++ b/packages/tests/custom-elements/html/closure.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/imports.html
+++ b/packages/tests/custom-elements/html/imports.html
@@ -14,8 +14,8 @@
     <script>
       (window.customElements = window.customElements || {}).forcePolyfill = true;
     </script>
-    <script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-    <script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+    <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+    <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
     <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
     <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
     <script>

--- a/packages/tests/custom-elements/html/instanceof.html
+++ b/packages/tests/custom-elements/html/instanceof.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/polyfill-define-lazy.html
+++ b/packages/tests/custom-elements/html/polyfill-define-lazy.html
@@ -6,7 +6,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/polyfillWrapFlushCallback/defaultSyncFlush.html
+++ b/packages/tests/custom-elements/html/polyfillWrapFlushCallback/defaultSyncFlush.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/polyfillWrapFlushCallback/defineDoesNotWalk.html
+++ b/packages/tests/custom-elements/html/polyfillWrapFlushCallback/defineDoesNotWalk.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/polyfillWrapFlushCallback/flushCallbackIsCalled.html
+++ b/packages/tests/custom-elements/html/polyfillWrapFlushCallback/flushCallbackIsCalled.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/polyfillWrapFlushCallback/imperativelyCreatedBeforeFlush.html
+++ b/packages/tests/custom-elements/html/polyfillWrapFlushCallback/imperativelyCreatedBeforeFlush.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/polyfillWrapFlushCallback/multipleDefineCalls.html
+++ b/packages/tests/custom-elements/html/polyfillWrapFlushCallback/multipleDefineCalls.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/polyfillWrapFlushCallback/multipleFlushCallbacks_blocking.html
+++ b/packages/tests/custom-elements/html/polyfillWrapFlushCallback/multipleFlushCallbacks_blocking.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/polyfillWrapFlushCallback/multipleFlushCallbacks_ordering.html
+++ b/packages/tests/custom-elements/html/polyfillWrapFlushCallback/multipleFlushCallbacks_ordering.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 <script type="module">

--- a/packages/tests/custom-elements/html/polyfillWrapFlushCallback/upgradeInDefineCallOrder.html
+++ b/packages/tests/custom-elements/html/polyfillWrapFlushCallback/upgradeInDefineCallOrder.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/polyfillWrapFlushCallback/whenDefined_after.html
+++ b/packages/tests/custom-elements/html/polyfillWrapFlushCallback/whenDefined_after.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/polyfillWrapFlushCallback/whenDefined_before.html
+++ b/packages/tests/custom-elements/html/polyfillWrapFlushCallback/whenDefined_before.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/reactions.html
+++ b/packages/tests/custom-elements/html/reactions.html
@@ -6,7 +6,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/registry-upgrade.html
+++ b/packages/tests/custom-elements/html/registry-upgrade.html
@@ -15,8 +15,8 @@
       (window.customElements = window.customElements || {}).forcePolyfill = true;
       ShadyDOM = {force: true};
     </script>
-    <script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-    <script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+    <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+    <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
     <script src="../../node_modules/@webcomponents/template/template.js"></script>
     <script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
     <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>

--- a/packages/tests/custom-elements/html/registry.html
+++ b/packages/tests/custom-elements/html/registry.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/shadow-dom.html
+++ b/packages/tests/custom-elements/html/shadow-dom.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/template-polyfill.html
+++ b/packages/tests/custom-elements/html/template-polyfill.html
@@ -15,8 +15,8 @@
       (window.customElements = window.customElements || {}).forcePolyfill = true;
       ShadyDOM = {force: true};
     </script>
-    <script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-    <script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+    <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+    <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
     <script src="../../node_modules/@webcomponents/template/template.js"></script>
     <script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
     <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>

--- a/packages/tests/custom-elements/html/typescript.html
+++ b/packages/tests/custom-elements/html/typescript.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/custom-elements/html/upgrade.html
+++ b/packages/tests/custom-elements/html/upgrade.html
@@ -5,7 +5,7 @@
 <script>
   (window.customElements = window.customElements || {}).forcePolyfill = true;
 </script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -12,12 +12,10 @@
     "@webcomponents/shadycss": "^1.9.5",
     "@webcomponents/shadydom": "^1.7.2",
     "@webcomponents/template": "^1.4.1",
-    "@webcomponents/webcomponents-platform": "^1.0.0",
     "@webcomponents/webcomponentsjs": "^2.4.2",
     "del": "^3.0.0",
     "es6-promise": "4.2.4",
     "gulp": "^4.0.0",
-    "promise-polyfill": "^8.1.3",
     "rollup-stream": "=1.23.1",
     "vinyl-source-stream": "^2.0.0",
     "wct-browser-legacy": "^1.0.2"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -14,7 +14,6 @@
     "@webcomponents/template": "^1.4.1",
     "@webcomponents/webcomponentsjs": "^2.4.2",
     "del": "^3.0.0",
-    "es6-promise": "4.2.4",
     "gulp": "^4.0.0",
     "rollup-stream": "=1.23.1",
     "vinyl-source-stream": "^2.0.0",

--- a/packages/tests/shadycss/apply-shim.html
+++ b/packages/tests/shadycss/apply-shim.html
@@ -17,8 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
   <script src="./test-flags.js"></script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/async-loading.html
+++ b/packages/tests/shadycss/async-loading.html
@@ -4,8 +4,8 @@
 </script>
 <script src="./test-flags.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js" defer></script>
 <script src="../node_modules/@webcomponents/shadycss/scoping-shim.min.js" defer></script>
 <script>

--- a/packages/tests/shadycss/complicated-mixin-ordering.html
+++ b/packages/tests/shadycss/complicated-mixin-ordering.html
@@ -17,8 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     WCT = { waitFor: function (cb) { HTMLImports.whenReady(cb) } }
   </script>
   <script src="./test-flags.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/custom-style-import.html
+++ b/packages/tests/shadycss/custom-style-import.html
@@ -13,8 +13,8 @@ WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
 </script>
 <script src="./test-flags.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/template/template.js"></script>
 <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/custom-style-late.html
+++ b/packages/tests/shadycss/custom-style-late.html
@@ -12,8 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
 </script>
 <script src="./test-flags.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/template/template.js"></script>
 <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/custom-style-only.html
+++ b/packages/tests/shadycss/custom-style-only.html
@@ -9,8 +9,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script src="./test-flags.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/template/template.js"></script>
 <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script>

--- a/packages/tests/shadycss/custom-style-ordering.html
+++ b/packages/tests/shadycss/custom-style-ordering.html
@@ -13,8 +13,8 @@ WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
 </script>
 <script src="./test-flags.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/template/template.js"></script>
 <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/custom-style.html
+++ b/packages/tests/shadycss/custom-style.html
@@ -13,8 +13,8 @@ WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
 </script>
 <script src="./test-flags.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/template/template.js"></script>
 <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/deferred-apply.html
+++ b/packages/tests/shadycss/deferred-apply.html
@@ -15,8 +15,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="utf-8">
   <script src="./test-flags.js"></script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/disable-runtime.html
+++ b/packages/tests/shadycss/disable-runtime.html
@@ -21,8 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     window.ShadyDOM = { force: true };
   </script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/dynamic-scoping.html
+++ b/packages/tests/shadycss/dynamic-scoping.html
@@ -18,8 +18,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
   <script src="./test-flags.js"></script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/lazy-init.html
+++ b/packages/tests/shadycss/lazy-init.html
@@ -11,8 +11,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>WCT = { waitFor(cb) { addEventListener('DOMContentLoaded', cb) } };</script>
 <script src="test-flags.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/template/template.js"></script>
 <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/media-query.html
+++ b/packages/tests/shadycss/media-query.html
@@ -18,8 +18,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
   <script src="./test-flags.js"></script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/mixin-fallbacks.html
+++ b/packages/tests/shadycss/mixin-fallbacks.html
@@ -13,8 +13,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </script>
 <script src="./test-flags.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/template/template.js"></script>
 <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/mixin-ordering.html
+++ b/packages/tests/shadycss/mixin-ordering.html
@@ -5,8 +5,8 @@
   </script>
   <script src="./test-flags.js"></script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/no-applyshim/custom-style-late.html
+++ b/packages/tests/shadycss/no-applyshim/custom-style-late.html
@@ -11,8 +11,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
 WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
 </script>
-<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../../node_modules/@webcomponents/template/template.js"></script>
 <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/no-applyshim/custom-style-only.html
+++ b/packages/tests/shadycss/no-applyshim/custom-style-only.html
@@ -10,8 +10,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <script src=".././test-flags.js"></script>
-<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../../node_modules/@webcomponents/template/template.js"></script>
 <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script>

--- a/packages/tests/shadycss/no-applyshim/custom-style.html
+++ b/packages/tests/shadycss/no-applyshim/custom-style.html
@@ -12,8 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
 </script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../../node_modules/@webcomponents/template/template.js"></script>
 <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/no-scopingshim/apply-shim.html
+++ b/packages/tests/shadycss/no-scopingshim/apply-shim.html
@@ -16,8 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
   </script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../../node_modules/@webcomponents/template/template.js"></script>
   <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/no-scopingshim/complicated-mixin-ordering.html
+++ b/packages/tests/shadycss/no-scopingshim/complicated-mixin-ordering.html
@@ -17,8 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     WCT = { waitFor: function (cb) { HTMLImports.whenReady(cb) } }
   </script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../../node_modules/@webcomponents/template/template.js"></script>
   <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>

--- a/packages/tests/shadycss/no-scopingshim/custom-style-late.html
+++ b/packages/tests/shadycss/no-scopingshim/custom-style-late.html
@@ -11,8 +11,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
 WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
 </script>
-<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../../node_modules/@webcomponents/template/template.js"></script>
 <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/no-scopingshim/custom-style-only.html
+++ b/packages/tests/shadycss/no-scopingshim/custom-style-only.html
@@ -9,8 +9,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script src=".././test-flags.js"></script>
-<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../../node_modules/@webcomponents/template/template.js"></script>
 <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script>

--- a/packages/tests/shadycss/no-scopingshim/custom-style.html
+++ b/packages/tests/shadycss/no-scopingshim/custom-style.html
@@ -12,8 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
 </script>
 <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../../node_modules/@webcomponents/template/template.js"></script>
 <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/no-scopingshim/mixin-ordering.html
+++ b/packages/tests/shadycss/no-scopingshim/mixin-ordering.html
@@ -4,8 +4,8 @@
   WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
   </script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../../node_modules/@webcomponents/template/template.js"></script>
   <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/ordering.html
+++ b/packages/tests/shadycss/ordering.html
@@ -11,8 +11,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>WCT = {waitFor(cb){addEventListener('DOMContentLoaded', cb)}};</script>
 <script src="test-flags.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/template/template.js"></script>
 <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/placeholder-ordering.html
+++ b/packages/tests/shadycss/placeholder-ordering.html
@@ -16,8 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
   <script src="./test-flags.js"></script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/scoping-api.html
+++ b/packages/tests/shadycss/scoping-api.html
@@ -17,8 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
   <script src="./test-flags.js"></script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script>

--- a/packages/tests/shadycss/scoping.html
+++ b/packages/tests/shadycss/scoping.html
@@ -16,8 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
   <script src="./test-flags.js"></script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/settings.html
+++ b/packages/tests/shadycss/settings.html
@@ -10,8 +10,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 <script src="./test-flags.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
 <script>
   suite('Settings', () => {

--- a/packages/tests/shadycss/style-transformer.html
+++ b/packages/tests/shadycss/style-transformer.html
@@ -13,8 +13,8 @@ WCT = {waitFor: function (cb) {HTMLImports.whenReady(cb)}}
 </script>
 <script src="./test-flags.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-<script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-<script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/template/template.js"></script>
 <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
 <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/svg.html
+++ b/packages/tests/shadycss/svg.html
@@ -21,8 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
   <script src="./test-flags.js"></script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadycss/workarounds.html
+++ b/packages/tests/shadycss/workarounds.html
@@ -19,8 +19,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
   <script src="./test-flags.js"></script>
   <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/es6-promise/dist/es6-promise.auto.min.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
   <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>

--- a/packages/tests/shadydom/active-element.html
+++ b/packages/tests/shadydom/active-element.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="loader.js"></script>
   <script>

--- a/packages/tests/shadydom/attach-while-loading.html
+++ b/packages/tests/shadydom/attach-while-loading.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script>
     ShadyDOM = {
       force: true,

--- a/packages/tests/shadydom/connect-disconnect.html
+++ b/packages/tests/shadydom/connect-disconnect.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script>
     ShadyDOM = {force: true};

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="loader.js"></script>
   <script>

--- a/packages/tests/shadydom/filter-mutations.html
+++ b/packages/tests/shadydom/filter-mutations.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script>
     ShadyDOM = {force: true};
   </script>

--- a/packages/tests/shadydom/live-childNodes.html
+++ b/packages/tests/shadydom/live-childNodes.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
 
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script>
     ShadyDOM = {force: true};
   </script>

--- a/packages/tests/shadydom/native-access.html
+++ b/packages/tests/shadydom/native-access.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script>
     ShadyDOM = {force: true};

--- a/packages/tests/shadydom/observeChildren.html
+++ b/packages/tests/shadydom/observeChildren.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script>
     ShadyDOM = {force: true, noPatch: window.location.search.match('noPatch=on-demand') ? 'on-demand' : !!window.location.search.match('noPatch')};
   </script>

--- a/packages/tests/shadydom/prefer-performance.html
+++ b/packages/tests/shadydom/prefer-performance.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script>
     window.NATIVE = {

--- a/packages/tests/shadydom/shady-content.html
+++ b/packages/tests/shadydom/shady-content.html
@@ -13,7 +13,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="utf-8">
 
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="loader.js"></script>
   <script>

--- a/packages/tests/shadydom/shady-dynamic.html
+++ b/packages/tests/shadydom/shady-dynamic.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script>
     window.NATIVE = {

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -22,7 +22,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     };
   </script>
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script>
     ShadyDOM = {force: true, noPatch: window.location.search.match('noPatch=on-demand') ? 'on-demand' : !!window.location.search.match('noPatch')};

--- a/packages/tests/shadydom/slot-scenarios.html
+++ b/packages/tests/shadydom/slot-scenarios.html
@@ -13,7 +13,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script src="../node_modules/@webcomponents/template/template.js"></script>
   <script src="loader.js"></script>
   <script>

--- a/packages/tests/shadydom/slotchange.html
+++ b/packages/tests/shadydom/slotchange.html
@@ -12,7 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script>
     ShadyDOM = {force: true, noPatch: window.location.search.match('noPatch=on-demand') ? 'on-demand' : !!window.location.search.match('noPatch')};
   </script>

--- a/packages/tests/shadydom/smoke/click.html
+++ b/packages/tests/shadydom/smoke/click.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html>
   <head>
-    <script src="../../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
     <script src="../../node_modules/@webcomponents/template/template.js"></script>
     <script>
       ShadyDOM = {force: true};

--- a/packages/tests/shadydom/smoke/focus-api.html
+++ b/packages/tests/shadydom/smoke/focus-api.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     ShadyDOM = {force: true};
   </script>
-  <script src="../../../es6-promise/es6-promise.auto.min.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
   <script src="../../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
 </head>
 <body>

--- a/packages/tests/shadydom/sync-style-scoping.html
+++ b/packages/tests/shadydom/sync-style-scoping.html
@@ -12,8 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
   <script src="wct-browser-config.js"></script>
-  <script src="../node_modules/@webcomponents/webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../node_modules/promise-polyfill/dist/polyfill.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
   <script>
     // TODO(sorvell): fix Promise to resolve at microtask time when polyfilled
     if (Promise._immediateFn) {


### PR DESCRIPTION
This is a follow on to #385 which replaces references to the @webcomponents/webcomponents-platform package and the multiple Promise polyfills in the tests with the new platform entrypoints in @webcomponents/webcomponentsjs.