### PR TITLE
Allow __handlers and __shady to be undefined

### DIFF
--- a/packages/shadydom/externs/shadydom.js
+++ b/packages/shadydom/externs/shadydom.js
@@ -6,11 +6,11 @@
 /**
  * Block renaming of properties added to Node to
  * prevent conflicts with other closure-compiler code.
- * @type {Object}
+ * @type {!Object|undefined}
  */
 EventTarget.prototype.__handlers;
 
-/** @type {Object} */
+/** @type {!Object|undefined} */
 Node.prototype.__shady;
 
 /** @interface */


### PR DESCRIPTION
Fix externs to allow __handlers and __shady values to be undefined.
Same as cl/350617519
