### PR TITLE
Add polyfills for ChildNode APIs.

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for ChildNode APIs.
+  ([#390](https://github.com/webcomponents/polyfills/pull/390))
 - Add support for select ParentNode APIs.
   ([#389](https://github.com/webcomponents/polyfills/pull/389))
 

--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -13,6 +13,7 @@ import {EventTargetPatches} from './patches/EventTarget.js';
 import {NodePatches} from './patches/Node.js';
 import {SlotablePatches} from './patches/Slotable.js';
 import {ParentNodePatches, ParentNodeDocumentOrFragmentPatches} from './patches/ParentNode.js';
+import {ChildNodePatches} from './patches/ChildNode.js';
 import {ElementPatches, ElementShadowPatches} from './patches/Element.js';
 import {ElementOrShadowRootPatches} from './patches/ElementOrShadowRoot.js';
 import {HTMLElementPatches} from './patches/HTMLElement.js';
@@ -57,14 +58,16 @@ const patchMap = {
   Comment: [SlotablePatches],
   CDATASection: [SlotablePatches],
   ProcessingInstruction: [SlotablePatches],
-  Element: [ElementPatches, ParentNodePatches, SlotablePatches,
+  Element: [ElementPatches, ParentNodePatches, ChildNodePatches, SlotablePatches,
     ElementShouldHaveInnerHTML ? ElementOrShadowRootPatches : null,
     !window.HTMLSlotElement ? SlotPatches : null],
   HTMLElement: [HTMLElementPatches, NonStandardHTMLElement],
   HTMLSlotElement: [SlotPatches],
   DocumentFragment: [ParentNodeDocumentOrFragmentPatches, DocumentOrFragmentPatches],
   Document: [DocumentPatches, ParentNodeDocumentOrFragmentPatches, DocumentOrFragmentPatches, DocumentOrShadowRootPatches],
-  Window: [WindowPatches]
+  Window: [WindowPatches],
+  CharacterData: [ChildNodePatches],
+  DocumentType: [ChildNodePatches],
 }
 
 const getPatchPrototype = (name) => window[name] && window[name].prototype;

--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -67,7 +67,6 @@ const patchMap = {
   Document: [DocumentPatches, ParentNodeDocumentOrFragmentPatches, DocumentOrFragmentPatches, DocumentOrShadowRootPatches],
   Window: [WindowPatches],
   CharacterData: [ChildNodePatches],
-  DocumentType: [ChildNodePatches],
 }
 
 const getPatchPrototype = (name) => window[name] && window[name].prototype;

--- a/packages/shadydom/src/patches/ChildNode.js
+++ b/packages/shadydom/src/patches/ChildNode.js
@@ -1,0 +1,60 @@
+/**
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+import * as utils from '../utils.js';
+
+export const ChildNodePatches = utils.getOwnPropertyDescriptors({
+  /** @this {Element} */
+  after(...args) {
+    const parentNode = this[utils.SHADY_PREFIX + 'parentNode'];
+    if (parentNode === null) {
+      return;
+    }
+    const nextSibling = this[utils.SHADY_PREFIX + 'nextSibling'];
+    for (const arg of args) {
+      const newChild = typeof arg === 'string' ? document.createTextNode(arg) : arg;
+      parentNode[utils.SHADY_PREFIX + 'insertBefore'](newChild, nextSibling);
+    }
+  },
+
+  /** @this {Element} */
+  before(...args) {
+    const parentNode = this[utils.SHADY_PREFIX + 'parentNode'];
+    if (parentNode === null) {
+      return;
+    }
+    for (const arg of args) {
+      const newChild = typeof arg === 'string' ? document.createTextNode(arg) : arg;
+      parentNode[utils.SHADY_PREFIX + 'insertBefore'](newChild, this);
+    }
+  },
+
+  /** @this {Element} */
+  remove() {
+    const parentNode = this[utils.SHADY_PREFIX + 'parentNode'];
+    if (parentNode === null) {
+      return;
+    }
+    parentNode[utils.SHADY_PREFIX + 'removeChild'](this);
+  },
+
+  /** @this {Element} */
+  replaceWith(...args) {
+    const parentNode = this[utils.SHADY_PREFIX + 'parentNode'];
+    if (parentNode === null) {
+      return;
+    }
+    for (const arg of args) {
+      const newChild = typeof arg === 'string' ? document.createTextNode(arg) : arg;
+      parentNode[utils.SHADY_PREFIX + 'insertBefore'](newChild, this);
+    }
+    parentNode[utils.SHADY_PREFIX + 'removeChild'](this);
+  },
+});

--- a/packages/shadydom/src/patches/ChildNode.js
+++ b/packages/shadydom/src/patches/ChildNode.js
@@ -51,10 +51,11 @@ export const ChildNodePatches = utils.getOwnPropertyDescriptors({
     if (parentNode === null) {
       return;
     }
+    const nextSibling = this[utils.SHADY_PREFIX + 'nextSibling'];
+    parentNode[utils.SHADY_PREFIX + 'removeChild'](this);
     for (const arg of args) {
       const newChild = typeof arg === 'string' ? document.createTextNode(arg) : arg;
-      parentNode[utils.SHADY_PREFIX + 'insertBefore'](newChild, this);
+      parentNode[utils.SHADY_PREFIX + 'insertBefore'](newChild, nextSibling);
     }
-    parentNode[utils.SHADY_PREFIX + 'removeChild'](this);
   },
 });

--- a/packages/shadydom/src/patches/ChildNode.js
+++ b/packages/shadydom/src/patches/ChildNode.js
@@ -18,10 +18,7 @@ export const ChildNodePatches = utils.getOwnPropertyDescriptors({
       return;
     }
     const nextSibling = this[utils.SHADY_PREFIX + 'nextSibling'];
-    for (const arg of args) {
-      const newChild = typeof arg === 'string' ? document.createTextNode(arg) : arg;
-      parentNode[utils.SHADY_PREFIX + 'insertBefore'](newChild, nextSibling);
-    }
+    parentNode[utils.SHADY_PREFIX + 'insertBefore'](utils.convertNodesIntoANode(...args), nextSibling);
   },
 
   /** @this {Element} */
@@ -30,10 +27,7 @@ export const ChildNodePatches = utils.getOwnPropertyDescriptors({
     if (parentNode === null) {
       return;
     }
-    for (const arg of args) {
-      const newChild = typeof arg === 'string' ? document.createTextNode(arg) : arg;
-      parentNode[utils.SHADY_PREFIX + 'insertBefore'](newChild, this);
-    }
+    parentNode[utils.SHADY_PREFIX + 'insertBefore'](utils.convertNodesIntoANode(...args), this);
   },
 
   /** @this {Element} */
@@ -53,9 +47,6 @@ export const ChildNodePatches = utils.getOwnPropertyDescriptors({
     }
     const nextSibling = this[utils.SHADY_PREFIX + 'nextSibling'];
     parentNode[utils.SHADY_PREFIX + 'removeChild'](this);
-    for (const arg of args) {
-      const newChild = typeof arg === 'string' ? document.createTextNode(arg) : arg;
-      parentNode[utils.SHADY_PREFIX + 'insertBefore'](newChild, nextSibling);
-    }
+    parentNode[utils.SHADY_PREFIX + 'insertBefore'](utils.convertNodesIntoANode(...args), nextSibling);
   },
 });

--- a/packages/shadydom/src/wrapper.js
+++ b/packages/shadydom/src/wrapper.js
@@ -257,6 +257,22 @@ class Wrapper {
     return this.node[utils.SHADY_PREFIX + 'replaceChildren'](...args);
   }
 
+  after(...args) {
+    return this.node[utils.SHADY_PREFIX + 'after'](...args);
+  }
+
+  before(...args) {
+    return this.node[utils.SHADY_PREFIX + 'before'](...args);
+  }
+
+  remove() {
+    return this.node[utils.SHADY_PREFIX + 'remove']();
+  }
+
+  replaceWith(...args) {
+    return this.node[utils.SHADY_PREFIX + 'replaceWith'](...args);
+  }
+
 }
 
 const addEventPropertyWrapper = (name) => {

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -592,6 +592,17 @@ suite('Mutate light DOM', function() {
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a><b></b>c<d></d>');
   });
 
+  test('after - mutate host - single string', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    helloAnchor.after('b');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>b');
+  });
+
   test('after - mutate shadow', function() {
     ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
     const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
@@ -605,6 +616,18 @@ suite('Mutate light DOM', function() {
     assert.strictEqual(getComposedHTML(host), '<a>Hello</a><b></b>c<d></d>');
   });
 
+  test('after - mutate shadow - single string', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    const slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).querySelector('slot');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    ShadyDOM.wrapIfNeeded(slot).after('b');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>b');
+  });
+
   test('before - mutate host', function() {
     ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
     const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
@@ -614,6 +637,17 @@ suite('Mutate light DOM', function() {
     helloAnchor.before(document.createElement('b'), 'c', document.createElement('d'));
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<b></b>c<d></d><a>Hello</a>');
+  });
+
+  test('before - mutate host - single string', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    helloAnchor.before('b');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), 'b<a>Hello</a>');
   });
 
   test('before - mutate shadow', function() {
@@ -627,6 +661,18 @@ suite('Mutate light DOM', function() {
         document.createElement('b'), 'c', document.createElement('d'));
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<b></b>c<d></d><a>Hello</a>');
+  });
+
+  test('before - mutate shadow - single string', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    const slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).querySelector('slot');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    ShadyDOM.wrapIfNeeded(slot).before('b');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), 'b<a>Hello</a>');
   });
 
   test('remove - mutate host', function() {
@@ -663,6 +709,17 @@ suite('Mutate light DOM', function() {
     assert.strictEqual(getComposedHTML(host), '<b></b>c<d></d>');
   });
 
+  test('replaceWith - mutate host - single string', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    helloAnchor.replaceWith('b');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), 'b');
+  });
+
   test('replaceWith - mutate shadow', function() {
     ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
     const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
@@ -674,6 +731,18 @@ suite('Mutate light DOM', function() {
         document.createElement('b'), 'c', document.createElement('d'));
     ShadyDOM.flush();
     assert.strictEqual(getComposedHTML(host), '<b></b>c<d></d>');
+  });
+
+  test('replaceWith - mutate shadow - single string', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    const slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).querySelector('slot');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    ShadyDOM.wrapIfNeeded(slot).replaceWith('b');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), 'b');
   });
 
   test('querySelectorAll .shadowRoot', function() {

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -521,6 +521,101 @@ suite('Mutate light DOM', function() {
     assert.strictEqual(getComposedHTML(host), '<b></b>c<d></d>');
   });
 
+  test('after - mutate host', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    helloAnchor.after(document.createElement('b'), 'c', document.createElement('d'));
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a><b></b>c<d></d>');
+  });
+
+  test('after - mutate shadow', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    const slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).querySelector('slot');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    ShadyDOM.wrapIfNeeded(slot).after(
+        document.createElement('b'), 'c', document.createElement('d'));
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a><b></b>c<d></d>');
+  });
+
+  test('before - mutate host', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    helloAnchor.before(document.createElement('b'), 'c', document.createElement('d'));
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<b></b>c<d></d><a>Hello</a>');
+  });
+
+  test('before - mutate shadow', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    const slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).querySelector('slot');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    ShadyDOM.wrapIfNeeded(slot).before(
+        document.createElement('b'), 'c', document.createElement('d'));
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<b></b>c<d></d><a>Hello</a>');
+  });
+
+  test('remove - mutate host', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    helloAnchor.remove();
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '');
+  });
+
+  test('remove - mutate shadow', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    const slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).querySelector('slot');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    ShadyDOM.wrapIfNeeded(slot).remove();
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '');
+  });
+
+  test('replaceWith - mutate host', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    helloAnchor.replaceWith(document.createElement('b'), 'c', document.createElement('d'));
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<b></b>c<d></d>');
+  });
+
+  test('replaceWith - mutate shadow', function() {
+    ShadyDOM.wrapIfNeeded(host).innerHTML = '<a>Hello</a>';
+    const helloAnchor = ShadyDOM.wrapIfNeeded(host).querySelector('a');
+    ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot>';
+    const slot = ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).querySelector('slot');
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<a>Hello</a>');
+    ShadyDOM.wrapIfNeeded(slot).replaceWith(
+        document.createElement('b'), 'c', document.createElement('d'));
+    ShadyDOM.flush();
+    assert.strictEqual(getComposedHTML(host), '<b></b>c<d></d>');
+  });
+
   test('querySelectorAll .shadowRoot', function() {
     ShadyDOM.wrapIfNeeded(host).innerHTML = '<div id="main"></div>';
     ShadyDOM.wrapIfNeeded(ShadyDOM.wrapIfNeeded(host).shadowRoot).innerHTML = '<slot></slot><span id="main"></span>' +

--- a/packages/tests/webcomponentsjs_/child-node/after.html
+++ b/packages/tests/webcomponentsjs_/child-node/after.html
@@ -14,7 +14,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     for (const item of [
       CharacterData.prototype,
-      DocumentType.prototype,
       Element.prototype,
     ]) {
       delete item.after;
@@ -70,46 +69,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert(container.childNodes[2].nodeType === Node.TEXT_NODE);
           assert(container.childNodes[2].textContent === 'This is some text.');
           assert(container.childNodes[3] === child3);
-        });
-      });
-
-      suite('DocumentType', function() {
-        test('Inserts a comment after the target node', () => {
-          const container = document.implementation.createHTMLDocument('');
-          const target = container.doctype;
-          let firstChild;
-          while ((firstChild = container.firstChild) !== null) {
-            container.removeChild(firstChild);
-          }
-          container.appendChild(target);
-
-          const child = document.createComment('');
-          target.after(child);
-
-          assert(child.parentNode === container);
-          assert(container.childNodes.length === 2);
-          assert(container.childNodes[0] === target);
-          assert(container.childNodes[1] === child);
-        });
-
-        test('Inserts multiple nodes after the target node', () => {
-          const container = document.implementation.createHTMLDocument('');
-          const target = container.doctype;
-          let firstChild;
-          while ((firstChild = container.firstChild) !== null) {
-            container.removeChild(firstChild);
-          }
-          container.appendChild(target);
-
-          // Text nodes can't be inserted as children of documents.
-          const child1 = document.createComment('');
-          const child2 = document.createComment('');
-          target.after(child1, child2);
-
-          assert(container.childNodes.length === 3);
-          assert(container.childNodes[0] === target);
-          assert(container.childNodes[1] === child1);
-          assert(container.childNodes[2] === child2);
         });
       });
 

