### PR TITLE
Pin Prettier to 2.2.1 and recreate 'package.json'.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "ignore-sync": "^3.0.1",
         "lerna": "^3.13.3",
         "lint-staged": "^10.5.3",
-        "prettier": "^2.2.1",
+        "prettier": "2.2.1",
         "prettier-plugin-package": "^1.3.0",
         "rollup": "^0.62.0",
         "rollup-plugin-babel": "^3.0.7",
@@ -4364,9 +4364,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
-      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -4573,13 +4573,13 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.23.0.tgz",
-      "integrity": "sha512-tGK1y3KIvdsQEEgq6xNn1DjiFJtl+wn8JJQiETtCbdQxw1vzjXyAaIkEmO2l6Nq24iy3uZBMFQjZ6ECf1QdgGw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.24.0.tgz",
+      "integrity": "sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.23.0",
-        "@typescript-eslint/scope-manager": "4.23.0",
+        "@typescript-eslint/experimental-utils": "4.24.0",
+        "@typescript-eslint/scope-manager": "4.24.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -4605,15 +4605,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.23.0.tgz",
-      "integrity": "sha512-WAFNiTDnQfrF3Z2fQ05nmCgPsO5o790vOhmWKXbbYQTO9erE1/YsFot5/LnOUizLzU2eeuz6+U/81KV5/hFTGA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.24.0.tgz",
+      "integrity": "sha512-IwTT2VNDKH1h8RZseMH4CcYBz6lTvRoOLDuuqNZZoThvfHEhOiZPQCow+5El3PtyxJ1iDr6UXZwYtE3yZQjhcw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.23.0",
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/typescript-estree": "4.23.0",
+        "@typescript-eslint/scope-manager": "4.24.0",
+        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/typescript-estree": "4.24.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
@@ -4629,14 +4629,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.23.0.tgz",
-      "integrity": "sha512-wsvjksHBMOqySy/Pi2Q6UuIuHYbgAMwLczRl4YanEPKW5KVxI9ZzDYh3B5DtcZPQTGRWFJrfcbJ6L01Leybwug==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.24.0.tgz",
+      "integrity": "sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.23.0",
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/typescript-estree": "4.23.0",
+        "@typescript-eslint/scope-manager": "4.24.0",
+        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/typescript-estree": "4.24.0",
         "debug": "^4.1.1"
       },
       "engines": {
@@ -4656,13 +4656,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.23.0.tgz",
-      "integrity": "sha512-ZZ21PCFxPhI3n0wuqEJK9omkw51wi2bmeKJvlRZPH5YFkcawKOuRMQMnI8mH6Vo0/DoHSeZJnHiIx84LmVQY+w==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz",
+      "integrity": "sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/visitor-keys": "4.23.0"
+        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/visitor-keys": "4.24.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -4673,9 +4673,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.23.0.tgz",
-      "integrity": "sha512-oqkNWyG2SLS7uTWLZf6Sr7Dm02gA5yxiz1RP87tvsmDsguVATdpVguHr4HoGOcFOpCvx9vtCSCyQUGfzq28YCw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.24.0.tgz",
+      "integrity": "sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -4686,13 +4686,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.23.0.tgz",
-      "integrity": "sha512-5Sty6zPEVZF5fbvrZczfmLCOcby3sfrSPu30qKoY1U3mca5/jvU5cwsPb/CO6Q3ByRjixTMIVsDkqwIxCf/dMw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.24.0.tgz",
+      "integrity": "sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/visitor-keys": "4.23.0",
+        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/visitor-keys": "4.24.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -4713,12 +4713,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.23.0.tgz",
-      "integrity": "sha512-5PNe5cmX9pSifit0H+nPoQBXdbNzi5tOEec+3riK+ku4e3er37pKxMKDH5Ct5Y4fhWxcD4spnlYjxi9vXbSpwg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.24.0.tgz",
+      "integrity": "sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/types": "4.24.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -4813,9 +4813,9 @@
       }
     },
     "node_modules/@web/dev-server-rollup": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.3.tgz",
-      "integrity": "sha512-3v+PG9xC+Q07NOVTqqYuab/XqDQfWXltVzOI6HstBD0RWP7u7Bk4G0BwSjD3RNdIzyrTW//zCwyCN7UkHNhIBA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.4.tgz",
+      "integrity": "sha512-QFaqHpJXri1TuN1yN0N670bxF5noC1RtIHPhoM5Sp6YX7v3610Z/fq465V7fNaeHnTNN7dIUmNkK9vqLIrsYTg==",
       "dev": true,
       "dependencies": {
         "@web/dev-server-core": "^0.3.3",
@@ -4829,9 +4829,9 @@
       }
     },
     "node_modules/@web/dev-server-rollup/node_modules/rollup": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.47.0.tgz",
