### PR TITLE
fix(scoped-registry): native HTMLElement

### DIFF
--- a/packages/scoped-custom-element-registry/CHANGELOG.md
+++ b/packages/scoped-custom-element-registry/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## Unreleased -->
 
+- Fix to allow definition of custom elements whose classes have been created before applying the polyfill.
 - Run `connectedCallback` on upgraded elements. Fixes #442.
 - Checks if ShadowRoot prototype supports the createElement method to determine if the polyfill should be applied or not.
 

--- a/packages/scoped-custom-element-registry/test/native-htmlelement.test.js
+++ b/packages/scoped-custom-element-registry/test/native-htmlelement.test.js
@@ -1,0 +1,19 @@
+import {expect} from '@open-wc/testing';
+
+import {getTestElement} from './utils';
+
+describe('Native HTMLElement', () => {
+  describe('custom element constructors', () => {
+    it('should allow to create a custom element which class has been created before applying the polyfill', async () => {
+      const {tagName, CustomElementClass} = getTestElement();
+
+      await import('../scoped-custom-element-registry.min.js');
+
+      customElements.define(tagName, CustomElementClass);
+
+      const element = document.createElement(tagName);
+
+      expect(element).to.not.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
This commit checks the CE class hierarchy and applies a patch on it in case the native HTMLElement is used by the CE to be defined.

Fixes #440 

@kevinpschaaf 