### PR TITLE
Correct a comment about `EventTarget` in old versions of Firefox.

### DIFF
--- a/packages/shadydom/src/patch-native.js
+++ b/packages/shadydom/src/patch-native.js
@@ -111,7 +111,7 @@ export const addNativePrefixedProperties = () => {
   if (window.EventTarget) {
     copyProperties(window.EventTarget.prototype, eventProps);
 
-    // In Firefox 33, `EventTarget` exists, but `EventTarget.prototype` is not
+    // In Firefox 31, `EventTarget` exists, but `EventTarget.prototype` is not
     // in the prototype chain of `window` and, strangely,
     // `window instanceof EventTarget` still returns true.
     if (window[NATIVE_PREFIX + 'addEventListener'] === undefined) {


### PR DESCRIPTION
The issue described in this comment is in Firefox **31**, not 33.