### PR TITLE
Convert all multi-line import statements to single line

### DIFF
--- a/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
+++ b/packages/formdata-event/ts_src/dispatch_formdata_for_submission.ts
@@ -17,23 +17,12 @@
 
 import {document} from './environment/globals.js';
 import {createElement} from './environment_api/document.js';
-import {
-  setType,
-  setName,
-  setValue,
-} from './environment_api/html_input_element.js';
-import {
-  appendChild,
-  getParentNode,
-  insertBefore,
-  removeChild,
-} from './environment_api/node.js';
-import {
-  hasAttribute,
-  getAttribute,
-  removeAttribute,
-  setAttribute,
-} from './environment_api/element.js';
+// prettier-ignore
+import {setType, setName, setValue} from './environment_api/html_input_element.js';
+// prettier-ignore
+import {appendChild, getParentNode, insertBefore, removeChild} from './environment_api/node.js';
+// prettier-ignore
+import {hasAttribute, getAttribute, removeAttribute, setAttribute} from './environment_api/element.js';
 import {getLength} from './environment_api/html_collection.js';
 import {getElements} from './environment_api/html_form_element.js';
 import {FormData, getEntries} from './wrappers/form_data.js';

--- a/packages/formdata-event/ts_src/environment_api/event.ts
+++ b/packages/formdata-event/ts_src/environment_api/event.ts
@@ -9,10 +9,8 @@
  * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import {
-  descriptors as EventDescriptors,
-  methods as EventMethods,
-} from '../environment/event.js';
+// prettier-ignore
+import {descriptors as EventDescriptors, methods as EventMethods} from '../environment/event.js';
 
 // `Object.getOwnPropertyDescriptor(Event.prototype, 'target')` is undefined
 // in Chrome 41.

--- a/packages/formdata-event/ts_src/environment_api/event_target.ts
+++ b/packages/formdata-event/ts_src/environment_api/event_target.ts
@@ -9,10 +9,8 @@
  * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import {
-  constructor as EventTargetConstructor,
-  methods as EventTargetMethods,
-} from '../environment/event_target.js';
+// prettier-ignore
+import {constructor as EventTargetConstructor, methods as EventTargetMethods} from '../environment/event_target.js';
 import {methods as NodeMethods} from '../environment/node.js';
 import {methods as WindowMethods} from '../environment/window.js';
 

--- a/packages/formdata-event/ts_src/environment_api/node.ts
+++ b/packages/formdata-event/ts_src/environment_api/node.ts
@@ -9,10 +9,8 @@
  * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import {
-  methods as NodeMethods,
-  descriptors as NodeDescriptors,
-} from '../environment/node.js';
+// prettier-ignore
+import {methods as NodeMethods, descriptors as NodeDescriptors} from '../environment/node.js';
 
 // `Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode')` is
 // undefined in Chrome 41.

--- a/packages/formdata-event/ts_src/formdata_listener_added.ts
+++ b/packages/formdata-event/ts_src/formdata_listener_added.ts
@@ -15,23 +15,16 @@
  * submissions that should dispatch a 'formdata' event.
  */
 
-import {
-  getEventPropagationStopped,
-  getEventPropagationImmediatelyStopped,
-} from './wrappers/event.js';
+// prettier-ignore
+import {getEventPropagationStopped, getEventPropagationImmediatelyStopped} from './wrappers/event.js';
 import {getTarget, getDefaultPrevented} from './environment_api/event.js';
-import {
-  addEventListener,
-  removeEventListener,
-} from './environment_api/event_target.js';
+// prettier-ignore
+import {addEventListener, removeEventListener} from './environment_api/event_target.js';
 import {getRootNode} from './environment_api/node.js';
 import {dispatchFormdataForSubmission} from './dispatch_formdata_for_submission.js';
 import {EventListenerArray} from './event_listener_array.js';
-import {
-  submitListenerAdded,
-  submitListenerRemoved,
-  targetToSubmitListeners,
-} from './submit_listener_added.js';
+// prettier-ignore
+import {submitListenerAdded, submitListenerRemoved, targetToSubmitListeners} from './submit_listener_added.js';
 
 /**
  * The set of 'formdata' event listeners for an event target.

--- a/packages/formdata-event/ts_src/wrappers/event.ts
+++ b/packages/formdata-event/ts_src/wrappers/event.ts
@@ -10,11 +10,8 @@
  */
 
 import {methods as DocumentMethods} from '../environment/document.js';
