### PR TITLE
When `EventTarget.prototype` exists but is not in the prototype chain of `window`, polyfill installation breaks.

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- When `EventTarget.prototype` exists but is not in the prototype chain of
+  `window`, polyfill installation breaks.
+  ([#416](https://github.com/webcomponents/polyfills/pull/416))
 
 ## [1.8.0] - 2020-10-21
 

--- a/packages/shadydom/src/patch-native.js
+++ b/packages/shadydom/src/patch-native.js
@@ -110,6 +110,13 @@ export const addNativePrefixedProperties = () => {
   ];
   if (window.EventTarget) {
     copyProperties(window.EventTarget.prototype, eventProps);
+
+    // In Firefox 33, `EventTarget` exists, but `EventTarget.prototype` is not
+    // in the prototype chain of `window` and, strangely,
+    // `window instanceof EventTarget` still returns true.
+    if (window[NATIVE_PREFIX + 'addEventListener'] === undefined) {
+      copyProperties(Window.prototype, eventProps);
+    }
   } else {
     copyProperties(Node.prototype, eventProps);
     copyProperties(Window.prototype, eventProps);


### PR DESCRIPTION
Firefox 33 has `EventTarget`, but `EventTarget.prototype` is not in the prototype chain of `window`. Currently, if `EventTarget` exists, then the `__shady_native_`-prefixed functions are only added to `EventTarget.prototype`. In Firefox 33, this causes the polyfills to throw when a call to one of these functions on `window` is attempted later during startup.

Tested as http://cl/351475102 .