### PR TITLE
Reintroduce catch and immediate throw in `CustomElementRegistry`.

### DIFF
--- a/packages/custom-elements/ts_src/CustomElementRegistry.ts
+++ b/packages/custom-elements/ts_src/CustomElementRegistry.ts
@@ -162,6 +162,9 @@ export default class CustomElementRegistry {
       // `attributesChangedCallback` exists
       observedAttributes =
         (attributeChangedCallback && constructor['observedAttributes']) || [];
+      // eslint-disable-next-line no-useless-catch
+    } catch (e) {
+      throw e;
     } finally {
       this._elementDefinitionIsRunning = false;
     }


### PR DESCRIPTION
I requested this `catch` removed [here](https://github.com/webcomponents/polyfills/pull/398#discussion_r508100575) but this change is breaking some internal tests.