--- a/packages/tests/webcomponentsjs_/child-node/after.html
+++ b/packages/tests/webcomponentsjs_/child-node/after.html
@@ -26,55 +26,51 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
   <script>
-    const testBefore = (createChildNode) => {
-      test('Inserts an element after the target node', () => {
-        const container = document.createElement('div');
-        const target = createChildNode();
-        container.appendChild(target);
-
-        const child = document.createElement('div');
-        target.after(child);
-
-        assert(child.parentNode === container);
-        assert(container.childNodes.length === 2);
-        assert(container.childNodes[0] === target);
-        assert(container.childNodes[1] === child);
-      });
-
-      test('Inserts a text node after the target node', () => {
-        const container = document.createElement('div');
-        const target = createChildNode();
-        container.appendChild(target);
-
-        target.after('This is some text.');
-
-        assert(container.childNodes.length === 2);
-        assert(container.childNodes[0] === target);
-        assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
-        assert(container.childNodes[1].textContent === 'This is some text.');
-      });
-
-      test('Inserts multiple types of nodes after the target node', () => {
-        const container = document.createElement('div');
-        const target = createChildNode();
-        container.appendChild(target);
-
-        const child1 = document.createElement('div');
-        const child3 = document.createElement('div');
-        target.after(child1, 'This is some text.', child3);
-
-        assert(container.childNodes.length === 4);
-        assert(container.childNodes[0] === target);
-        assert(container.childNodes[1] === child1);
-        assert(container.childNodes[2].nodeType === Node.TEXT_NODE);
-        assert(container.childNodes[2].textContent === 'This is some text.');
-        assert(container.childNodes[3] === child3);
-      });
-    };
-
     suite('ChildNode after', function() {
       suite('CharacterData', function() {
-        testBefore(() => document.createTextNode(''));
+        test('Inserts an element after the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createTextNode('');
+          container.appendChild(target);
+
+          const child = document.createElement('div');
+          target.after(child);
+
+          assert(child.parentNode === container);
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0] === target);
+          assert(container.childNodes[1] === child);
+        });
+
+        test('Inserts a text node after the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createTextNode('');
+          container.appendChild(target);
+
+          target.after('This is some text.');
+
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0] === target);
+          assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[1].textContent === 'This is some text.');
+        });
+
+        test('Inserts multiple types of nodes after the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createTextNode('');
+          container.appendChild(target);
+
+          const child1 = document.createElement('div');
+          const child3 = document.createElement('div');
+          target.after(child1, 'This is some text.', child3);
+
+          assert(container.childNodes.length === 4);
+          assert(container.childNodes[0] === target);
+          assert(container.childNodes[1] === child1);
+          assert(container.childNodes[2].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[2].textContent === 'This is some text.');
+          assert(container.childNodes[3] === child3);
+        });
       });
 
       suite('DocumentType', function() {
@@ -118,7 +114,49 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('Element', function() {
-        testBefore(() => document.createElement('div'));
+        test('Inserts an element after the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createElement('div');
+          container.appendChild(target);
+
+          const child = document.createElement('div');
+          target.after(child);
+
+          assert(child.parentNode === container);
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0] === target);
+          assert(container.childNodes[1] === child);
+        });
+
+        test('Inserts a text node after the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createElement('div');
+          container.appendChild(target);
+
+          target.after('This is some text.');
+
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0] === target);
+          assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[1].textContent === 'This is some text.');
+        });
+
+        test('Inserts multiple types of nodes after the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createElement('div');
+          container.appendChild(target);
+
+          const child1 = document.createElement('div');
+          const child3 = document.createElement('div');
+          target.after(child1, 'This is some text.', child3);
+
+          assert(container.childNodes.length === 4);
+          assert(container.childNodes[0] === target);
+          assert(container.childNodes[1] === child1);
+          assert(container.childNodes[2].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[2].textContent === 'This is some text.');
+          assert(container.childNodes[3] === child3);
+        });
       });
     });
   </script>

