### PR TITLE
Polyfill `Element#matches`.

### DIFF
--- a/packages/tests/webcomponentsjs_/matches.html
+++ b/packages/tests/webcomponentsjs_/matches.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>Element matches</title>
+  <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
+  <script src="./wct-config.js"></script>
+  <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+  <script>
+    suite('Element matches', function() {
+      test('Returns an array of attribute names', () => {
+        const element = document.createElement('div');
+        element.className = 'a b';
+
+        assert.isTrue(element.matches('div'));
+        assert.isTrue(element.matches('.a'));
+        assert.isTrue(element.matches('.b'));
+        assert.isTrue(element.matches('div.a.b'));
+        assert.isFalse(element.matches('.c'));
+      });
+    });
+  </script>
+</body>
+</html>

--- a/packages/tests/webcomponentsjs_/runner.html
+++ b/packages/tests/webcomponentsjs_/runner.html
@@ -35,6 +35,7 @@
     'baseuri.html',
     'object-assign.html',
     'get-attribute-names.html',
+    'matches.html',
     'parent-node/index.html',
     'child-node/index.html',
     'svg-element-class-list.html',

--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Polyfill `Element#matches`.
+  ([#400](https://github.com/webcomponents/polyfills/pull/400))
 - Remove function declarations from platform polyfills to sastisfy internal lint
   after import transforms.
   ([#396](https://github.com/webcomponents/polyfills/pull/396))

--- a/packages/webcomponentsjs/src/entrypoints/webcomponents-pf_dom-index.js
+++ b/packages/webcomponentsjs/src/entrypoints/webcomponents-pf_dom-index.js
@@ -11,6 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import '../platform/custom-event.js';
 import '../platform/baseuri.js';
 import '../platform/get-attribute-names.js';
+import '../platform/matches.js';
 import '../platform/parent-node/index.js';
 import '../platform/child-node/index.js';
 import '../platform/svg-element-class-list.js';

--- a/packages/webcomponentsjs/ts_src/platform/matches.ts
+++ b/packages/webcomponentsjs/ts_src/platform/matches.ts
@@ -1,0 +1,20 @@
+/**
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
+*/
+
+export {};
+
+const Element_prototype = Element.prototype;
+
+if (!Element_prototype.hasOwnProperty('matches')) {
+  Element_prototype.matches =
+      ((Element_prototype as any).webkitMatchesSelector as Element['matches']) ??
+      ((Element_prototype as any).msMatchesSelector as Element['matches']);
+}


### PR DESCRIPTION
Fixes #397. As mentioned in the bug, `Element#matches` exists with a vendor-prefixed in the browsers that we polyfill, so this just copies the function over using the standard name.