### PR TITLE
[scoped-custom-element-registry] Resolve whenDefined promise if already defined.

### DIFF
--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
@@ -94,7 +94,7 @@ if (!ShadowRoot.prototype.createElement) {
       // Flush whenDefined callbacks
       const resolver = this._definedResolvers.get(tagName);
       if (resolver) {
-        resolver();
+        resolver(elementClass);
       }
       return elementClass;
     }
@@ -121,6 +121,10 @@ if (!ShadowRoot.prototype.createElement) {
         promise = new Promise((r) => (resolve = r));
         this._definedPromises.set(tagName, promise);
         this._definedResolvers.set(tagName, resolve);
+        const definition = this._getDefinition(tagName);
+        if (definition !== undefined) {
+          resolve(definition.elementClass);
+        }
       }
       return promise;
     }

--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
@@ -34,8 +34,7 @@ if (!ShadowRoot.prototype.createElement) {
     constructor() {
       this._definitionsByTag = new Map();
       this._definitionsByClass = new Map();
-      this._definedPromises = new Map();
-      this._definedResolvers = new Map();
+      this._whenDefinedPromises = new Map();
       this._awaitingUpgrade = new Map();
     }
 
@@ -92,9 +91,10 @@ if (!ShadowRoot.prototype.createElement) {
         }
       }
       // Flush whenDefined callbacks
-      const resolver = this._definedResolvers.get(tagName);
-      if (resolver) {
-        resolver(elementClass);
+      const info = this._whenDefinedPromises.get(tagName);
+      if (info !== undefined) {
+        info.resolve(elementClass);
+        this._whenDefinedPromises.delete(tagName);
       }
       return elementClass;
     }
@@ -115,18 +115,17 @@ if (!ShadowRoot.prototype.createElement) {
     }
 
     whenDefined(tagName) {
-      let promise = this._definedPromises.get(tagName);
-      if (!promise) {
-        let resolve;
-        promise = new Promise((r) => (resolve = r));
-        this._definedPromises.set(tagName, promise);
-        this._definedResolvers.set(tagName, resolve);
-        const definition = this._getDefinition(tagName);
-        if (definition !== undefined) {
-          resolve(definition.elementClass);
-        }
+      const definition = this._getDefinition(tagName);
+      if (definition !== undefined) {
+        return Promise.resolve(definition.elementClass);
       }
-      return promise;
+      let info = this._whenDefinedPromises.get(tagName);
+      if (info === undefined) {
+        info = {};
+        info.promise = new Promise((r) => (info.resolve = r));
+        this._whenDefinedPromises.set(tagName, info);
+      }
+      return info.promise;
     }
 
     _upgradeWhenDefined(element, tagName, shouldUpgrade) {

--- a/packages/scoped-custom-element-registry/test/global-registry.test.html.js
+++ b/packages/scoped-custom-element-registry/test/global-registry.test.html.js
@@ -23,4 +23,21 @@ describe('Global Registry', () => {
       expect(() => new CustomElementClass()).to.throw();
     });
   });
+
+  describe('whenDefined', () => {
+    it('should resolve whenDefined when defined after calling whenDefined', async () => {
+      const {tagName, CustomElementClass} = getTestElement();
+      const whenDefined = customElements.whenDefined(tagName);
+      customElements.define(tagName, CustomElementClass);
+      const ctor = await whenDefined;
+      expect(ctor).to.equal(CustomElementClass);
+    });
+
+    it('should resolve whenDefined when defined before calling whenDefined', async () => {
+      const {tagName, CustomElementClass} = getTestElement();
+      customElements.define(tagName, CustomElementClass);
+      const ctor = await customElements.whenDefined(tagName);
+      expect(ctor).to.equal(CustomElementClass);
+    });
+  });
 });

--- a/packages/scoped-custom-element-registry/test/scoped-registry.test.html.js
+++ b/packages/scoped-custom-element-registry/test/scoped-registry.test.html.js
@@ -55,4 +55,23 @@ describe('Scoped Registry', () => {
       expect(() => new CustomElementClass()).to.throw();
     });
   });
+
+  describe('whenDefined', () => {
+    it('should resolve whenDefined when defined after calling whenDefined', async () => {
+      const registry = new CustomElementRegistry();
+      const {tagName, CustomElementClass} = getTestElement();
+      const whenDefined = registry.whenDefined(tagName);
+      registry.define(tagName, CustomElementClass);
+      const ctor = await whenDefined;
+      expect(ctor).to.equal(CustomElementClass);
+    });
+
+    it('should resolve whenDefined when defined before calling whenDefined', async () => {
+      const registry = new CustomElementRegistry();
+      const {tagName, CustomElementClass} = getTestElement();
+      registry.define(tagName, CustomElementClass);
+      const ctor = await registry.whenDefined(tagName);
+      expect(ctor).to.equal(CustomElementClass);
+    });
+  });
 });


### PR DESCRIPTION
Also ensure the promise resolves to the constructor, per spec.

Fixes #443