### PR TITLE
Fix typo: `ShadyDom` -> `ShadyDOM`

### DIFF
--- a/packages/custom-elements/ts_src/CustomElementInternals.ts
+++ b/packages/custom-elements/ts_src/CustomElementInternals.ts
@@ -37,7 +37,7 @@ export default class CustomElementInternals {
     callback: (elem: Element) => void,
     visitedImports?: Set<Node>
   ) {
-    const sd = window['ShadyDom'];
+    const sd = window['ShadyDOM'];
     if (this.shadyDomFastWalk && sd && sd['inUse']) {
       if (node.nodeType === Node.ELEMENT_NODE) {
         const element = node as Element;

--- a/packages/custom-elements/ts_src/Externs.ts
+++ b/packages/custom-elements/ts_src/Externs.ts
@@ -82,7 +82,7 @@ declare global {
   }
 
   // eslint-disable-next-line no-var
-  var ShadyDom:
+  var ShadyDOM:
     | undefined
     | {
         inUse: boolean;


### PR DESCRIPTION
~This PR seems to break some internal tests. Not sure why yet.~

The tests are failing because there are screenshot tests that display a size to which the size of the custom elements polyfill contributes.