-      "integrity": "sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==",
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.48.0.tgz",
+      "integrity": "sha512-wl9ZSSSsi5579oscSDYSzGn092tCS076YB+TQrzsGuSfYyJeep8eEWj0eaRjuC5McuMNmcnR8icBqiE/FWNB1A==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4896,9 +4896,9 @@
       "dev": true
     },
     "node_modules/@web/dev-server/node_modules/rollup": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.47.0.tgz",
-      "integrity": "sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==",
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.48.0.tgz",
+      "integrity": "sha512-wl9ZSSSsi5579oscSDYSzGn092tCS076YB+TQrzsGuSfYyJeep8eEWj0eaRjuC5McuMNmcnR8icBqiE/FWNB1A==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -7988,9 +7988,9 @@
       }
     },
     "node_modules/command-line-usage/node_modules/array-back": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -8719,7 +8719,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.",
+      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
       "dev": true,
       "hasInstallScript": true
     },
@@ -9481,9 +9481,9 @@
       }
     },
     "node_modules/detect-node": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.5.tgz",
-      "integrity": "sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
     "node_modules/devtools-protocol": {
@@ -9573,13 +9573,13 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
-      "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "dev": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
       },
       "funding": {
@@ -9749,9 +9749,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.727",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
-      "integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==",
+      "version": "1.3.728",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.728.tgz",
+      "integrity": "sha512-SHv4ziXruBpb1Nz4aTuqEHBYi/9GNCJMYIJgDEXrp/2V01nFXMNFUTli5Z85f5ivSkioLilQatqBYFB44wNJrA==",
       "dev": true
     },
     "node_modules/emitter-component": {
@@ -15484,9 +15484,9 @@
       }
     },
     "node_modules/is-ssh": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
-      "integrity": "sha512-elEw0/0c2UscLrNG+OAorbP539E3rhliKPg+hDMWN9VwrDXfYK+4PBEykDPfxlYYtQvl84TascnQyobfQLHEhQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.3.tgz",
+      "integrity": "sha512-NKzJmQzJfEEma3w5cJNcUMxoXfDjz0Zj0eyCalHn2E6VOwlzjZo0yuO2fcBSf8zhFuVCL/82/r5gRcoi6aEPVQ==",
       "dev": true,
       "dependencies": {
         "protocols": "^1.1.0"
@@ -18311,9 +18311,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.71",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
       "dev": true
     },
     "node_modules/nomnom": {
@@ -18888,9 +18888,9 @@
       "dev": true
     },
     "node_modules/open": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.0.8.tgz",
-      "integrity": "sha512-3XmKIU8+H/TVr8wB8C4vj0z748+yBydSvtpzZVS6vQ1dKNHB6AiPbhaoG+89zb80717GPk9y/7OvK0R6FXkNmQ==",
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.0.9.tgz",
+      "integrity": "sha512-vbCrqMav3K8mCCy8NdK4teUky0tpDrBbuiDLduCdVhc5oA9toJMip9rBkuwdwSI9E7NOkz4VkLWPi8DD2MP1gQ==",
       "dev": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -23581,9 +23581,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
+      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
       "dev": true
     },
     "node_modules/spdy": {
@@ -24507,9 +24507,9 @@
       }
     },
     "node_modules/table": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.0.tgz",
-      "integrity": "sha512-SAM+5p6V99gYiiy2gT5ArdzgM1dLDed0nkrWmG6Fry/bUS/m9x83BwpJUOf1Qj/x2qJd+thL6IkIx7qPGRxqBw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.0.1",
@@ -24539,9 +24539,9 @@
       }
     },
     "node_modules/table-layout/node_modules/array-back": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -24557,9 +24557,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.3.0.tgz",
-      "integrity": "sha512-RYE7B5An83d7eWnDR8kbdaIFqmKCNsP16ay1hDbJEU+sa0e3H9SebskCt0Uufem6cfAVu7Col6ubcn/W+Sm8/Q==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
+      "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -27404,9 +27404,9 @@
       }
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz",
-      "integrity": "sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -31359,9 +31359,9 @@
       }
     },
     "@types/node": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
