### PR TITLE
Remove function declarations from platform polyfills to sastisfy internal lint after import transforms.

### DIFF
--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Remove function declarations from platform polyfills to sastisfy internal lint
+  after import transforms.
+  ([#396](https://github.com/webcomponents/polyfills/pull/396))
 - Polyfill `Element#getAttributeNames`.
   ([#393](https://github.com/webcomponents/polyfills/pull/393))
 - Add polyfills for ChildNode APIs.

--- a/packages/webcomponentsjs/ts_src/platform/child-node/after.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/after.ts
@@ -23,7 +23,7 @@ const nativeGetNextSibling =
     // undefined.
     function(this: Node) { return this.nextSibling; };
 
-function installAfter<T>(constructor: Constructor<T>) {
+const installAfter = <T>(constructor: Constructor<T>) => {
   const prototype = constructor.prototype;
   if (prototype.hasOwnProperty('after')) {
     return;
@@ -49,7 +49,7 @@ function installAfter<T>(constructor: Constructor<T>) {
       }
     }
   });
-}
+};
 
 installAfter(CharacterData);
 installAfter(Element);

--- a/packages/webcomponentsjs/ts_src/platform/child-node/before.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/before.ts
@@ -18,7 +18,7 @@ const nativeGetParentNode =
     // In Safari 9, the `parentNode` descriptor's `get` and `set` are undefined.
     function(this: Node) { return this.parentNode; };
 
-function installBefore<T>(constructor: Constructor<T>) {
+const installBefore = <T>(constructor: Constructor<T>) => {
   const prototype = constructor.prototype;
   if (prototype.hasOwnProperty('before')) {
     return;
@@ -43,7 +43,7 @@ function installBefore<T>(constructor: Constructor<T>) {
       }
     }
   });
-}
+};
 
 installBefore(CharacterData);
 installBefore(Element);

--- a/packages/webcomponentsjs/ts_src/platform/child-node/remove.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/remove.ts
@@ -18,7 +18,7 @@ const nativeGetParentNode =
     // In Safari 9, the `parentNode` descriptor's `get` and `set` are undefined.
     function(this: Node) { return this.parentNode; };
 
-function installRemove<T>(constructor: Constructor<T>) {
+const installRemove = <T>(constructor: Constructor<T>) => {
   const prototype = constructor.prototype;
   if (prototype.hasOwnProperty('remove')) {
     return;
@@ -35,7 +35,7 @@ function installRemove<T>(constructor: Constructor<T>) {
       }
     }
   });
-}
+};
 
 installRemove(CharacterData);
 installRemove(Element);

--- a/packages/webcomponentsjs/ts_src/platform/child-node/replace-with.ts
+++ b/packages/webcomponentsjs/ts_src/platform/child-node/replace-with.ts
@@ -19,7 +19,7 @@ const nativeGetParentNode =
     // In Safari 9, the `parentNode` descriptor's `get` and `set` are undefined.
     function(this: Node) { return this.parentNode; };
 
-function installReplaceWith<T>(constructor: Constructor<T>) {
+const installReplaceWith = <T>(constructor: Constructor<T>) => {
   const prototype = constructor.prototype;
   if (prototype.hasOwnProperty('replaceWith')) {
     return;
@@ -46,7 +46,7 @@ function installReplaceWith<T>(constructor: Constructor<T>) {
       nativeRemoveChild.call(parentNode, this);
     }
   });
-}
+};
 
 installReplaceWith(CharacterData);
 installReplaceWith(Element);

--- a/packages/webcomponentsjs/ts_src/platform/parent-node/append.ts
+++ b/packages/webcomponentsjs/ts_src/platform/parent-node/append.ts
@@ -14,7 +14,7 @@ type Constructor<T> = new (...args: Array<any>) => T;
 
 const nativeAppendChild = Node.prototype.appendChild;
 
-function installAppend<T>(constructor: Constructor<T>) {
+const installAppend = <T>(constructor: Constructor<T>) => {
   const prototype = constructor.prototype;
   if (prototype.hasOwnProperty('append')) {
     return;
@@ -30,7 +30,7 @@ function installAppend<T>(constructor: Constructor<T>) {
       }
     }
   });
-}
+};
 
 installAppend(Document);
 installAppend(DocumentFragment);

--- a/packages/webcomponentsjs/ts_src/platform/parent-node/prepend.ts
+++ b/packages/webcomponentsjs/ts_src/platform/parent-node/prepend.ts
@@ -20,7 +20,7 @@ const nativeGetFirstChild =
     // In Safari 9, the `firstChild` descriptor's `get` and `set` are undefined.
     function(this: Node) { return this.firstChild; };
 
-function installPrepend<T>(constructor: Constructor<T>) {
+const installPrepend = <T>(constructor: Constructor<T>) => {
   const prototype = constructor.prototype;
   if (prototype.hasOwnProperty('prepend')) {
     return;
@@ -38,7 +38,7 @@ function installPrepend<T>(constructor: Constructor<T>) {
       }
     }
   });
-}
+};
 
 installPrepend(Document);
 installPrepend(DocumentFragment);

--- a/packages/webcomponentsjs/ts_src/platform/parent-node/replace-children.ts
+++ b/packages/webcomponentsjs/ts_src/platform/parent-node/replace-children.ts
@@ -21,7 +21,7 @@ const nativeGetFirstChild =
     // In Safari 9, the `firstChild` descriptor's `get` and `set` are undefined.
     function(this: Node) { return this.firstChild; };
 
-function installReplaceChildren<T>(constructor: Constructor<T>) {
+const installReplaceChildren = <T>(constructor: Constructor<T>) => {
   const prototype = constructor.prototype;
   if (prototype.hasOwnProperty('replaceChildren')) {
     return;
@@ -42,7 +42,7 @@ function installReplaceChildren<T>(constructor: Constructor<T>) {
       }
     }
   });
-}
+};
 
 installReplaceChildren(Document);
 installReplaceChildren(DocumentFragment);


### PR DESCRIPTION
During import, we're going to wrap these entire modules in if statements, but the internal linter doesn't like function declarations nested inside blocks that don't define the scope for the function's binding.