-import {
-  constructor as EventConstructor,
-  prototype as EventPrototype,
-  methods as EventMethods,
-} from '../environment/event.js';
+// prettier-ignore
+import {constructor as EventConstructor, prototype as EventPrototype, methods as EventMethods} from '../environment/event.js';
 import {document} from '../environment/globals.js';
 import {initEvent} from '../environment_api/event.js';
 import {prepareWrapper, installWrapper} from './wrap_constructor.js';

--- a/packages/formdata-event/ts_src/wrappers/event_target.ts
+++ b/packages/formdata-event/ts_src/wrappers/event_target.ts
@@ -9,27 +9,16 @@
  * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import {
-  prototype as EventTargetPrototype,
-  methods as EventTargetMethods,
-} from '../environment/event_target.js';
-import {
-  prototype as NodePrototype,
-  methods as NodeMethods,
-} from '../environment/node.js';
-import {
-  prototype as WindowPrototype,
-  methods as WindowMethods,
-} from '../environment/window.js';
-import {
-  formdataListenerAdded,
-  formdataListenerRemoved,
-  wrapSubmitListener,
-} from '../formdata_listener_added.js';
-import {
-  submitListenerAdded,
-  submitListenerRemoved,
-} from '../submit_listener_added.js';
+// prettier-ignore
+import {prototype as EventTargetPrototype, methods as EventTargetMethods} from '../environment/event_target.js';
+// prettier-ignore
+import {prototype as NodePrototype, methods as NodeMethods} from '../environment/node.js';
+// prettier-ignore
+import {prototype as WindowPrototype, methods as WindowMethods} from '../environment/window.js';
+// prettier-ignore
+import {formdataListenerAdded, formdataListenerRemoved, wrapSubmitListener} from '../formdata_listener_added.js';
+// prettier-ignore
+import {submitListenerAdded, submitListenerRemoved} from '../submit_listener_added.js';
 
 const submitListenerToWrapper = new WeakMap<
   EventListenerOrEventListenerObject,

--- a/packages/formdata-event/ts_src/wrappers/form_data.ts
+++ b/packages/formdata-event/ts_src/wrappers/form_data.ts
@@ -9,11 +9,8 @@
  * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import {
-  constructor as FormDataConstructor,
-  prototype as FormDataPrototype,
-  methods as FormDataMethods,
-} from '../environment/form_data.js';
+// prettier-ignore
+import {constructor as FormDataConstructor, prototype as FormDataPrototype, methods as FormDataMethods} from '../environment/form_data.js';
 import {dispatchEvent} from '../environment_api/event_target.js';
 import {FormDataEvent} from '../form_data_event.js';
 import {prepareWrapper, installWrapper} from './wrap_constructor.js';