-      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -31567,13 +31567,13 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.23.0.tgz",
-      "integrity": "sha512-tGK1y3KIvdsQEEgq6xNn1DjiFJtl+wn8JJQiETtCbdQxw1vzjXyAaIkEmO2l6Nq24iy3uZBMFQjZ6ECf1QdgGw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.24.0.tgz",
+      "integrity": "sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.23.0",
-        "@typescript-eslint/scope-manager": "4.23.0",
+        "@typescript-eslint/experimental-utils": "4.24.0",
+        "@typescript-eslint/scope-manager": "4.24.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -31583,55 +31583,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.23.0.tgz",
-      "integrity": "sha512-WAFNiTDnQfrF3Z2fQ05nmCgPsO5o790vOhmWKXbbYQTO9erE1/YsFot5/LnOUizLzU2eeuz6+U/81KV5/hFTGA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.24.0.tgz",
+      "integrity": "sha512-IwTT2VNDKH1h8RZseMH4CcYBz6lTvRoOLDuuqNZZoThvfHEhOiZPQCow+5El3PtyxJ1iDr6UXZwYtE3yZQjhcw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.23.0",
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/typescript-estree": "4.23.0",
+        "@typescript-eslint/scope-manager": "4.24.0",
+        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/typescript-estree": "4.24.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.23.0.tgz",
-      "integrity": "sha512-wsvjksHBMOqySy/Pi2Q6UuIuHYbgAMwLczRl4YanEPKW5KVxI9ZzDYh3B5DtcZPQTGRWFJrfcbJ6L01Leybwug==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.24.0.tgz",
+      "integrity": "sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.23.0",
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/typescript-estree": "4.23.0",
+        "@typescript-eslint/scope-manager": "4.24.0",
+        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/typescript-estree": "4.24.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.23.0.tgz",
-      "integrity": "sha512-ZZ21PCFxPhI3n0wuqEJK9omkw51wi2bmeKJvlRZPH5YFkcawKOuRMQMnI8mH6Vo0/DoHSeZJnHiIx84LmVQY+w==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz",
+      "integrity": "sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/visitor-keys": "4.23.0"
+        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/visitor-keys": "4.24.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.23.0.tgz",
-      "integrity": "sha512-oqkNWyG2SLS7uTWLZf6Sr7Dm02gA5yxiz1RP87tvsmDsguVATdpVguHr4HoGOcFOpCvx9vtCSCyQUGfzq28YCw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.24.0.tgz",
+      "integrity": "sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.23.0.tgz",
-      "integrity": "sha512-5Sty6zPEVZF5fbvrZczfmLCOcby3sfrSPu30qKoY1U3mca5/jvU5cwsPb/CO6Q3ByRjixTMIVsDkqwIxCf/dMw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.24.0.tgz",
+      "integrity": "sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/visitor-keys": "4.23.0",
+        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/visitor-keys": "4.24.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -31640,12 +31640,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.23.0.tgz",
-      "integrity": "sha512-5PNe5cmX9pSifit0H+nPoQBXdbNzi5tOEec+3riK+ku4e3er37pKxMKDH5Ct5Y4fhWxcD4spnlYjxi9vXbSpwg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.24.0.tgz",
+      "integrity": "sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/types": "4.24.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -31731,9 +31731,9 @@
           "dev": true
         },
         "rollup": {
-          "version": "2.47.0",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.47.0.tgz",
-          "integrity": "sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==",
+          "version": "2.48.0",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.48.0.tgz",
+          "integrity": "sha512-wl9ZSSSsi5579oscSDYSzGn092tCS076YB+TQrzsGuSfYyJeep8eEWj0eaRjuC5McuMNmcnR8icBqiE/FWNB1A==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -31769,9 +31769,9 @@
       }
     },
     "@web/dev-server-rollup": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.3.tgz",
