### PR TITLE
Polyfill `Object.is`.

### DIFF
--- a/packages/tests/webcomponentsjs_/object-is.html
+++ b/packages/tests/webcomponentsjs_/object-is.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+
+<head>
+  <title>Object.is</title>
+  <script>delete Object.is;</script>
+  <script id="loader" src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
+  <script src="./wct-config.js"></script>
+  <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+  <script>
+    suite('Object.is', function() {
+      test('undefined', function() {
+        assert(Object.is(undefined, undefined));
+      });
+
+      test('null', function() {
+        assert(Object.is(null, null));
+      });
+
+      test('booleans', function() {
+        assert(Object.is(true, true));
+        assert(Object.is(false, false));
+        assert(!Object.is(true, false));
+      });
+
+      test('strings', function() {
+        assert(Object.is('a', 'a'));
+        assert(Object.is('b', 'b'));
+        assert(!Object.is('a', 'b'));
+      });
+
+      test('numbers', function() {
+        assert(Object.is(1, 1));
+        assert(Object.is(2, 2));
+        assert(!Object.is(1, 2));
+      });
+
+      test('0 and -0', function() {
+        assert(Object.is(0, 0));
+        assert(Object.is(-0, -0));
+        assert(!Object.is(0, -0));
+      });
+
+      test('NaN', function() {
+        assert(Object.is(NaN, NaN));
+      });
+
+      test('objects', function() {
+        const a = {};
+        const b = {};
+        assert(Object.is(a, a));
+        assert(Object.is(b, b));
+        assert(!Object.is(a, b));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/packages/tests/webcomponentsjs_/runner.html
+++ b/packages/tests/webcomponentsjs_/runner.html
@@ -33,7 +33,8 @@
     'bundle-after-load.html',
     'loader-after-load.html',
     'baseuri.html',
-    'object-assign.html'
+    'object-assign.html',
+    'object-is.html',
   ];
 </script>
 <script>

--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Polyfill `Object.is`.
+  ([#394](https://github.com/webcomponents/polyfills/pull/394))
 - Add new entrypoints to webcomponentsjs for the 'platform' polyfills.
   ([#385](https://github.com/webcomponents/polyfills/pull/385))
 

--- a/packages/webcomponentsjs/src/entrypoints/webcomponents-pf_js-index.js
+++ b/packages/webcomponentsjs/src/entrypoints/webcomponents-pf_js-index.js
@@ -11,3 +11,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import '../platform/es6-misc.js';
 import '../platform/promise.js';
 import '../platform/symbol.js';
+import '../platform/object-is.js';

--- a/packages/webcomponentsjs/ts_src/platform/object-is.ts
+++ b/packages/webcomponentsjs/ts_src/platform/object-is.ts
@@ -1,0 +1,24 @@
+// Derived from a snippet on
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+// which was added after 2010.
+// https://developer.mozilla.org/en-US/docs/MDN/About#Code_samples_and_snippets
+
+export {};
+
+if (!Object.hasOwnProperty('is')) {
+  Object.defineProperty(Object, 'is', {
+    configurable: true,
+    enumerable: false,
+    writable: true,
+    value: function is(x: any, y: any): boolean {
+      // SameValue algorithm
+      if (x === y) { // Steps 1-5, 7-10
+        // Steps 6.b-6.e: +0 != -0
+        return x !== 0 || 1 / x === 1 / y;
+      } else {
+        // Step 6.a: NaN == NaN
+        return x !== x && y !== y;
+      }
+    }
+  });
+}

--- a/packages/webcomponentsjs/ts_src/platform/object-is.ts
+++ b/packages/webcomponentsjs/ts_src/platform/object-is.ts
@@ -1,3 +1,14 @@
+/**
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
+*/
+
 // Derived from a snippet on
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
 // which was added after 2010.


### PR DESCRIPTION
Adds a polyfill for [`Object.is`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is).