### PR TITLE
Add `CHANGELOG.md` to the each package's `files` field explicitly.

### DIFF
--- a/packages/custom-elements/package.json
+++ b/packages/custom-elements/package.json
@@ -22,6 +22,7 @@
     "prepack": "npm run build"
   },
   "files": [
+    "CHANGELOG.md",
     "custom-elements.min.js*",
     "externs/",
     "src/"

--- a/packages/formdata-event/package.json
+++ b/packages/formdata-event/package.json
@@ -22,6 +22,7 @@
     "prepack": "npm run build"
   },
   "files": [
+    "CHANGELOG.md",
     "formdata-event.min.js*",
     "src/"
   ],

--- a/packages/html-imports/package.json
+++ b/packages/html-imports/package.json
@@ -22,6 +22,7 @@
     "prepack": "npm run build"
   },
   "files": [
+    "CHANGELOG.md",
     "externs/",
     "html-imports.min.js*",
     "src/"

--- a/packages/scoped-custom-element-registry/package.json
+++ b/packages/scoped-custom-element-registry/package.json
@@ -22,6 +22,7 @@
     "test": "cd ../.. && wtr 'packages/scoped-custom-element-registry/test/**/*.test.(js|html)'"
   },
   "files": [
+    "CHANGELOG.md",
     "scoped-custom-element-registry.min.js*",
     "src/"
   ],

--- a/packages/shadycss/package.json
+++ b/packages/shadycss/package.json
@@ -27,6 +27,7 @@
   "files": [
     "apply-shim.html",
     "apply-shim.min.js*",
+    "CHANGELOG.md",
     "custom-style-interface.html",
     "custom-style-interface.min.js*",
     "entrypoints/**/*.js",

--- a/packages/shadydom/package.json
+++ b/packages/shadydom/package.json
@@ -23,6 +23,7 @@
     "regen-package-lock": "rm -rf node_modules package-lock.json; npm install"
   },
   "files": [
+    "CHANGELOG.md",
     "externs/**/*.js",
     "LICENSE.md",
     "shadydom.min.js*",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -21,6 +21,7 @@
     "prepack": "npm run build"
   },
   "files": [
+    "CHANGELOG.md",
     "template.min.js*"
   ]
 }

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -21,6 +21,7 @@
     "prepack": "npm run build"
   },
   "files": [
+    "CHANGELOG.md",
     "url.js",
     "url.min.js*"
   ]

--- a/packages/webcomponentsjs/package.json
+++ b/packages/webcomponentsjs/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "bundles/**/*",
+    "CHANGELOG.md",
     "custom-elements-es5-adapter.js",
     "src/**/*.js",
     "webcomponents-bundle.js*",


### PR DESCRIPTION
npm seems to have stopped automatically including these. [The docs][1] aren't 100% clear, but still seem to imply 'CHANGELOG.md' should be automatically included. (Or, maybe only specifically `CHANGES` can have alternate extensions?)

[1]: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files

<!--
Please include a clear and concise description of what bug this PR fixes, or
what feature this PR implements.

If it resolves an existing issue, please include a line like "Fixes #1234"
-->