--- a/packages/tests/webcomponentsjs_/child-node/after.html
+++ b/packages/tests/webcomponentsjs_/child-node/after.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>ChildNode after</title>
+  <script>
+    for (const item of [
+      CharacterData.prototype,
+      DocumentType.prototype,
+      Element.prototype,
+    ]) {
+      delete item.after;
+    }
+  </script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
+  <script src="../wct-config.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+  <script>
+    const testBefore = (createChildNode) => {
+      test('Inserts an element after the target node', () => {
+        const container = document.createElement('div');
+        const target = createChildNode();
+        container.appendChild(target);
+
+        const child = document.createElement('div');
+        target.after(child);
+
+        assert(child.parentNode === container);
+        assert(container.childNodes.length === 2);
+        assert(container.childNodes[0] === target);
+        assert(container.childNodes[1] === child);
+      });
+
+      test('Inserts a text node after the target node', () => {
+        const container = document.createElement('div');
+        const target = createChildNode();
+        container.appendChild(target);
+
+        target.after('This is some text.');
+
+        assert(container.childNodes.length === 2);
+        assert(container.childNodes[0] === target);
+        assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
+        assert(container.childNodes[1].textContent === 'This is some text.');
+      });
+
+      test('Inserts multiple types of nodes after the target node', () => {
+        const container = document.createElement('div');
+        const target = createChildNode();
+        container.appendChild(target);
+
+        const child1 = document.createElement('div');
+        const child3 = document.createElement('div');
+        target.after(child1, 'This is some text.', child3);
+
+        assert(container.childNodes.length === 4);
+        assert(container.childNodes[0] === target);
+        assert(container.childNodes[1] === child1);
+        assert(container.childNodes[2].nodeType === Node.TEXT_NODE);
+        assert(container.childNodes[2].textContent === 'This is some text.');
+        assert(container.childNodes[3] === child3);
+      });
+    };
+
+    suite('ChildNode after', function() {
+      suite('CharacterData', function() {
+        testBefore(() => document.createTextNode(''));
+      });
+
+      suite('DocumentType', function() {
+        test('Inserts a comment after the target node', () => {
+          const container = document.implementation.createHTMLDocument('');
+          const target = container.doctype;
+          let firstChild;
+          while ((firstChild = container.firstChild) !== null) {
+            container.removeChild(firstChild);
+          }
+          container.appendChild(target);
+
+          const child = document.createComment('');
+          target.after(child);
+
+          assert(child.parentNode === container);
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0] === target);
+          assert(container.childNodes[1] === child);
+        });
+
+        test('Inserts multiple nodes after the target node', () => {
+          const container = document.implementation.createHTMLDocument('');
+          const target = container.doctype;
+          let firstChild;
+          while ((firstChild = container.firstChild) !== null) {
+            container.removeChild(firstChild);
+          }
+          container.appendChild(target);
+
+          // Text nodes can't be inserted as children of documents.
+          const child1 = document.createComment('');
+          const child2 = document.createComment('');
+          target.after(child1, child2);
+
+          assert(container.childNodes.length === 3);
+          assert(container.childNodes[0] === target);
+          assert(container.childNodes[1] === child1);
+          assert(container.childNodes[2] === child2);
+        });
+      });
+
+      suite('Element', function() {
+        testBefore(() => document.createElement('div'));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/packages/tests/webcomponentsjs_/child-node/before.html
+++ b/packages/tests/webcomponentsjs_/child-node/before.html
@@ -26,55 +26,51 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
   <script>
-    const testBefore = (createChildNode) => {
-      test('Inserts an element before the target node', () => {
-        const container = document.createElement('div');
-        const target = createChildNode();
-        container.appendChild(target);
-
-        const child = document.createElement('div');
-        target.before(child);
-
-        assert(child.parentNode === container);
-        assert(container.childNodes.length === 2);
-        assert(container.childNodes[0] === child);
-        assert(container.childNodes[1] === target);
-      });
-
-      test('Inserts a text node before the target node', () => {
-        const container = document.createElement('div');
-        const target = createChildNode();
-        container.appendChild(target);
-
-        target.before('This is some text.');
-
-        assert(container.childNodes.length === 2);
-        assert(container.childNodes[0].nodeType === Node.TEXT_NODE);
-        assert(container.childNodes[0].textContent === 'This is some text.');
-        assert(container.childNodes[1] === target);
-      });
-
-      test('Inserts multiple types of nodes before the target node', () => {
-        const container = document.createElement('div');
-        const target = createChildNode();
-        container.appendChild(target);
-
-        const child0 = document.createElement('div');
-        const child2 = document.createElement('div');
-        target.before(child0, 'This is some text.', child2);
-
-        assert(container.childNodes.length === 4);
-        assert(container.childNodes[0] === child0);
-        assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
-        assert(container.childNodes[1].textContent === 'This is some text.');
-        assert(container.childNodes[2] === child2);
-        assert(container.childNodes[3] === target);
-      });
-    };
-
     suite('ChildNode before', function() {
       suite('CharacterData', function() {
-        testBefore(() => document.createTextNode(''));
+        test('Inserts an element before the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createTextNode('');
+          container.appendChild(target);
+
+          const child = document.createElement('div');
+          target.before(child);
+
+          assert(child.parentNode === container);
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0] === child);
+          assert(container.childNodes[1] === target);
+        });
+
+        test('Inserts a text node before the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createTextNode('');
+          container.appendChild(target);
+
+          target.before('This is some text.');
+
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[0].textContent === 'This is some text.');
+          assert(container.childNodes[1] === target);
+        });
+
+        test('Inserts multiple types of nodes before the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createTextNode('');
+          container.appendChild(target);
+
+          const child0 = document.createElement('div');
+          const child2 = document.createElement('div');
+          target.before(child0, 'This is some text.', child2);
+
+          assert(container.childNodes.length === 4);
+          assert(container.childNodes[0] === child0);
+          assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[1].textContent === 'This is some text.');
+          assert(container.childNodes[2] === child2);
+          assert(container.childNodes[3] === target);
+        });
       });
 
       suite('DocumentType', function() {
@@ -118,7 +114,49 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('Element', function() {
-        testBefore(() => document.createElement('div'));
+        test('Inserts an element before the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createElement('div');
+          container.appendChild(target);
+
+          const child = document.createElement('div');
+          target.before(child);
+
+          assert(child.parentNode === container);
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0] === child);
+          assert(container.childNodes[1] === target);
+        });
+
+        test('Inserts a text node before the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createElement('div');
+          container.appendChild(target);
+
+          target.before('This is some text.');
+
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[0].textContent === 'This is some text.');
+          assert(container.childNodes[1] === target);
+        });
+
+        test('Inserts multiple types of nodes before the target node', () => {
+          const container = document.createElement('div');
+          const target = document.createElement('div');
+          container.appendChild(target);
+
+          const child0 = document.createElement('div');
+          const child2 = document.createElement('div');
+          target.before(child0, 'This is some text.', child2);
+
+          assert(container.childNodes.length === 4);
+          assert(container.childNodes[0] === child0);
+          assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[1].textContent === 'This is some text.');
+          assert(container.childNodes[2] === child2);
+          assert(container.childNodes[3] === target);
+        });
       });
     });
   </script>

