### PR TITLE
Polyfill `Element#getAttributeNames`.

### DIFF
--- a/packages/tests/webcomponentsjs_/get-attribute-names.html
+++ b/packages/tests/webcomponentsjs_/get-attribute-names.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>Element getAttributeNames</title>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
+  <script src="./wct-config.js"></script>
+  <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+  <script>
+    suite('Element getAttributeNames', function() {
+      test('Returns an array of attribute names', () => {
+        const element = document.createElement('div');
+        assert(element.getAttributeNames().length === 0);
+
+        let attributeNames;
+
+        attributeNames = element.getAttributeNames();
+        assert.isArray(attributeNames);
+        assert.deepEqual(attributeNames, []);
+
+        element.setAttribute('name-a', 'value-a');
+        attributeNames = element.getAttributeNames();
+        assert.deepEqual(attributeNames, ['name-a']);
+
+        element.setAttribute('name-b', 'value-b');
+        attributeNames = element.getAttributeNames();
+        assert.deepEqual(attributeNames, ['name-a', 'name-b']);
+
+        element.removeAttribute('name-a');
+        attributeNames = element.getAttributeNames();
+        assert.deepEqual(attributeNames, ['name-b']);
+
+        element.removeAttribute('name-b');
+        attributeNames = element.getAttributeNames();
+        assert.deepEqual(attributeNames, []);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/packages/tests/webcomponentsjs_/runner.html
+++ b/packages/tests/webcomponentsjs_/runner.html
@@ -33,7 +33,8 @@
     'bundle-after-load.html',
     'loader-after-load.html',
     'baseuri.html',
-    'object-assign.html'
+    'object-assign.html',
+    'get-attribute-names.html',
   ];
 </script>
 <script>

--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Polyfill `Element#getAttributeNames`.
+  ([#393](https://github.com/webcomponents/polyfills/pull/393))
 - Add new entrypoints to webcomponentsjs for the 'platform' polyfills.
   ([#385](https://github.com/webcomponents/polyfills/pull/385))
 

--- a/packages/webcomponentsjs/src/entrypoints/webcomponents-pf_dom-index.js
+++ b/packages/webcomponentsjs/src/entrypoints/webcomponents-pf_dom-index.js
@@ -10,3 +10,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import '../platform/custom-event.js';
 import '../platform/baseuri.js';
+import '../platform/get-attribute-names.js';

--- a/packages/webcomponentsjs/ts_src/platform/get-attribute-names.ts
+++ b/packages/webcomponentsjs/ts_src/platform/get-attribute-names.ts
@@ -1,0 +1,20 @@
+/**
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
+*/
+
+const Element_prototype = Element.prototype;
+const getAttributes = Object.getOwnPropertyDescriptor(Element.prototype, 'attributes')!.get!;
+const map = Array.prototype.map;
+
+if (!Element_prototype.hasOwnProperty('getAttributeNames')) {
+  Element_prototype.getAttributeNames = function getAttributeNames(this: Element): Array<string> {
+    return map.call(getAttributes.call(this), attr => attr.name) as Array<string>;
+  };
+}

--- a/packages/webcomponentsjs/ts_src/platform/get-attribute-names.ts
+++ b/packages/webcomponentsjs/ts_src/platform/get-attribute-names.ts
@@ -10,7 +10,11 @@ found at http://polymer.github.io/PATENTS.txt
 */
 
 const Element_prototype = Element.prototype;
-const getAttributes = Object.getOwnPropertyDescriptor(Element.prototype, 'attributes')!.get!;
+const attributesDescriptor =
+    Object.getOwnPropertyDescriptor(Element_prototype, 'attributes') ??
+    // In IE11, the `attributes` descriptor is on `Node.prototype`.
+    Object.getOwnPropertyDescriptor(Node.prototype, 'attributes');
+const getAttributes = attributesDescriptor!.get!;
 const map = Array.prototype.map;
 
 if (!Element_prototype.hasOwnProperty('getAttributeNames')) {

--- a/packages/webcomponentsjs/ts_src/platform/get-attribute-names.ts
+++ b/packages/webcomponentsjs/ts_src/platform/get-attribute-names.ts
@@ -9,12 +9,17 @@ part of the polymer project is also subject to an additional IP rights grant
 found at http://polymer.github.io/PATENTS.txt
 */
 
+export {};
+
 const Element_prototype = Element.prototype;
+// In IE11, the `attributes` descriptor is on `Node.prototype`.
 const attributesDescriptor =
     Object.getOwnPropertyDescriptor(Element_prototype, 'attributes') ??
-    // In IE11, the `attributes` descriptor is on `Node.prototype`.
     Object.getOwnPropertyDescriptor(Node.prototype, 'attributes');
-const getAttributes = attributesDescriptor!.get!;
+// In Safari 9, the `attributes` descriptor's getter is undefined. In Chrome 41,
+// the `attributes` descriptor is a data descriptor on each Element instance.
+const getAttributes = attributesDescriptor?.get ??
+    function(this: Element) { return this.attributes; };
 const map = Array.prototype.map;
 
 if (!Element_prototype.hasOwnProperty('getAttributeNames')) {


### PR DESCRIPTION
Adds a polyfill for [`Element#getAttributeNames`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNames).