### PR TITLE
Upstream cl/345169174: Fix calls to XMLHttpRequest#getResponseHeader to accept null as a return value.

### DIFF
--- a/packages/html-imports/CHANGELOG.md
+++ b/packages/html-imports/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Upstream cl/345169174: Fix calls to XMLHttpRequest#getResponseHeader to accept
+  null as a return value.
+  ([#433](https://github.com/webcomponents/polyfills/pull/433))
 
 ## [1.2.6] - 2020-10-21
 

--- a/packages/html-imports/gulpfile.js
+++ b/packages/html-imports/gulpfile.js
@@ -16,7 +16,7 @@ const closure = require('google-closure-compiler').gulp();
 const closureOptions = {
   compilation_level: 'ADVANCED',
   warning_level: 'VERBOSE',
-  language_in: 'ES6_STRICT',
+  language_in: 'STABLE',
   language_out: 'ES5_STRICT',
   externs: ['externs/html-imports.js'],
   js_output_file: 'html-imports.min.js',

--- a/packages/html-imports/src/html-imports.js
+++ b/packages/html-imports/src/html-imports.js
@@ -179,7 +179,8 @@
           // Prefer responseURL which already resolves redirects
           // https://xhr.spec.whatwg.org/#the-responseurl-attribute
           let redirectedUrl =
-            request.responseURL || request.getResponseHeader('Location');
+            (request.responseURL || request.getResponseHeader('Location')) ??
+            undefined;
           if (redirectedUrl && redirectedUrl.indexOf('/') === 0) {
             // In IE location.origin might not work
             // https://connect.microsoft.com/IE/feedback/details/1763802/location-origin-is-undefined-in-ie-11-on-windows-10-but-works-on-windows-7

--- a/packages/tests/html-imports/html/es-module.html
+++ b/packages/tests/html-imports/html/es-module.html
@@ -11,7 +11,7 @@
 <html>
   <head>
     <title>HTML Imports es module</title>
-    <script src="../../node_modules/@webcomponents/html-imports/src/html-imports.js"></script>
+    <script src="../../node_modules/@webcomponents/html-imports/html-imports.min.js"></script>
     <script>
       WCT = {
         waitFor: function (callback) {


### PR DESCRIPTION
This PR upstreams http://cl/345169174 , which fixes a warning caused by this update to the Closure externs: https://github.com/google/closure-compiler/commit/113514db81ef44e2c145f9fc76fa502cd57010ab .