--- a/packages/tests/webcomponentsjs_/child-node/before.html
+++ b/packages/tests/webcomponentsjs_/child-node/before.html
@@ -14,7 +14,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     for (const item of [
       CharacterData.prototype,
-      DocumentType.prototype,
       Element.prototype,
     ]) {
       delete item.before;
@@ -70,46 +69,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert(container.childNodes[1].textContent === 'This is some text.');
           assert(container.childNodes[2] === child2);
           assert(container.childNodes[3] === target);
-        });
-      });
-
-      suite('DocumentType', function() {
-        test('Inserts a comment before the target node', () => {
-          const container = document.implementation.createHTMLDocument('');
-          const target = container.doctype;
-          let firstChild;
-          while ((firstChild = container.firstChild) !== null) {
-            container.removeChild(firstChild);
-          }
-          container.appendChild(target);
-
-          const child = document.createComment('');
-          target.before(child);
-
-          assert(child.parentNode === container);
-          assert(container.childNodes.length === 2);
-          assert(container.childNodes[0] === child);
-          assert(container.childNodes[1] === target);
-        });
-
-        test('Inserts multiple nodes before the target node', () => {
-          const container = document.implementation.createHTMLDocument('');
-          const target = container.doctype;
-          let firstChild;
-          while ((firstChild = container.firstChild) !== null) {
-            container.removeChild(firstChild);
-          }
-          container.appendChild(target);
-
-          // Text nodes can't be inserted as children of documents.
-          const child0 = document.createComment('');
-          const child1 = document.createComment('');
-          target.before(child0, child1);
-
-          assert(container.childNodes.length === 3);
-          assert(container.childNodes[0] === child0);
-          assert(container.childNodes[1] === child1);
-          assert(container.childNodes[2] === target);
         });
       });
 

