### PR TITLE
DO NOT MERGE: Testing if Safari 11 on Sauce is currently broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+random change
+
 # Web Components Polyfills
 
 [![Test Status](https://github.com/webcomponents/polyfills/workflows/tests/badge.svg?branch=master)](https://github.com/webcomponents/polyfills/actions?query=workflow%3Atests+branch%3Amaster+event%3Apush)


### PR DESCRIPTION
Safari 11 on Sauce via the Polymer CLI is failing on other repos, but it seems like the result of bad WebDriver commands being sent to the browser rather than an actual code problem. The last tests here passed on Safari 11 on Sauce, so I'm pushing a random change to see if Safari 11 starts failing here also.