--- a/packages/formdata-event/ts_src/wrappers/html_form_element.ts
+++ b/packages/formdata-event/ts_src/wrappers/html_form_element.ts
@@ -9,10 +9,8 @@
  * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import {
-  prototype as HTMLFormElementPrototype,
-  methods as HTMLFormElementMethods,
-} from '../environment/html_form_element.js';
+// prettier-ignore
+import {prototype as HTMLFormElementPrototype, methods as HTMLFormElementMethods} from '../environment/html_form_element.js';
 import {dispatchFormdataForSubmission} from '../dispatch_formdata_for_submission.js';
 
 export const wrapSubmit = (

--- a/packages/scoped-custom-element-registry/test/ShadowRoot.test.html.js
+++ b/packages/scoped-custom-element-registry/test/ShadowRoot.test.html.js
@@ -1,12 +1,7 @@
 import {expect} from '@open-wc/testing';
 
-import {
-  getTestTagName,
-  getTestElement,
-  getShadowRoot,
-  getHTML,
-  createTemplate,
-} from './utils.js';
+// prettier-ignore
+import {getTestTagName, getTestElement, getShadowRoot, getHTML, createTemplate} from './utils.js';
 
 describe('ShadowRoot', () => {
   it('should be able to be associate a custom registry', () => {

--- a/packages/shadycss/entrypoints/apply-shim.js
+++ b/packages/shadycss/entrypoints/apply-shim.js
@@ -12,23 +12,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import ApplyShim from '../src/apply-shim.js';
 import templateMap from '../src/template-map.js';
-import {
-  getIsExtends,
-  toCssText,
-  elementHasBuiltCss,
-} from '../src/style-util.js';
+// prettier-ignore
+import {getIsExtends, toCssText, elementHasBuiltCss} from '../src/style-util.js';
 import * as ApplyShimUtils from '../src/apply-shim-utils.js';
-import {
-  getComputedStyleValue,
-  updateNativeProperties,
-} from '../src/common-utils.js';
+// prettier-ignore
+import {getComputedStyleValue, updateNativeProperties} from '../src/common-utils.js';
 import {CustomStyleInterfaceInterface} from '../src/custom-style-interface.js'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import {
-  nativeCssVariables,
-  nativeShadow,
-  cssBuild,
-  disableRuntime,
-} from '../src/style-settings.js';
+// prettier-ignore
+import {nativeCssVariables, nativeShadow, cssBuild, disableRuntime} from '../src/style-settings.js';
 
 /** @const {ApplyShim} */
 const applyShim = new ApplyShim();

--- a/packages/shadycss/entrypoints/custom-style-interface.js
+++ b/packages/shadycss/entrypoints/custom-style-interface.js
@@ -11,16 +11,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 'use strict';
 
 import CustomStyleInterface from '../src/custom-style-interface.js';
-import {
-  getComputedStyleValue,
-  updateNativeProperties,
-} from '../src/common-utils.js';
-import {
-  nativeCssVariables,
-  nativeShadow,
-  cssBuild,
-  disableRuntime,
-} from '../src/style-settings.js';
+// prettier-ignore
+import {getComputedStyleValue, updateNativeProperties} from '../src/common-utils.js';
+// prettier-ignore
+import {nativeCssVariables, nativeShadow, cssBuild, disableRuntime} from '../src/style-settings.js';
 
 const customStyleInterface = new CustomStyleInterface();
 

--- a/packages/shadycss/entrypoints/scoping-shim.js
+++ b/packages/shadycss/entrypoints/scoping-shim.js
@@ -11,12 +11,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 'use strict';
 
 import ScopingShim from '../src/scoping-shim.js';
-import {
-  nativeCssVariables,
-  nativeShadow,
-  cssBuild,
-  disableRuntime,
-} from '../src/style-settings.js';
+// prettier-ignore
+import {nativeCssVariables, nativeShadow, cssBuild, disableRuntime} from '../src/style-settings.js';
 
 /** @const {ScopingShim} */
 const scopingShim = new ScopingShim();

--- a/packages/shadycss/src/apply-shim.js
+++ b/packages/shadycss/src/apply-shim.js
@@ -71,13 +71,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 'use strict';
 
-import {
-  forEachRule,
-  processVariableAndFallback,
-  rulesForStyle,
-  toCssText,
-  gatherStyleText,
-} from './style-util.js';
+// prettier-ignore
+import {forEachRule, processVariableAndFallback, rulesForStyle, toCssText, gatherStyleText} from './style-util.js';
 import {MIXIN_MATCH, VAR_ASSIGN} from './common-regex.js';
 import {detectMixin} from './common-utils.js';
 import {StyleNode} from './css-parse.js'; // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/shadycss/src/scoping-shim.js
+++ b/packages/shadycss/src/scoping-shim.js
@@ -11,34 +11,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 'use strict';
 
 import {parse, StyleNode} from './css-parse.js';
-import {
-  nativeShadow,
-  nativeCssVariables,
-  disableRuntime,
-} from './style-settings.js';
+// prettier-ignore
+import {nativeShadow, nativeCssVariables, disableRuntime} from './style-settings.js';
 import StyleTransformer from './style-transformer.js';
 import * as StyleUtil from './style-util.js';
 import StyleProperties from './style-properties.js';
-import {
-  ensureStylePlaceholder,
-  getStylePlaceholder,
-} from './style-placeholder.js';
+// prettier-ignore
+import {ensureStylePlaceholder, getStylePlaceholder} from './style-placeholder.js';
 import StyleInfo from './style-info.js';
 import StyleCache from './style-cache.js';
-import {
-  flush as watcherFlush,
-  getOwnerScope,
-  getCurrentScope,
-} from './document-watcher.js';
+// prettier-ignore
+import {flush as watcherFlush, getOwnerScope, getCurrentScope} from './document-watcher.js';
 import templateMap from './template-map.js';
 import * as ApplyShimUtils from './apply-shim-utils.js';
 import {updateNativeProperties, detectMixin} from './common-utils.js';
-import {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  CustomStyleInterfaceInterface,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  CustomStyleProvider,
-} from './custom-style-interface.js';
+// prettier-ignore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import {CustomStyleInterfaceInterface, CustomStyleProvider} from './custom-style-interface.js';
 
 /** @type {!Object<string, string>} */
 const adoptedCssTextMap = {};

--- a/packages/shadycss/src/style-util.js
+++ b/packages/shadycss/src/style-util.js
@@ -13,10 +13,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import {nativeShadow, nativeCssVariables, cssBuild} from './style-settings.js';
 import {parse, stringify, types, StyleNode} from './css-parse.js'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import {MEDIA_MATCH} from './common-regex.js';
-import {
-  processUnscopedStyle,
-  isUnscopedStyle,
-} from './unscoped-style-handler.js';
+// prettier-ignore
+import {processUnscopedStyle, isUnscopedStyle} from './unscoped-style-handler.js';
 
 /**
  * @param {string|StyleNode} rules

--- a/packages/shadydom/src/link-nodes.js
+++ b/packages/shadydom/src/link-nodes.js
@@ -10,10 +10,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import * as utils from './utils.js';
 import {shadyDataForNode, ensureShadyDataForNode} from './shady-data.js';
-import {
-  patchInsideElementAccessors,
-  patchOutsideElementAccessors,
-} from './patch-instances.js';
+// prettier-ignore
+import {patchInsideElementAccessors, patchOutsideElementAccessors} from './patch-instances.js';
 import {patchNodeProto} from './patch-prototypes.js';
 
 const OutsideAccessors = 1;

--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -12,10 +12,8 @@ import * as utils from './utils.js';
 import {EventTargetPatches} from './patches/EventTarget.js';
 import {NodePatches} from './patches/Node.js';
 import {SlotablePatches} from './patches/Slotable.js';
-import {
-  ParentNodePatches,
-  ParentNodeDocumentOrFragmentPatches,
-} from './patches/ParentNode.js';
+// prettier-ignore
+import {ParentNodePatches, ParentNodeDocumentOrFragmentPatches} from './patches/ParentNode.js';
 import {ChildNodePatches} from './patches/ChildNode.js';
 import {ElementPatches, ElementShadowPatches} from './patches/Element.js';
 import {ElementOrShadowRootPatches} from './patches/ElementOrShadowRoot.js';

--- a/packages/shadydom/src/patch-shadyRoot.js
+++ b/packages/shadydom/src/patch-shadyRoot.js
@@ -10,11 +10,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import * as utils from './utils.js';
 import {NodePatches} from './patches/Node.js';
-import {
-  OutsideDescriptors,
-  InsideDescriptors,
-  TextContentInnerHTMLDescriptors,
-} from './patch-instances.js';
+// prettier-ignore
+import {OutsideDescriptors, InsideDescriptors, TextContentInnerHTMLDescriptors} from './patch-instances.js';
 import {ParentNodePatches} from './patches/ParentNode.js';
 import {DocumentOrFragmentPatches} from './patches/DocumentOrFragment.js';
 import {DocumentOrShadowRootPatches} from './patches/DocumentOrShadowRoot.js';

--- a/packages/shadydom/src/patches/Element.js
+++ b/packages/shadydom/src/patches/Element.js
@@ -12,10 +12,8 @@ import * as utils from '../utils.js';
 import {scopeClassAttribute} from '../style-scoping.js';
 import {shadyDataForNode} from '../shady-data.js';
 import {attachShadow, ownerShadyRootForNode} from '../attach-shadow.js';
-import {
-  eventPropertyNamesForElement,
-  wrappedDescriptorForEventProperty,
-} from '../patch-events.js';
+// prettier-ignore
+import {eventPropertyNamesForElement, wrappedDescriptorForEventProperty} from '../patch-events.js';
 
 const doc = window.document;
 

--- a/packages/shadydom/src/patches/EventTarget.js
+++ b/packages/shadydom/src/patches/EventTarget.js
@@ -9,11 +9,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import * as utils from '../utils.js';
-import {
-  addEventListener,
-  removeEventListener,
-  dispatchEvent,
-} from '../patch-events.js';
+// prettier-ignore
+import {addEventListener, removeEventListener, dispatchEvent} from '../patch-events.js';
 
 export const EventTargetPatches = utils.getOwnPropertyDescriptors({
   dispatchEvent,

--- a/packages/shadydom/src/patches/HTMLElement.js
+++ b/packages/shadydom/src/patches/HTMLElement.js
@@ -9,10 +9,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import * as utils from '../utils.js';
-import {
-  eventPropertyNamesForHTMLElement,
-  wrappedDescriptorForEventProperty,
-} from '../patch-events.js';
+// prettier-ignore
+import {eventPropertyNamesForHTMLElement, wrappedDescriptorForEventProperty} from '../patch-events.js';
 import {shadyDataForNode} from '../shady-data.js';
 
 export const HTMLElementPatches = utils.getOwnPropertyDescriptors({

--- a/packages/shadydom/src/patches/Node.js
+++ b/packages/shadydom/src/patches/Node.js
@@ -9,14 +9,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import * as utils from '../utils.js';
-import {
-  getScopingShim,
-  removeShadyScoping,
-  replaceShadyScoping,
-  treeVisitor,
-  currentScopeForNode,
-  currentScopeIsCorrect,
-} from '../style-scoping.js';
+// prettier-ignore
+import {getScopingShim, removeShadyScoping, replaceShadyScoping, treeVisitor, currentScopeForNode, currentScopeIsCorrect} from '../style-scoping.js';
 import {shadyDataForNode, ensureShadyDataForNode} from '../shady-data.js';
 import {recordInsertBefore, recordRemoveChild} from '../link-nodes.js';
 import {ownerShadyRootForNode} from '../attach-shadow.js';

--- a/packages/shadydom/src/patches/Window.js
+++ b/packages/shadydom/src/patches/Window.js
@@ -8,11 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 import * as utils from '../utils.js';
-import {
-  addEventListener,
-  removeEventListener,
-  dispatchEvent,
-} from '../patch-events.js';
+// prettier-ignore
+import {addEventListener, removeEventListener, dispatchEvent} from '../patch-events.js';
 
 export const WindowPatches = utils.getOwnPropertyDescriptors({
   // Ensure that `dispatchEvent` is patched directly on Window since on

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -20,29 +20,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import * as utils from './utils.js';
 import {flush, enqueue} from './flush.js';
-import {
-  observeChildren,
-  unobserveChildren,
-  filterMutations,
-} from './observe-changes.js';
-import {
-  addNativePrefixedProperties,
-  nativeMethods,
-  nativeTree,
-} from './patch-native.js';
-import {
-  patchInsideElementAccessors,
-  patchOutsideElementAccessors,
-} from './patch-instances.js';
+// prettier-ignore
+import {observeChildren, unobserveChildren, filterMutations} from './observe-changes.js';
+// prettier-ignore
+import {addNativePrefixedProperties, nativeMethods, nativeTree} from './patch-native.js';
+// prettier-ignore
+import {patchInsideElementAccessors, patchOutsideElementAccessors} from './patch-instances.js';
 import {patchEvents, patchClick, composedPath} from './patch-events.js';
 import {ShadyRoot} from './attach-shadow.js';
 import {wrap, Wrapper} from './wrapper.js';
-import {
-  addShadyPrefixedProperties,
-  applyPatches,
-  patchShadowOnElement,
-  patchElementProto,
-} from './patch-prototypes.js';
+// prettier-ignore
+import {addShadyPrefixedProperties, applyPatches, patchShadowOnElement, patchElementProto} from './patch-prototypes.js';
 
 if (utils.settings.inUse) {
   const patch = utils.settings.hasDescriptors

--- a/packages/shadydom/src/wrapper.js
+++ b/packages/shadydom/src/wrapper.js
@@ -9,10 +9,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import * as utils from './utils.js';
-import {
-  eventPropertyNamesForElement,
-  eventPropertyNamesForHTMLElement,
-} from './patch-events.js';
+// prettier-ignore
+import {eventPropertyNamesForElement, eventPropertyNamesForHTMLElement} from './patch-events.js';
 
 /** @implements {IWrapper} */
 class Wrapper {


### PR DESCRIPTION
There's an internal tool that breaks on multiline imports. It's being actively replaced, but for now we need to work around it.

This PR is part of http://cl/379640941, which is waiting on internal tests to finish. I also tested that CL + #455 last night and only saw 5 failures, which were fixed locally after reverting changes from #455.