--- a/packages/tests/webcomponentsjs_/child-node/before.html
+++ b/packages/tests/webcomponentsjs_/child-node/before.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>ChildNode before</title>
+  <script>
+    for (const item of [
+      CharacterData.prototype,
+      DocumentType.prototype,
+      Element.prototype,
+    ]) {
+      delete item.before;
+    }
+  </script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
+  <script src="../wct-config.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+  <script>
+    const testBefore = (createChildNode) => {
+      test('Inserts an element before the target node', () => {
+        const container = document.createElement('div');
+        const target = createChildNode();
+        container.appendChild(target);
+
+        const child = document.createElement('div');
+        target.before(child);
+
+        assert(child.parentNode === container);
+        assert(container.childNodes.length === 2);
+        assert(container.childNodes[0] === child);
+        assert(container.childNodes[1] === target);
+      });
+
+      test('Inserts a text node before the target node', () => {
+        const container = document.createElement('div');
+        const target = createChildNode();
+        container.appendChild(target);
+
+        target.before('This is some text.');
+
+        assert(container.childNodes.length === 2);
+        assert(container.childNodes[0].nodeType === Node.TEXT_NODE);
+        assert(container.childNodes[0].textContent === 'This is some text.');
+        assert(container.childNodes[1] === target);
+      });
+
+      test('Inserts multiple types of nodes before the target node', () => {
+        const container = document.createElement('div');
+        const target = createChildNode();
+        container.appendChild(target);
+
+        const child0 = document.createElement('div');
+        const child2 = document.createElement('div');
+        target.before(child0, 'This is some text.', child2);
+
+        assert(container.childNodes.length === 4);
+        assert(container.childNodes[0] === child0);
+        assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
+        assert(container.childNodes[1].textContent === 'This is some text.');
+        assert(container.childNodes[2] === child2);
+        assert(container.childNodes[3] === target);
+      });
+    };
+
+    suite('ChildNode before', function() {
+      suite('CharacterData', function() {
+        testBefore(() => document.createTextNode(''));
+      });
+
+      suite('DocumentType', function() {
+        test('Inserts a comment before the target node', () => {
+          const container = document.implementation.createHTMLDocument('');
+          const target = container.doctype;
+          let firstChild;
+          while ((firstChild = container.firstChild) !== null) {
+            container.removeChild(firstChild);
+          }
+          container.appendChild(target);
+
+          const child = document.createComment('');
+          target.before(child);
+
+          assert(child.parentNode === container);
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0] === child);
+          assert(container.childNodes[1] === target);
+        });
+
+        test('Inserts multiple nodes before the target node', () => {
+          const container = document.implementation.createHTMLDocument('');
+          const target = container.doctype;
+          let firstChild;
+          while ((firstChild = container.firstChild) !== null) {
+            container.removeChild(firstChild);
+          }
+          container.appendChild(target);
+
+          // Text nodes can't be inserted as children of documents.
+          const child0 = document.createComment('');
+          const child1 = document.createComment('');
+          target.before(child0, child1);
+
+          assert(container.childNodes.length === 3);
+          assert(container.childNodes[0] === child0);
+          assert(container.childNodes[1] === child1);
+          assert(container.childNodes[2] === target);
+        });
+      });
+
+      suite('Element', function() {
+        testBefore(() => document.createElement('div'));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/packages/tests/webcomponentsjs_/child-node/index.html
+++ b/packages/tests/webcomponentsjs_/child-node/index.html
@@ -5,5 +5,6 @@
     './after.html',
     './before.html',
     './remove.html',
+    './replace-with.html',
   ]);
 </script>

--- a/packages/tests/webcomponentsjs_/child-node/index.html
+++ b/packages/tests/webcomponentsjs_/child-node/index.html
@@ -2,6 +2,7 @@
 <script src="../../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script>
   WCT.loadSuites([
+    './after.html',
     './before.html',
     './remove.html',
   ]);

--- a/packages/tests/webcomponentsjs_/child-node/index.html
+++ b/packages/tests/webcomponentsjs_/child-node/index.html
@@ -2,6 +2,7 @@
 <script src="../../../../node_modules/wct-browser-legacy/browser.js"></script>
 <script>
   WCT.loadSuites([
+    './before.html',
     './remove.html',
   ]);
 </script>

--- a/packages/tests/webcomponentsjs_/child-node/index.html
+++ b/packages/tests/webcomponentsjs_/child-node/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<script src="../../../../node_modules/wct-browser-legacy/browser.js"></script>
+<script>
+  WCT.loadSuites([
+    './remove.html',
+  ]);
+</script>

--- a/packages/tests/webcomponentsjs_/child-node/remove.html
+++ b/packages/tests/webcomponentsjs_/child-node/remove.html
@@ -26,22 +26,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
   <script>
