### PR TITLE
Implicitly coerce values passed to `createTextNode` to a string.

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Implicitly coerce values passed to `createTextNode` to a string.
+  ([#401](https://github.com/webcomponents/polyfills/pull/401))
 - Add support for ChildNode APIs.
   ([#390](https://github.com/webcomponents/polyfills/pull/390))
 - Add support for select ParentNode APIs.

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -238,7 +238,10 @@ export const arrayFrom = (object) => {
  * @return {!Node}
  */
 const convertIntoANode = (arg) => {
-  return !(arg instanceof Node) ? document.createTextNode(arg) : arg;
+  // `"" + arg` is used to implicitly coerce the value to a string (coercing a
+  // symbol *should* fail here) before passing to `createTextNode`, which has
+  // argument type `(number|string)`.
+  return !(arg instanceof Node) ? document.createTextNode("" + arg) : arg;
 };
 
 /**


### PR DESCRIPTION
The internal type checker claims that `document.createTextNode`'s argument should be `(number|string)`. I don't think this type is correct or reflected by browser behavior, but loosely coercing to a string before passing the arg provides the same behavior and passes this check.