-      "integrity": "sha512-3v+PG9xC+Q07NOVTqqYuab/XqDQfWXltVzOI6HstBD0RWP7u7Bk4G0BwSjD3RNdIzyrTW//zCwyCN7UkHNhIBA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.4.tgz",
+      "integrity": "sha512-QFaqHpJXri1TuN1yN0N670bxF5noC1RtIHPhoM5Sp6YX7v3610Z/fq465V7fNaeHnTNN7dIUmNkK9vqLIrsYTg==",
       "dev": true,
       "requires": {
         "@web/dev-server-core": "^0.3.3",
@@ -31782,9 +31782,9 @@
       },
       "dependencies": {
         "rollup": {
-          "version": "2.47.0",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.47.0.tgz",
-          "integrity": "sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==",
+          "version": "2.48.0",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.48.0.tgz",
+          "integrity": "sha512-wl9ZSSSsi5579oscSDYSzGn092tCS076YB+TQrzsGuSfYyJeep8eEWj0eaRjuC5McuMNmcnR8icBqiE/FWNB1A==",
           "dev": true,
           "requires": {
             "fsevents": "~2.3.1"
@@ -34361,9 +34361,9 @@
           }
         },
         "array-back": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
           "dev": true
         },
         "chalk": {
@@ -35574,9 +35574,9 @@
       "dev": true
     },
     "detect-node": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.5.tgz",
-      "integrity": "sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
     "devtools-protocol": {
@@ -35656,13 +35656,13 @@
       }
     },
     "dom-serializer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
-      "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
       }
     },
@@ -35809,9 +35809,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.727",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
-      "integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==",
+      "version": "1.3.728",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.728.tgz",
+      "integrity": "sha512-SHv4ziXruBpb1Nz4aTuqEHBYi/9GNCJMYIJgDEXrp/2V01nFXMNFUTli5Z85f5ivSkioLilQatqBYFB44wNJrA==",
       "dev": true
     },
     "emitter-component": {
@@ -40370,9 +40370,9 @@
       "dev": true
     },
     "is-ssh": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
-      "integrity": "sha512-elEw0/0c2UscLrNG+OAorbP539E3rhliKPg+hDMWN9VwrDXfYK+4PBEykDPfxlYYtQvl84TascnQyobfQLHEhQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.3.tgz",
+      "integrity": "sha512-NKzJmQzJfEEma3w5cJNcUMxoXfDjz0Zj0eyCalHn2E6VOwlzjZo0yuO2fcBSf8zhFuVCL/82/r5gRcoi6aEPVQ==",
       "dev": true,
       "requires": {
         "protocols": "^1.1.0"
@@ -42726,9 +42726,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.71",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
       "dev": true
     },
     "nomnom": {
@@ -43197,9 +43197,9 @@
       "dev": true
     },
     "open": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.0.8.tgz",
-      "integrity": "sha512-3XmKIU8+H/TVr8wB8C4vj0z748+yBydSvtpzZVS6vQ1dKNHB6AiPbhaoG+89zb80717GPk9y/7OvK0R6FXkNmQ==",
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.0.9.tgz",
+      "integrity": "sha512-vbCrqMav3K8mCCy8NdK4teUky0tpDrBbuiDLduCdVhc5oA9toJMip9rBkuwdwSI9E7NOkz4VkLWPi8DD2MP1gQ==",
       "dev": true,
       "requires": {
         "define-lazy-prop": "^2.0.0",
@@ -47061,9 +47061,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
+      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
       "dev": true
     },
     "spdy": {
@@ -47801,9 +47801,9 @@
       }
     },
     "table": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.0.tgz",
-      "integrity": "sha512-SAM+5p6V99gYiiy2gT5ArdzgM1dLDed0nkrWmG6Fry/bUS/m9x83BwpJUOf1Qj/x2qJd+thL6IkIx7qPGRxqBw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
@@ -47815,9 +47815,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.3.0.tgz",
-          "integrity": "sha512-RYE7B5An83d7eWnDR8kbdaIFqmKCNsP16ay1hDbJEU+sa0e3H9SebskCt0Uufem6cfAVu7Col6ubcn/W+Sm8/Q==",
+          "version": "8.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
+          "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -47875,9 +47875,9 @@
       },
       "dependencies": {
         "array-back": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
           "dev": true
         },
         "typical": {
@@ -50146,9 +50146,9 @@
       "optional": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz",
-      "integrity": "sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ignore-sync": "^3.0.1",
     "lerna": "^3.13.3",
     "lint-staged": "^10.5.3",
-    "prettier": "^2.2.1",
+    "prettier": "2.2.1",
     "prettier-plugin-package": "^1.3.0",
     "rollup": "^0.62.0",
     "rollup-plugin-babel": "^3.0.7",


### PR DESCRIPTION
Apparently Prettier doesn't follow semver and may produce different formatting between updates within the same major version - they recommend pinning to an exact version: https://prettier.io/docs/en/install.html#summary . The recent 2.3.0 update changes the formatting in this project.