-    const testRemove = (createChild) => {
-      test('Removes the node', () => {
-        const parent = document.createElement('div');
-        const child = createChild();
-
-        parent.appendChild(child);
-        assert.equal(child.parentNode, parent);
-
-        child.remove();
-        assert.equal(child.parentNode, null);
-      });
-    };
-
     suite('ChildNode remove', function() {
       suite('CharacterData', function() {
-        testRemove(() => document.createTextNode(''));
+        test('Removes the node', () => {
+          const parent = document.createElement('div');
+          const child = document.createTextNode('');
+
+          parent.appendChild(child);
+          assert.equal(child.parentNode, parent);
+
+          child.remove();
+          assert.equal(child.parentNode, null);
+        });
       });
 
       suite('DocumentType', function() {
@@ -61,7 +57,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('Element', function() {
-        testRemove(() => document.createElement('div'));
+        test('Removes the node', () => {
+          const parent = document.createElement('div');
+          const child = document.createElement('div');
+
+          parent.appendChild(child);
+          assert.equal(child.parentNode, parent);
+
+          child.remove();
+          assert.equal(child.parentNode, null);
+        });
       });
     });
   </script>

--- a/packages/tests/webcomponentsjs_/child-node/remove.html
+++ b/packages/tests/webcomponentsjs_/child-node/remove.html
@@ -14,7 +14,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     for (const item of [
       CharacterData.prototype,
-      DocumentType.prototype,
       Element.prototype,
     ]) {
       delete item.remove;
@@ -33,22 +32,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           const child = document.createTextNode('');
 
           parent.appendChild(child);
-          assert.equal(child.parentNode, parent);
-
-          child.remove();
-          assert.equal(child.parentNode, null);
-        });
-      });
-
-      suite('DocumentType', function() {
-        test('Removes the node', () => {
-          // Doctypes can only be inserted as children of documents.
-          const parent = document.implementation.createHTMLDocument('');
-          parent.removeChild(parent.doctype);
-          const child = document.implementation.createHTMLDocument('').doctype;
-
-          // The doctype must come before the document element.
-          parent.insertBefore(child, parent.documentElement);
           assert.equal(child.parentNode, parent);
 
           child.remove();

--- a/packages/tests/webcomponentsjs_/child-node/remove.html
+++ b/packages/tests/webcomponentsjs_/child-node/remove.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>ChildNode remove</title>
+  <script>
+    for (const item of [
+      CharacterData.prototype,
+      DocumentType.prototype,
+      Element.prototype,
+    ]) {
+      delete item.remove;
+    }
+  </script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
+  <script src="../wct-config.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+  <script>
+    const testRemove = (createChild) => {
+      test('Removes the node', () => {
+        const parent = document.createElement('div');
+        const child = createChild();
+
+        parent.appendChild(child);
+        assert.equal(child.parentNode, parent);
+
+        child.remove();
+        assert.equal(child.parentNode, null);
+      });
+    };
+
+    suite('ChildNode remove', function() {
+      suite('CharacterData', function() {
+        testRemove(() => document.createTextNode(''));
+      });
+
+      suite('DocumentType', function() {
+        test('Removes the node', () => {
+          // Doctypes can only be inserted as children of documents.
+          const parent = document.implementation.createHTMLDocument('');
+          parent.removeChild(parent.doctype);
+          const child = document.implementation.createHTMLDocument('').doctype;
+
+          // The doctype must come before the document element.
+          parent.insertBefore(child, parent.documentElement);
+          assert.equal(child.parentNode, parent);
+
+          child.remove();
+          assert.equal(child.parentNode, null);
+        });
+      });
+
+      suite('Element', function() {
+        testRemove(() => document.createElement('div'));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/packages/tests/webcomponentsjs_/child-node/replace-with.html
+++ b/packages/tests/webcomponentsjs_/child-node/replace-with.html
@@ -14,7 +14,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     for (const item of [
       CharacterData.prototype,
-      DocumentType.prototype,
       Element.prototype,
     ]) {
       delete item.replaceWith;
@@ -67,44 +66,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
           assert(container.childNodes[1].textContent === 'This is some text.');
           assert(container.childNodes[2] === child2);
-        });
-      });
-
-      suite('DocumentType', function() {
-        test('Replaces the target node with a comment', () => {
-          const container = document.implementation.createHTMLDocument('');
-          const target = container.doctype;
-          let firstChild;
-          while ((firstChild = container.firstChild) !== null) {
-            container.removeChild(firstChild);
-          }
-          container.appendChild(target);
-
-          const child = document.createComment('');
-          target.replaceWith(child);
-
-          assert(child.parentNode === container);
-          assert(container.childNodes.length === 1);
-          assert(container.childNodes[0] === child);
-        });
-
-        test('Replaces the target node with multiple comments', () => {
-          const container = document.implementation.createHTMLDocument('');
-          const target = container.doctype;
-          let firstChild;
-          while ((firstChild = container.firstChild) !== null) {
-            container.removeChild(firstChild);
-          }
-          container.appendChild(target);
-
-          // Text nodes can't be inserted as children of documents.
-          const child0 = document.createComment('');
-          const child1 = document.createComment('');
-          target.replaceWith(child0, child1);
-
-          assert(container.childNodes.length === 2);
-          assert(container.childNodes[0] === child0);
-          assert(container.childNodes[1] === child1);
         });
       });
 

--- a/packages/tests/webcomponentsjs_/child-node/replace-with.html
+++ b/packages/tests/webcomponentsjs_/child-node/replace-with.html
@@ -26,52 +26,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
   <script>
-    const testBefore = (createChildNode) => {
-      test('Replaces the target node with an element', () => {
-        const container = document.createElement('div');
-        const target = createChildNode();
-        container.appendChild(target);
-
-        const child = document.createElement('div');
-        target.replaceWith(child);
-
-        assert(child.parentNode === container);
-        assert(container.childNodes.length === 1);
-        assert(container.childNodes[0] === child);
-      });
-
-      test('Replaces the target node with a text node', () => {
-        const container = document.createElement('div');
-        const target = createChildNode();
-        container.appendChild(target);
-
-        target.replaceWith('This is some text.');
-
-        assert(container.childNodes.length === 1);
-        assert(container.childNodes[0].nodeType === Node.TEXT_NODE);
-        assert(container.childNodes[0].textContent === 'This is some text.');
-      });
-
-      test('Replaces the target node with multiple types of nodes', () => {
-        const container = document.createElement('div');
-        const target = createChildNode();
-        container.appendChild(target);
-
-        const child0 = document.createElement('div');
-        const child2 = document.createElement('div');
-        target.replaceWith(child0, 'This is some text.', child2);
-
-        assert(container.childNodes.length === 3);
-        assert(container.childNodes[0] === child0);
-        assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
-        assert(container.childNodes[1].textContent === 'This is some text.');
-        assert(container.childNodes[2] === child2);
-      });
-    };
-
     suite('ChildNode replaceWith', function() {
       suite('CharacterData', function() {
-        testBefore(() => document.createTextNode(''));
+        test('Replaces the target node with an element', () => {
+          const container = document.createElement('div');
+          const target = document.createTextNode('');
+          container.appendChild(target);
+
+          const child = document.createElement('div');
+          target.replaceWith(child);
+
+          assert(child.parentNode === container);
+          assert(container.childNodes.length === 1);
+          assert(container.childNodes[0] === child);
+        });
+
+        test('Replaces the target node with a text node', () => {
+          const container = document.createElement('div');
+          const target = document.createTextNode('');
+          container.appendChild(target);
+
+          target.replaceWith('This is some text.');
+
+          assert(container.childNodes.length === 1);
+          assert(container.childNodes[0].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[0].textContent === 'This is some text.');
+        });
+
+        test('Replaces the target node with multiple types of nodes', () => {
+          const container = document.createElement('div');
+          const target = document.createTextNode('');
+          container.appendChild(target);
+
+          const child0 = document.createElement('div');
+          const child2 = document.createElement('div');
+          target.replaceWith(child0, 'This is some text.', child2);
+
+          assert(container.childNodes.length === 3);
+          assert(container.childNodes[0] === child0);
+          assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[1].textContent === 'This is some text.');
+          assert(container.childNodes[2] === child2);
+        });
       });
 
       suite('DocumentType', function() {
@@ -113,7 +109,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('Element', function() {
-        testBefore(() => document.createElement('div'));
+        test('Replaces the target node with an element', () => {
+          const container = document.createElement('div');
+          const target = document.createElement('div');
+          container.appendChild(target);
+
+          const child = document.createElement('div');
+          target.replaceWith(child);
+
+          assert(child.parentNode === container);
+          assert(container.childNodes.length === 1);
+          assert(container.childNodes[0] === child);
+        });
+
+        test('Replaces the target node with a text node', () => {
+          const container = document.createElement('div');
+          const target = document.createElement('div');
+          container.appendChild(target);
+
+          target.replaceWith('This is some text.');
+
+          assert(container.childNodes.length === 1);
+          assert(container.childNodes[0].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[0].textContent === 'This is some text.');
+        });
+
+        test('Replaces the target node with multiple types of nodes', () => {
+          const container = document.createElement('div');
+          const target = document.createElement('div');
+          container.appendChild(target);
+
+          const child0 = document.createElement('div');
+          const child2 = document.createElement('div');
+          target.replaceWith(child0, 'This is some text.', child2);
+
+          assert(container.childNodes.length === 3);
+          assert(container.childNodes[0] === child0);
+          assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
+          assert(container.childNodes[1].textContent === 'This is some text.');
+          assert(container.childNodes[2] === child2);
+        });
       });
     });
   </script>

--- a/packages/tests/webcomponentsjs_/child-node/replace-with.html
+++ b/packages/tests/webcomponentsjs_/child-node/replace-with.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>ChildNode replaceWith</title>
+  <script>
+    for (const item of [
+      CharacterData.prototype,
+      DocumentType.prototype,
+      Element.prototype,
+    ]) {
+      delete item.replaceWith;
+    }
+  </script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
+  <script src="../wct-config.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+  <script>
+    const testBefore = (createChildNode) => {
+      test('Replaces the target node with an element', () => {
+        const container = document.createElement('div');
+        const target = createChildNode();
+        container.appendChild(target);
+
+        const child = document.createElement('div');
+        target.replaceWith(child);
+
+        assert(child.parentNode === container);
+        assert(container.childNodes.length === 1);
+        assert(container.childNodes[0] === child);
+      });
+
+      test('Replaces the target node with a text node', () => {
+        const container = document.createElement('div');
+        const target = createChildNode();
+        container.appendChild(target);
+
+        target.replaceWith('This is some text.');
+
+        assert(container.childNodes.length === 1);
+        assert(container.childNodes[0].nodeType === Node.TEXT_NODE);
+        assert(container.childNodes[0].textContent === 'This is some text.');
+      });
+
+      test('Replaces the target node with multiple types of nodes', () => {
+        const container = document.createElement('div');
+        const target = createChildNode();
+        container.appendChild(target);
+
+        const child0 = document.createElement('div');
+        const child2 = document.createElement('div');
+        target.replaceWith(child0, 'This is some text.', child2);
+
+        assert(container.childNodes.length === 3);
+        assert(container.childNodes[0] === child0);
+        assert(container.childNodes[1].nodeType === Node.TEXT_NODE);
+        assert(container.childNodes[1].textContent === 'This is some text.');
+        assert(container.childNodes[2] === child2);
+      });
+    };
+
+    suite('ChildNode replaceWith', function() {
+      suite('CharacterData', function() {
+        testBefore(() => document.createTextNode(''));
+      });
+
+      suite('DocumentType', function() {
+        test('Replaces the target node with a comment', () => {
+          const container = document.implementation.createHTMLDocument('');
+          const target = container.doctype;
+          let firstChild;
+          while ((firstChild = container.firstChild) !== null) {
+            container.removeChild(firstChild);
+          }
+          container.appendChild(target);
+
+          const child = document.createComment('');
+          target.replaceWith(child);
+
+          assert(child.parentNode === container);
+          assert(container.childNodes.length === 1);
+          assert(container.childNodes[0] === child);
+        });
+
+        test('Replaces the target node with multiple comments', () => {
+          const container = document.implementation.createHTMLDocument('');
+          const target = container.doctype;
+          let firstChild;
+          while ((firstChild = container.firstChild) !== null) {
+            container.removeChild(firstChild);
+          }
+          container.appendChild(target);
+
+          // Text nodes can't be inserted as children of documents.
+          const child0 = document.createComment('');
+          const child1 = document.createComment('');
+          target.replaceWith(child0, child1);
+
+          assert(container.childNodes.length === 2);
+          assert(container.childNodes[0] === child0);
+          assert(container.childNodes[1] === child1);
+        });
+      });
+
+      suite('Element', function() {
+        testBefore(() => document.createElement('div'));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/packages/tests/webcomponentsjs_/runner.html
+++ b/packages/tests/webcomponentsjs_/runner.html
@@ -34,7 +34,8 @@
     'loader-after-load.html',
     'baseuri.html',
     'object-assign.html',
-    'parent-node/index.html'
+    'parent-node/index.html',
+    'child-node/index.html',
   ];
 </script>
 <script>

--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Add polyfills for ChildNode APIs.
+  ([#390](https://github.com/webcomponents/polyfills/pull/390))
 - Add polyfills for select ParentNode APIs.
   ([#389](https://github.com/webcomponents/polyfills/pull/389))
 - Add new entrypoints to webcomponentsjs for the 'platform' polyfills.

--- a/packages/webcomponentsjs/ts_src/platform/child-node/after.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/after.ts
@@ -52,5 +52,4 @@ function installAfter<T>(constructor: Constructor<T>) {
 }
 
 installAfter(CharacterData);
-installAfter(DocumentType);
 installAfter(Element);

--- a/packages/webcomponentsjs/ts_src/platform/child-node/after.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/after.ts
@@ -1,0 +1,51 @@
+/**
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+export {};
+
+type Constructor<T> = new (...args: Array<any>) => T;
+
+const nativeInsertBefore = Node.prototype.insertBefore;
+const nativeGetParentNode =
+    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get!;
+const nativeGetNextSibling =
+    Object.getOwnPropertyDescriptor(Node.prototype, 'nextSibling')?.get!;
+
+function installAfter<T>(constructor: Constructor<T>) {
+  const prototype = constructor.prototype;
+  if (prototype.hasOwnProperty('after')) {
+    return;
+  }
+
+  Object.defineProperty(prototype, 'after', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: function after(...args: Array<Node|string>) {
+      const parentNode = nativeGetParentNode.call(this);
+      if (parentNode === null) {
+        return;
+      }
+
+      const nextSibling = nativeGetNextSibling.call(this);
+      for (const arg of args) {
+        nativeInsertBefore.call(
+          parentNode,
+          typeof arg === 'string' ? document.createTextNode(arg) : arg,
+          nextSibling
+        );
+      }
+    }
+  });
+}
+
+installAfter(CharacterData);
+installAfter(DocumentType);
+installAfter(Element);

--- a/packages/webcomponentsjs/ts_src/platform/child-node/after.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/after.ts
@@ -14,9 +14,14 @@ type Constructor<T> = new (...args: Array<any>) => T;
 
 const nativeInsertBefore = Node.prototype.insertBefore;
 const nativeGetParentNode =
-    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get!;
+    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get! ??
+    // In Safari 9, the `parentNode` descriptor's `get` and `set` are undefined.
+    function(this: Node) { return this.parentNode; };
 const nativeGetNextSibling =
-    Object.getOwnPropertyDescriptor(Node.prototype, 'nextSibling')?.get!;
+    Object.getOwnPropertyDescriptor(Node.prototype, 'nextSibling')?.get! ??
+    // In Safari 9, the `nextSibling` descriptor's `get` and `set` are
+    // undefined.
+    function(this: Node) { return this.nextSibling; };
 
 function installAfter<T>(constructor: Constructor<T>) {
   const prototype = constructor.prototype;

--- a/packages/webcomponentsjs/ts_src/platform/child-node/before.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/before.ts
@@ -14,7 +14,9 @@ type Constructor<T> = new (...args: Array<any>) => T;
 
 const nativeInsertBefore = Node.prototype.insertBefore;
 const nativeGetParentNode =
-    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get!;
+    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get! ??
+    // In Safari 9, the `parentNode` descriptor's `get` and `set` are undefined.
+    function(this: Node) { return this.parentNode; };
 
 function installBefore<T>(constructor: Constructor<T>) {
   const prototype = constructor.prototype;

--- a/packages/webcomponentsjs/ts_src/platform/child-node/before.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/before.ts
@@ -46,5 +46,4 @@ function installBefore<T>(constructor: Constructor<T>) {
 }
 
 installBefore(CharacterData);
-installBefore(DocumentType);
 installBefore(Element);

--- a/packages/webcomponentsjs/ts_src/platform/child-node/before.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/before.ts
@@ -1,0 +1,48 @@
+/**
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+export {};
+
+type Constructor<T> = new (...args: Array<any>) => T;
+
+const nativeInsertBefore = Node.prototype.insertBefore;
+const nativeGetParentNode =
+    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get!;
+
+function installBefore<T>(constructor: Constructor<T>) {
+  const prototype = constructor.prototype;
+  if (prototype.hasOwnProperty('before')) {
+    return;
+  }
+
+  Object.defineProperty(prototype, 'before', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: function before(...args: Array<Node|string>) {
+      const parentNode = nativeGetParentNode.call(this);
+      if (parentNode === null) {
+        return;
+      }
+
+      for (const arg of args) {
+        nativeInsertBefore.call(
+          parentNode,
+          typeof arg === 'string' ? document.createTextNode(arg) : arg,
+          this
+        );
+      }
+    }
+  });
+}
+
+installBefore(CharacterData);
+installBefore(DocumentType);
+installBefore(Element);

--- a/packages/webcomponentsjs/ts_src/platform/child-node/index.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/index.ts
@@ -8,5 +8,6 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import './after.js';
 import './before.js';
 import './remove.js';

--- a/packages/webcomponentsjs/ts_src/platform/child-node/index.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/index.ts
@@ -8,4 +8,5 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import './before.js';
 import './remove.js';

--- a/packages/webcomponentsjs/ts_src/platform/child-node/index.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/index.ts
@@ -11,3 +11,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import './after.js';
 import './before.js';
 import './remove.js';
+import './replace-with.js';

--- a/packages/webcomponentsjs/ts_src/platform/child-node/index.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/index.ts
@@ -8,7 +8,4 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
-import '../platform/custom-event.js';
-import '../platform/baseuri.js';
-import '../platform/parent-node/index.js';
-import '../platform/child-node/index.js';
+import './remove.js';

--- a/packages/webcomponentsjs/ts_src/platform/child-node/remove.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/remove.ts
@@ -1,0 +1,40 @@
+/**
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+export {};
+
+type Constructor<T> = new (...args: Array<any>) => T;
+
+const nativeRemoveChild = Node.prototype.removeChild;
+const nativeGetParentNode =
+    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get!;
+
+function installRemove<T>(constructor: Constructor<T>) {
+  const prototype = constructor.prototype;
+  if (prototype.hasOwnProperty('remove')) {
+    return;
+  }
+
+  Object.defineProperty(prototype, 'remove', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: function remove() {
+      const parentNode = nativeGetParentNode.call(this);
+      if (parentNode) {
+        nativeRemoveChild.call(parentNode, this);
+      }
+    }
+  });
+}
+
+installRemove(CharacterData);
+installRemove(DocumentType);
+installRemove(Element);

--- a/packages/webcomponentsjs/ts_src/platform/child-node/remove.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/remove.ts
@@ -38,5 +38,4 @@ function installRemove<T>(constructor: Constructor<T>) {
 }
 
 installRemove(CharacterData);
-installRemove(DocumentType);
 installRemove(Element);

--- a/packages/webcomponentsjs/ts_src/platform/child-node/remove.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/remove.ts
@@ -14,7 +14,9 @@ type Constructor<T> = new (...args: Array<any>) => T;
 
 const nativeRemoveChild = Node.prototype.removeChild;
 const nativeGetParentNode =
-    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get!;
+    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get! ??
+    // In Safari 9, the `parentNode` descriptor's `get` and `set` are undefined.
+    function(this: Node) { return this.parentNode; };
 
 function installRemove<T>(constructor: Constructor<T>) {
   const prototype = constructor.prototype;

--- a/packages/webcomponentsjs/ts_src/platform/child-node/replace-with.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/replace-with.ts
@@ -15,7 +15,9 @@ type Constructor<T> = new (...args: Array<any>) => T;
 const nativeInsertBefore = Node.prototype.insertBefore;
 const nativeRemoveChild = Node.prototype.removeChild;
 const nativeGetParentNode =
-    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get!;
+    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get! ??
+    // In Safari 9, the `parentNode` descriptor's `get` and `set` are undefined.
+    function(this: Node) { return this.parentNode; };
 
 function installReplaceWith<T>(constructor: Constructor<T>) {
   const prototype = constructor.prototype;

--- a/packages/webcomponentsjs/ts_src/platform/child-node/replace-with.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/replace-with.ts
@@ -1,0 +1,51 @@
+/**
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+export {};
+
+type Constructor<T> = new (...args: Array<any>) => T;
+
+const nativeInsertBefore = Node.prototype.insertBefore;
+const nativeRemoveChild = Node.prototype.removeChild;
+const nativeGetParentNode =
+    Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')?.get!;
+
+function installReplaceWith<T>(constructor: Constructor<T>) {
+  const prototype = constructor.prototype;
+  if (prototype.hasOwnProperty('replaceWith')) {
+    return;
+  }
+
+  Object.defineProperty(prototype, 'replaceWith', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: function replaceWith(...args: Array<Node|string>) {
+      const parentNode = nativeGetParentNode.call(this);
+      if (parentNode === null) {
+        return;
+      }
+
+      for (const arg of args) {
+        nativeInsertBefore.call(
+          parentNode,
+          typeof arg === 'string' ? document.createTextNode(arg) : arg,
+          this
+        );
+      }
+
+      nativeRemoveChild.call(parentNode, this);
+    }
+  });
+}
+
+installReplaceWith(CharacterData);
+installReplaceWith(DocumentType);
+installReplaceWith(Element);

--- a/packages/webcomponentsjs/ts_src/platform/child-node/replace-with.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/replace-with.ts
@@ -49,5 +49,4 @@ function installReplaceWith<T>(constructor: Constructor<T>) {
 }
 
 installReplaceWith(CharacterData);
-installReplaceWith(DocumentType);
 installReplaceWith(Element);


### PR DESCRIPTION
Adds polyfills for `ChildNode`'s `after`, `before`, `remove`, and `replaceWith` functions and wrappers to support these in Shady DOM.