### PR TITLE
Allow event listener options to be specified with a function in addition to an object or boolean

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## Unreleased -->
 
+## Unreleased
+
+- Allow event listener options to be specified using a function in addition to
+  an object ([#469]https://github.com/webcomponents/polyfills/pull/469)
+
 ## [1.9.0] - 2021-08-02
 
 - Add `@this` annotation to new `elementFromPoint` wrappers.

--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Allow event listener options to be specified using a function in addition to
-  an object ([#469](https://github.com/webcomponents/polyfills/pull/469))
-- Adds an opt-out for polyfilling `element(s)FromPoint` on `document` via setting `ShadyDOM.useNativeDocumentEFP` to `true`.
+  an object ([#469](https://github.com/webcomponents/polyfills/pull/469)).
+- The `eventPhase` property of events is now properly set to `Event.AT_TARGET`
+  when events are re-targeted to hosts of shadowRoots
+  ([#469](https://github.com/webcomponents/polyfills/pull/469)).
+- Adds an opt-out for polyfilling `element(s)FromPoint` on `document` via
+  setting `ShadyDOM.useNativeDocumentEFP` to `true`.
 
 ## [1.9.0] - 2021-08-02
 

--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#469](https://github.com/webcomponents/polyfills/pull/469)).
 - Adds an opt-out for polyfilling `element(s)FromPoint` on `document` via
   setting `ShadyDOM.useNativeDocumentEFP` to `true`.
+  ([#469](https://github.com/webcomponents/polyfills/pull/469))
 
 ## [1.9.0] - 2021-08-02
 

--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Allow event listener options to be specified using a function in addition to
-  an object ([#469](https://github.com/webcomponents/polyfills/pull/469)).
+  an object. ([#469](https://github.com/webcomponents/polyfills/pull/469))
 - The `eventPhase` property of events is now properly set to `Event.AT_TARGET`
-  when events are re-targeted to hosts of shadowRoots
-  ([#469](https://github.com/webcomponents/polyfills/pull/469)).
+  when events are re-targeted to hosts of shadowRoots.
+  ([#469](https://github.com/webcomponents/polyfills/pull/469))
 - Adds an opt-out for polyfilling `element(s)FromPoint` on `document` via
   setting `ShadyDOM.useNativeDocumentEFP` to `true`.
-  ([#469](https://github.com/webcomponents/polyfills/pull/469))
+  ([#472](https://github.com/webcomponents/polyfills/pull/472))
 
 ## [1.9.0] - 2021-08-02
 

--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Allow event listener options to be specified using a function in addition to
-  an object ([#469]https://github.com/webcomponents/polyfills/pull/469)
+  an object ([#469](https://github.com/webcomponents/polyfills/pull/469))
 - Adds an opt-out for polyfilling `element(s)FromPoint` on `document` via setting `ShadyDOM.useNativeDocumentEFP` to `true`.
 
 ## [1.9.0] - 2021-08-02

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -193,16 +193,12 @@ function retarget(refNode, path) {
   }
 }
 
-const nativeEventPhase = Object.getOwnPropertyDescriptor(
+const eventPhaseDescriptor = Object.getOwnPropertyDescriptor(
   Event.prototype,
   'eventPhase'
 );
 
 let EventPatches = {
-  get [utils.NATIVE_PREFIX + 'eventPhase']() {
-    return nativeEventPhase.get.call(this);
-  },
-
   get eventPhase() {
     return this.currentTarget === this.target
       ? Event.AT_TARGET
@@ -285,6 +281,12 @@ let EventPatches = {
     this.__propagationStopped = true;
   },
 };
+
+Object.defineProperty(
+  EventPatches,
+  utils.NATIVE_PREFIX + 'eventPhase',
+  eventPhaseDescriptor
+);
 
 function mixinComposedFlag(Base) {
   // NOTE: avoiding use of `class` here so that transpiled output does not

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -514,7 +514,7 @@ export function addEventListener(type, fnOrObj, optionsOrCapture) {
    * @this {HTMLElement}
    * @param {Event} e
    */
-  const wrapperFn = function (e) {
+  const wrapperFn = (e) => {
     // Support `once` option.
     if (once) {
       this[utils.SHADY_PREFIX + 'removeEventListener'](

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -193,7 +193,22 @@ function retarget(refNode, path) {
   }
 }
 
+const nativeEventPhase = Object.getOwnPropertyDescriptor(
+  Event.prototype,
+  'eventPhase'
+);
+
 let EventPatches = {
+  get [utils.NATIVE_PREFIX + 'eventPhase']() {
+    return nativeEventPhase.get.call(this);
+  },
+
+  get eventPhase() {
+    return this.currentTarget === this.target
+      ? Event.AT_TARGET
+      : this[utils.NATIVE_PREFIX + 'eventPhase'];
+  },
+
   /**
    * @this {Event}
    */

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -44,7 +44,10 @@ const supportsEventOptions = (() => {
 
 const parseEventOptions = (optionsOrCapture) => {
   let capture, once, passive, shadyTarget;
-  if (optionsOrCapture && optionsOrCapture instanceof Object) {
+  if (
+    optionsOrCapture &&
+    (typeof optionsOrCapture === 'object' || optionsOrCapture instanceof Object)
+  ) {
     capture = Boolean(optionsOrCapture.capture);
     once = Boolean(optionsOrCapture.once);
     passive = Boolean(optionsOrCapture.passive);

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -271,11 +271,12 @@ let EventPatches = {
   },
 };
 
-const eventPhaseDescriptor = Object.getOwnPropertyDescriptor(
-  Event.prototype,
-  'eventPhase'
-);
-if (eventPhaseDescriptor !== undefined) {
+const hasDescriptors = utils.settings.hasDescriptors;
+
+const eventPhaseDescriptor =
+  hasDescriptors &&
+  Object.getOwnPropertyDescriptor(Event.prototype, 'eventPhase');
+if (eventPhaseDescriptor) {
   Object.defineProperty(EventPatches, 'eventPhase', {
     get() {
       return this.currentTarget === this.target

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -46,7 +46,8 @@ const parseEventOptions = (optionsOrCapture) => {
   let capture, once, shadyTarget;
   if (
     optionsOrCapture &&
-    (typeof optionsOrCapture === 'object' || optionsOrCapture instanceof Object)
+    (typeof optionsOrCapture === 'object' ||
+      typeof optionsOrCapture === 'function')
   ) {
     capture = Boolean(optionsOrCapture.capture);
     once = Boolean(optionsOrCapture.once);

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -45,7 +45,7 @@ const supportsEventOptions = (() => {
 const parseEventOptions = (optionsOrCapture) => {
   let capture, once, shadyTarget;
   if (
-    optionsOrCapture &&
+    optionsOrCapture !== null &&
     (typeof optionsOrCapture === 'object' ||
       typeof optionsOrCapture === 'function')
   ) {

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -193,18 +193,7 @@ function retarget(refNode, path) {
   }
 }
 
-const eventPhaseDescriptor = Object.getOwnPropertyDescriptor(
-  Event.prototype,
-  'eventPhase'
-);
-
 let EventPatches = {
-  get eventPhase() {
-    return this.currentTarget === this.target
-      ? Event.AT_TARGET
-      : this[utils.NATIVE_PREFIX + 'eventPhase'];
-  },
-
   /**
    * @this {Event}
    */
@@ -282,11 +271,27 @@ let EventPatches = {
   },
 };
 
-Object.defineProperty(
-  EventPatches,
-  utils.NATIVE_PREFIX + 'eventPhase',
-  eventPhaseDescriptor
+const eventPhaseDescriptor = Object.getOwnPropertyDescriptor(
+  Event.prototype,
+  'eventPhase'
 );
+if (eventPhaseDescriptor !== undefined) {
+  Object.defineProperty(EventPatches, 'eventPhase', {
+    get() {
+      return this.currentTarget === this.target
+        ? Event.AT_TARGET
+        : this[utils.NATIVE_PREFIX + 'eventPhase'];
+    },
+    enumerable: true,
+    configurable: true,
+  });
+
+  Object.defineProperty(
+    EventPatches,
+    utils.NATIVE_PREFIX + 'eventPhase',
+    eventPhaseDescriptor
+  );
+}
 
 function mixinComposedFlag(Base) {
   // NOTE: avoiding use of `class` here so that transpiled output does not

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -272,10 +272,12 @@ let EventPatches = {
   },
 };
 
-const hasDescriptors = utils.settings.hasDescriptors;
-
+// Some browsers have missing or broken descriptors. If this is the case
+// eventPhase can't be polyfilled. For example, Chrome 41 does not
+// have prototypical descriptors on DOM objects and Safari 9 has broken ones
+// that cannot be used.
 const eventPhaseDescriptor =
-  hasDescriptors &&
+  utils.settings.hasDescriptors &&
   Object.getOwnPropertyDescriptor(Event.prototype, 'eventPhase');
 if (eventPhaseDescriptor) {
   Object.defineProperty(EventPatches, 'eventPhase', {

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -44,7 +44,7 @@ const supportsEventOptions = (() => {
 
 const parseEventOptions = (optionsOrCapture) => {
   let capture, once, passive, shadyTarget;
-  if (optionsOrCapture && typeof optionsOrCapture === 'object') {
+  if (optionsOrCapture && optionsOrCapture instanceof Object) {
     capture = Boolean(optionsOrCapture.capture);
     once = Boolean(optionsOrCapture.once);
     passive = Boolean(optionsOrCapture.passive);

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -512,7 +512,7 @@ export function addEventListener(type, fnOrObj, optionsOrCapture) {
   }
 
   /**
-   * @this {HTMLElement}
+   * @this {EventTarget}
    * @param {Event} e
    */
   const wrapperFn = (e) => {
@@ -609,9 +609,9 @@ export function addEventListener(type, fnOrObj, optionsOrCapture) {
     // note: use target here which is either a shadowRoot
     // (when the host element is proxy'ing the event) or this element
     node: target,
-    type: type,
-    capture: capture,
-    wrapperFn: wrapperFn,
+    type,
+    capture,
+    wrapperFn,
   });
 
   this.__handlers = this.__handlers || {};

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -1589,7 +1589,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test.only('bubbling eventPhase', function () {
+        test('bubbling eventPhase', function () {
           const eventPhases = [];
           const listener = (e) => {
             eventPhases.push(e.eventPhase);
@@ -1606,7 +1606,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.deepEqual(eventPhases, [t, t, b, t, b, t]);
         });
 
-        test.only('capturing eventPhase', function () {
+        test('capturing eventPhase', function () {
           const eventPhases = [];
           const listener = (e) => {
             eventPhases.push(e.eventPhase);

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -1664,17 +1664,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ? test
           : test.skip)('bubbling eventPhase', function () {
           const eventPhases = [];
-          const listener = (e) => {
+          const listener = function (e) {
             eventPhases.push(e.eventPhase);
           };
+          // Note, order of propagation between listeners on shadowRoots
+          // and hosts is known to be incorrect; ensure correct ordering
+          // by adding shadowRoot listeners first.
+          ShadyDOM.wrapIfNeeded(h1).shadowRoot.addEventListener(
+            'click',
+            listener
+          );
           ShadyDOM.wrapIfNeeded(h1).addEventListener('click', listener);
           ShadyDOM.wrapIfNeeded(h1_c).addEventListener('click', listener);
+          ShadyDOM.wrapIfNeeded(h1_c_h2).shadowRoot.addEventListener(
+            'click',
+            listener
+          );
           ShadyDOM.wrapIfNeeded(h1_c_h2).addEventListener('click', listener);
           ShadyDOM.wrapIfNeeded(h1_c_h2_c).addEventListener('click', listener);
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3).shadowRoot.addEventListener(
+            'click',
+            listener
+          );
           ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3).addEventListener(
             'click',
             listener
           );
+
           ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3_c).addEventListener(
             'click',
             listener
@@ -1684,7 +1700,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           );
           const t = Event.AT_TARGET;
           const b = Event.BUBBLING_PHASE;
-          assert.deepEqual(eventPhases, [t, t, b, t, b, t]);
+          assert.deepEqual(eventPhases, [t, b, t, b, b, t, b, b, t]);
         });
 
         (window.canTestEventPhase
@@ -1695,8 +1711,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             eventPhases.push(e.eventPhase);
           };
           ShadyDOM.wrapIfNeeded(h1).addEventListener('click', listener, true);
+          ShadyDOM.wrapIfNeeded(h1).shadowRoot.addEventListener(
+            'click',
+            listener,
+            true
+          );
           ShadyDOM.wrapIfNeeded(h1_c).addEventListener('click', listener, true);
           ShadyDOM.wrapIfNeeded(h1_c_h2).addEventListener(
+            'click',
+            listener,
+            true
+          );
+          ShadyDOM.wrapIfNeeded(h1_c_h2).shadowRoot.addEventListener(
             'click',
             listener,
             true
@@ -1711,6 +1737,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             listener,
             true
           );
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3).shadowRoot.addEventListener(
+            'click',
+            listener,
+            true
+          );
           ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3_c).addEventListener(
             'click',
             listener,
@@ -1721,7 +1752,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           );
           const t = Event.AT_TARGET;
           const c = Event.CAPTURING_PHASE;
-          assert.deepEqual(eventPhases, [t, c, t, c, t, t]);
+          assert.deepEqual(eventPhases, [t, c, c, t, c, c, t, c, t]);
         });
       });
 

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -1260,6 +1260,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('Patch of addEventListener/removeEventListener', function () {
         var el1, el2, parent, child, gchild, callback;
+        var h1, h1_c, h1_c_h2, h1_c_h2_c, h1_c_h2_c_h3, h1_c_h2_c_h3_c;
 
         setup(function () {
           el1 = document.createElement('button');
@@ -1277,22 +1278,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ShadyDOM.wrapIfNeeded(parent).appendChild(child);
           ShadyDOM.wrapIfNeeded(document.body).appendChild(parent);
 
+          h1 = document.createElement('div');
+          h1_c = document.createElement('div');
+          h1_c_h2 = document.createElement('div');
+          h1_c_h2_c = document.createElement('div');
+          h1_c_h2_c_h3 = document.createElement('div');
+          h1_c_h2_c_h3_c = document.createElement('div');
+          ShadyDOM.wrapIfNeeded(h1).attachShadow({mode: 'open'});
+          ShadyDOM.wrapIfNeeded(h1_c_h2).attachShadow({mode: 'open'});
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3).attachShadow({mode: 'open'});
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3).shadowRoot.appendChild(
+            h1_c_h2_c_h3_c
+          );
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c).appendChild(h1_c_h2_c_h3);
+          ShadyDOM.wrapIfNeeded(h1_c_h2).shadowRoot.appendChild(h1_c_h2_c);
+          ShadyDOM.wrapIfNeeded(h1_c).appendChild(h1_c_h2);
+          ShadyDOM.wrapIfNeeded(h1).shadowRoot.appendChild(h1_c);
+          ShadyDOM.wrapIfNeeded(document.body).appendChild(h1);
           callback = sinon.stub();
         });
 
         teardown(function () {
-          ShadyDOM.wrapIfNeeded(el1).parentNode &&
-            ShadyDOM.wrapIfNeeded(
-              ShadyDOM.wrapIfNeeded(el1).parentNode
-            ).removeChild(el1);
-          ShadyDOM.wrapIfNeeded(el2).parentNode &&
-            ShadyDOM.wrapIfNeeded(
-              ShadyDOM.wrapIfNeeded(el2).parentNode
-            ).removeChild(el2);
-          ShadyDOM.wrapIfNeeded(parent).parentNode &&
-            ShadyDOM.wrapIfNeeded(
-              ShadyDOM.wrapIfNeeded(parent).parentNode
-            ).removeChild(parent);
+          ShadyDOM.wrapIfNeeded(el1).remove();
+          ShadyDOM.wrapIfNeeded(el2).remove();
+          ShadyDOM.wrapIfNeeded(parent).remove();
+          ShadyDOM.wrapIfNeeded(h1).remove();
         });
 
         test('events bubble as expected with different listener options', function () {
@@ -1577,6 +1587,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.doesNotThrow(function () {
             ShadyDOM.wrapIfNeeded(el1).addEventListener('baz', null);
           });
+        });
+
+        test.only('bubbling eventPhase', function () {
+          const eventPhases = [];
+          const listener = (e) => {
+            eventPhases.push(e.eventPhase);
+          };
+          h1.addEventListener('click', listener);
+          h1_c.addEventListener('click', listener);
+          h1_c_h2.addEventListener('click', listener);
+          h1_c_h2_c.addEventListener('click', listener);
+          h1_c_h2_c_h3.addEventListener('click', listener);
+          h1_c_h2_c_h3_c.addEventListener('click', listener);
+          h1_c_h2_c_h3_c.click();
+          const t = Event.AT_TARGET;
+          const b = Event.BUBBLING_PHASE;
+          assert.deepEqual(eventPhases, [t, t, b, t, b, t]);
+        });
+
+        test.only('capturing eventPhase', function () {
+          const eventPhases = [];
+          const listener = (e) => {
+            eventPhases.push(e.eventPhase);
+          };
+          h1.addEventListener('click', listener, true);
+          h1_c.addEventListener('click', listener, true);
+          h1_c_h2.addEventListener('click', listener, true);
+          h1_c_h2_c.addEventListener('click', listener, true);
+          h1_c_h2_c_h3.addEventListener('click', listener, true);
+          h1_c_h2_c_h3_c.addEventListener('click', listener, true);
+          h1_c_h2_c_h3_c.click();
+          const t = Event.AT_TARGET;
+          const c = Event.CAPTURING_PHASE;
+          assert.deepEqual(eventPhases, [t, c, t, c, t, t]);
         });
       });
 

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -1259,7 +1259,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('Patch of addEventListener/removeEventListener', function () {
-        var el1, el2, callback;
+        var el1, el2, parent, child, gchild, callback;
 
         setup(function () {
           el1 = document.createElement('button');
@@ -1269,6 +1269,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           el2 = document.createElement('button');
           ShadyDOM.wrapIfNeeded(el2).textContent = 'hi again';
           ShadyDOM.wrapIfNeeded(document.body).appendChild(el2);
+
+          parent = document.createElement('div');
+          child = document.createElement('div');
+          gchild = document.createElement('div');
+          ShadyDOM.wrapIfNeeded(child).appendChild(gchild);
+          ShadyDOM.wrapIfNeeded(parent).appendChild(child);
+          ShadyDOM.wrapIfNeeded(document.body).appendChild(parent);
 
           callback = sinon.stub();
         });
@@ -1282,6 +1289,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ShadyDOM.wrapIfNeeded(
               ShadyDOM.wrapIfNeeded(el2).parentNode
             ).removeChild(el2);
+          ShadyDOM.wrapIfNeeded(parent).parentNode &&
+            ShadyDOM.wrapIfNeeded(
+              ShadyDOM.wrapIfNeeded(parent).parentNode
+            ).removeChild(parent);
+        });
+
+        test('events bubble as expected with different listener options', function () {
+          const test = (options) => {
+            const targets = [];
+            const listener = (e) => targets.push(e.currentTarget);
+            const event = 'test-bubble-event';
+            ShadyDOM.wrap(parent).addEventListener(event, listener, options);
+            ShadyDOM.wrap(child).addEventListener(event, listener, options);
+            ShadyDOM.wrap(gchild).addEventListener(event, listener, options);
+            ShadyDOM.wrap(gchild).dispatchEvent(
+              new CustomEvent(event, {bubbles: true})
+            );
+            assert.deepEqual(targets, [gchild, child, parent]);
+            ShadyDOM.wrap(parent).removeEventListener(event, listener, options);
+            ShadyDOM.wrap(child).removeEventListener(event, listener, options);
+            ShadyDOM.wrap(gchild).removeEventListener(event, listener, options);
+          };
+          // no options
+          test();
+          // options as boolean
+          test(false);
+          // options as object
+          test({capture: false});
+          // options as function
+          const f = () => {};
+          f.capture = false;
+          test(f);
+        });
+
+        test('events capture as expected with different listener options', function () {
+          const test = (options) => {
+            const targets = [];
+            const listener = (e) => targets.push(e.currentTarget);
+            const event = 'test-event';
+            ShadyDOM.wrap(parent).addEventListener(event, listener, options);
+            ShadyDOM.wrap(child).addEventListener(event, listener, options);
+            ShadyDOM.wrap(gchild).addEventListener(event, listener, options);
+            ShadyDOM.wrap(gchild).dispatchEvent(new CustomEvent(event));
+            assert.deepEqual(targets, [parent, child, gchild]);
+            ShadyDOM.wrap(parent).removeEventListener(event, listener, options);
+            ShadyDOM.wrap(child).removeEventListener(event, listener, options);
+            ShadyDOM.wrap(gchild).removeEventListener(event, listener, options);
+          };
+          // options as boolean
+          test(true);
+          // options as object
+          test({capture: true});
+          // options as function
+          const f = () => {};
+          f.capture = true;
+          test(f);
         });
 
         test('different events, same callback', function () {

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -20,6 +20,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           HTMLElement.prototype
         ).filter((x) => x.substring(0, 2) === 'on'),
       };
+
+      window.canTestEventPhase = !!Object.getOwnPropertyDescriptor(
+        Event.prototype,
+        'eventPhase'
+      );
     </script>
     <script src="wct-browser-config.js"></script>
     <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_js.js"></script>
@@ -1377,24 +1382,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('listener adding de-duplicate based only on capture option', function () {
           ShadyDOM.wrap(el1).addEventListener('click', callback);
           ShadyDOM.wrap(el1).addEventListener('click', callback);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 1, 'listener called once');
           ShadyDOM.wrap(el1).addEventListener('click', callback, {
             passive: true,
           });
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 2, 'listener called once');
           ShadyDOM.wrap(el1).addEventListener('click', callback, {once: true});
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 3, 'listener called once');
           // once not honored because listener not added.
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 4, 'listener called once');
           ShadyDOM.wrap(el1).addEventListener('click', callback, true);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 6, 'listener called 2x');
           ShadyDOM.wrap(el1).addEventListener('click', callback, true);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 8, 'listener called 2x');
         });
 
@@ -1402,35 +1419,51 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ShadyDOM.wrap(el1).addEventListener('click', callback);
           ShadyDOM.wrap(el1).addEventListener('click', callback);
           ShadyDOM.wrap(el1).removeEventListener('click', callback);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 0, 'listener not called');
           ShadyDOM.wrap(el1).addEventListener('click', callback, {
             passive: true,
           });
           ShadyDOM.wrap(el1).removeEventListener('click', callback);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 0, 'listener not called');
           ShadyDOM.wrap(el1).addEventListener('click', callback);
           ShadyDOM.wrap(el1).removeEventListener('click', callback, true);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 1, 'listener called');
           ShadyDOM.wrap(el1).removeEventListener('click', callback);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 1, 'listener not called');
           ShadyDOM.wrap(el1).addEventListener('click', callback, true);
           ShadyDOM.wrap(el1).removeEventListener('click', callback);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 2, 'listener called');
           ShadyDOM.wrap(el1).removeEventListener('click', callback, true);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 2, 'listener not called');
         });
 
         test('support `once` option', function () {
           ShadyDOM.wrap(el1).addEventListener('click', callback, {once: true});
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 1, 'listener called once');
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(
             callback.callCount,
             1,
@@ -1445,17 +1478,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ShadyDOM.wrap(el1).addEventListener('click', callback, {
             capture: true,
           });
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 2, 'called twice');
           ShadyDOM.wrap(el1).removeEventListener('click', callback, {
             passive: true,
           });
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 3, 'called by capturing listener');
           ShadyDOM.wrap(el1).removeEventListener('click', callback, {
             capture: true,
           });
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(
             callback.callCount,
             3,
@@ -1466,10 +1505,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('add same listener twice, invoke callback once', function () {
           ShadyDOM.wrap(el1).addEventListener('click', callback);
           ShadyDOM.wrap(el1).addEventListener('click', callback);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 1, 'called once');
           ShadyDOM.wrap(el1).removeEventListener('click', callback);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(
             callback.callCount,
             1,
@@ -1486,12 +1529,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ShadyDOM.wrap(el1).addEventListener('click', callback, {
             capture: true,
           });
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 1, 'listener called once');
           ShadyDOM.wrap(el1).removeEventListener('click', callback, {
             capture: true,
           });
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(
             callback.callCount,
             1,
@@ -1508,13 +1555,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             passive: true,
             capture: false,
           });
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 1, 'listener called once');
           ShadyDOM.wrap(el1).removeEventListener('click', callback, {
             passive: true,
             capture: false,
           });
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(
             callback.callCount,
             1,
@@ -1525,14 +1576,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('add same listener on two different nodes', function () {
           ShadyDOM.wrap(el1).addEventListener('click', callback);
           ShadyDOM.wrap(el2).addEventListener('click', callback);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 1, 'called once');
-          el2.click();
+          ShadyDOM.wrapIfNeeded(el2).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(callback.callCount, 2, 'called twice');
           ShadyDOM.wrap(el1).removeEventListener('click', callback);
           ShadyDOM.wrap(el2).removeEventListener('click', callback);
-          el1.click();
-          el2.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
+          ShadyDOM.wrapIfNeeded(el2).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(
             callback.callCount,
             2,
@@ -1544,7 +1603,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var obj = {handleEvent: sinon.stub()};
           ShadyDOM.wrap(el1).addEventListener('click', obj);
           ShadyDOM.wrap(el2).addEventListener('click', obj);
-          el1.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.isTrue(
             obj.handleEvent.calledOn(obj),
             'called on object listened'
@@ -1554,12 +1615,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             'called with event argument'
           );
           assert.equal(obj.handleEvent.callCount, 1, 'called once');
-          el2.click();
+          ShadyDOM.wrapIfNeeded(el2).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(obj.handleEvent.callCount, 2, 'called twice');
           ShadyDOM.wrap(el1).removeEventListener('click', obj);
           ShadyDOM.wrap(el2).removeEventListener('click', obj);
-          el1.click();
-          el2.click();
+          ShadyDOM.wrapIfNeeded(el1).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
+          ShadyDOM.wrapIfNeeded(el2).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           assert.equal(
             obj.handleEvent.callCount,
             2,
@@ -1589,7 +1656,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('bubbling eventPhase', function () {
+        (window.canTestEventPhase
+          ? test
+          : test.skip)('bubbling eventPhase', function () {
           const eventPhases = [];
           const listener = (e) => {
             eventPhases.push(e.eventPhase);
@@ -1606,13 +1675,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             'click',
             listener
           );
-          h1_c_h2_c_h3_c.click();
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3_c).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           const t = Event.AT_TARGET;
           const b = Event.BUBBLING_PHASE;
           assert.deepEqual(eventPhases, [t, t, b, t, b, t]);
         });
 
-        test('capturing eventPhase', function () {
+        (window.canTestEventPhase
+          ? test
+          : test.skip)('capturing eventPhase', function () {
           const eventPhases = [];
           const listener = (e) => {
             eventPhases.push(e.eventPhase);
@@ -1639,7 +1712,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             listener,
             true
           );
-          h1_c_h2_c_h3_c.click();
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3_c).dispatchEvent(
+            new Event('click', {bubbles: true, composed: true})
+          );
           const t = Event.AT_TARGET;
           const c = Event.CAPTURING_PHASE;
           assert.deepEqual(eventPhases, [t, c, t, c, t, t]);

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -1594,12 +1594,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           const listener = (e) => {
             eventPhases.push(e.eventPhase);
           };
-          h1.addEventListener('click', listener);
-          h1_c.addEventListener('click', listener);
-          h1_c_h2.addEventListener('click', listener);
-          h1_c_h2_c.addEventListener('click', listener);
-          h1_c_h2_c_h3.addEventListener('click', listener);
-          h1_c_h2_c_h3_c.addEventListener('click', listener);
+          ShadyDOM.wrapIfNeeded(h1).addEventListener('click', listener);
+          ShadyDOM.wrapIfNeeded(h1_c).addEventListener('click', listener);
+          ShadyDOM.wrapIfNeeded(h1_c_h2).addEventListener('click', listener);
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c).addEventListener('click', listener);
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3).addEventListener(
+            'click',
+            listener
+          );
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3_c).addEventListener(
+            'click',
+            listener
+          );
           h1_c_h2_c_h3_c.click();
           const t = Event.AT_TARGET;
           const b = Event.BUBBLING_PHASE;
@@ -1611,12 +1617,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           const listener = (e) => {
             eventPhases.push(e.eventPhase);
           };
-          h1.addEventListener('click', listener, true);
-          h1_c.addEventListener('click', listener, true);
-          h1_c_h2.addEventListener('click', listener, true);
-          h1_c_h2_c.addEventListener('click', listener, true);
-          h1_c_h2_c_h3.addEventListener('click', listener, true);
-          h1_c_h2_c_h3_c.addEventListener('click', listener, true);
+          ShadyDOM.wrapIfNeeded(h1).addEventListener('click', listener, true);
+          ShadyDOM.wrapIfNeeded(h1_c).addEventListener('click', listener, true);
+          ShadyDOM.wrapIfNeeded(h1_c_h2).addEventListener(
+            'click',
+            listener,
+            true
+          );
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c).addEventListener(
+            'click',
+            listener,
+            true
+          );
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3).addEventListener(
+            'click',
+            listener,
+            true
+          );
+          ShadyDOM.wrapIfNeeded(h1_c_h2_c_h3_c).addEventListener(
+            'click',
+            listener,
+            true
+          );
           h1_c_h2_c_h3_c.click();
           const t = Event.AT_TARGET;
           const c = Event.CAPTURING_PHASE;

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -1364,6 +1364,58 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           );
         });
 
+        test('listener adding de-duplicate based only on capture option', function () {
+          ShadyDOM.wrap(el1).addEventListener('click', callback);
+          ShadyDOM.wrap(el1).addEventListener('click', callback);
+          el1.click();
+          assert.equal(callback.callCount, 1, 'listener called once');
+          ShadyDOM.wrap(el1).addEventListener('click', callback, {
+            passive: true,
+          });
+          el1.click();
+          assert.equal(callback.callCount, 2, 'listener called once');
+          ShadyDOM.wrap(el1).addEventListener('click', callback, {once: true});
+          el1.click();
+          assert.equal(callback.callCount, 3, 'listener called once');
+          // once not honored because listener not added.
+          el1.click();
+          assert.equal(callback.callCount, 4, 'listener called once');
+          ShadyDOM.wrap(el1).addEventListener('click', callback, true);
+          el1.click();
+          assert.equal(callback.callCount, 6, 'listener called 2x');
+          ShadyDOM.wrap(el1).addEventListener('click', callback, true);
+          el1.click();
+          assert.equal(callback.callCount, 8, 'listener called 2x');
+        });
+
+        test('listener removing de-duplicate based only on capture option', function () {
+          ShadyDOM.wrap(el1).addEventListener('click', callback);
+          ShadyDOM.wrap(el1).addEventListener('click', callback);
+          ShadyDOM.wrap(el1).removeEventListener('click', callback);
+          el1.click();
+          assert.equal(callback.callCount, 0, 'listener not called');
+          ShadyDOM.wrap(el1).addEventListener('click', callback, {
+            passive: true,
+          });
+          ShadyDOM.wrap(el1).removeEventListener('click', callback);
+          el1.click();
+          assert.equal(callback.callCount, 0, 'listener not called');
+          ShadyDOM.wrap(el1).addEventListener('click', callback);
+          ShadyDOM.wrap(el1).removeEventListener('click', callback, true);
+          el1.click();
+          assert.equal(callback.callCount, 1, 'listener called');
+          ShadyDOM.wrap(el1).removeEventListener('click', callback);
+          el1.click();
+          assert.equal(callback.callCount, 1, 'listener not called');
+          ShadyDOM.wrap(el1).addEventListener('click', callback, true);
+          ShadyDOM.wrap(el1).removeEventListener('click', callback);
+          el1.click();
+          assert.equal(callback.callCount, 2, 'listener called');
+          ShadyDOM.wrap(el1).removeEventListener('click', callback, true);
+          el1.click();
+          assert.equal(callback.callCount, 2, 'listener not called');
+        });
+
         test('support `once` option', function () {
           ShadyDOM.wrap(el1).addEventListener('click', callback, {once: true});
           el1.click();

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -21,9 +21,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         ).filter((x) => x.substring(0, 2) === 'on'),
       };
 
-      window.canTestEventPhase = !!Object.getOwnPropertyDescriptor(
+      const eventPhaseDescriptor = Object.getOwnPropertyDescriptor(
         Event.prototype,
         'eventPhase'
+      );
+
+      window.canTestEventPhase = !!(
+        eventPhaseDescriptor && eventPhaseDescriptor.get
       );
     </script>
     <script src="wct-browser-config.js"></script>

--- a/packages/tests/webcomponentsjs_/event-listener-options.html
+++ b/packages/tests/webcomponentsjs_/event-listener-options.html
@@ -107,48 +107,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el1.removeEventListener('test-event-2', callback);
             el1.dispatchEvent(new CustomEvent('test-event-1'));
             el1.dispatchEvent(new CustomEvent('test-event-2'));
-            assert.equal(
-              callback.callCount,
-              2,
-              'listeners removed (callCount did not increase)'
-            );
+            assert.equal(callback.callCount, 2, 'not called after removal');
           });
 
-          test('support `once` option', function () {
-            el1.addEventListener('click', callback, {once: true});
-            el1.click();
-            assert.equal(callback.callCount, 1, 'listener called once');
-            el1.click();
-            assert.equal(
-              callback.callCount,
-              1,
-              'listener automatically removed (callCount did not increase)'
-            );
-          });
-
-          test('same event, same callback, different options', function () {
-            el1.addEventListener('click', callback, {
-              passive: true,
-            });
+          test('same event, same callback, different capture options', function () {
+            el1.addEventListener('click', callback, {});
             el1.addEventListener('click', callback, {
               capture: true,
             });
             el1.click();
             assert.equal(callback.callCount, 2, 'called twice');
-            el1.removeEventListener('click', callback, {
-              passive: true,
-            });
+            el1.removeEventListener('click', callback, {});
             el1.click();
             assert.equal(callback.callCount, 3, 'called by capturing listener');
             el1.removeEventListener('click', callback, {
               capture: true,
             });
             el1.click();
-            assert.equal(
-              callback.callCount,
-              3,
-              'listeners removed (callCount did not increase)'
-            );
+            assert.equal(callback.callCount, 3, 'not called after removal');
           });
 
           test('add same listener twice, invoke callback once', function () {
@@ -158,11 +134,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(callback.callCount, 1, 'called once');
             el1.removeEventListener('click', callback);
             el1.click();
-            assert.equal(
-              callback.callCount,
-              1,
-              'listener removed (callCount did not increase)'
-            );
+            assert.equal(callback.callCount, 1, 'not called after removal');
           });
 
           test('add same listener twice, invoke callback once (different useCapture notation)', function () {
@@ -176,11 +148,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               capture: true,
             });
             el1.click();
-            assert.equal(
-              callback.callCount,
-              1,
-              'listener removed (callCount did not increase)'
-            );
+            assert.equal(callback.callCount, 1, 'not called after removal');
           });
 
           test('add same listener twice, different order of options keys', function () {
@@ -199,11 +167,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               capture: false,
             });
             el1.click();
-            assert.equal(
-              callback.callCount,
-              1,
-              'listener removed (callCount did not increase)'
-            );
+            assert.equal(callback.callCount, 1, 'not called after removal');
           });
 
           test('add same listener on two different nodes', function () {
@@ -217,11 +181,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             el2.removeEventListener('click', callback);
             el1.click();
             el2.click();
-            assert.equal(
-              callback.callCount,
-              2,
-              'listeners removed (callCount did not increase)'
-            );
+            assert.equal(callback.callCount, 2, 'not called after removal');
+          });
+
+          test('add same listener on two different events types', function () {
+            el1.addEventListener('click', callback);
+            el1.addEventListener('foo', callback);
+            el1.click();
+            assert.equal(callback.callCount, 1, 'called once');
+            el1.dispatchEvent(new Event('foo'));
+            assert.equal(callback.callCount, 2, 'called twice');
+            el1.removeEventListener('click', callback);
+            el1.dispatchEvent(new Event('foo'));
+            assert.equal(callback.callCount, 3, 'called 3x');
+            el1.removeEventListener('foo', callback);
+            el1.click();
+            el1.dispatchEvent(new Event('foo'));
+            assert.equal(callback.callCount, 3, 'not called after removal');
           });
 
           test('add listener with `handleEvent` function', function () {
@@ -247,8 +223,96 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(
               obj.handleEvent.callCount,
               2,
-              'listeners removed (callCount did not increase)'
+              'not called after removal'
             );
+          });
+
+          test('support `once` option', function () {
+            el1.addEventListener('click', callback, {once: true});
+            el1.click();
+            assert.equal(callback.callCount, 1, 'listener called once');
+            el1.click();
+            assert.equal(callback.callCount, 1, 'respects once option');
+          });
+
+          test('same listener with different `once` options', function () {
+            // same listener adds only once
+            el1.addEventListener('click', callback, {once: true});
+            el1.addEventListener('click', callback);
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 1, 'listener called once');
+            // same listener different event
+            el1.addEventListener('foo', callback, {once: true});
+            el1.addEventListener('foo', callback);
+            el1.dispatchEvent(new Event('foo'));
+            assert.equal(callback.callCount, 2, 'listener called twice');
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 2, 'listener called twice');
+            // can re-add listener
+            el1.addEventListener('click', callback);
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 3, 'called after re-listening');
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 4, 'called when once not used');
+            // changing once state doesn't affect listener
+            el1.addEventListener('click', callback, {once: true});
+            el1.dispatchEvent(new Event('click'));
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 6, 'changing `once` does nothing');
+          });
+
+          test('`once` option can remove listener early and be re-used', function () {
+            el1.addEventListener('click', callback, {once: true});
+            el1.removeEventListener('click', callback);
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 0, 'not called if removed early');
+            el1.addEventListener('click', callback, {once: true});
+            el1.removeEventListener('click', callback, {once: true});
+            el2.addEventListener('click', callback, {once: true});
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 0, 'not called if removed early');
+            el2.dispatchEvent(new Event('click'));
+            el2.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 1, 'not called if removed early');
+          });
+
+          test('same listener with different `once` and `capture` options', function () {
+            // same listener adds 2x with change of capture state
+            el1.addEventListener('click', callback, {once: true});
+            el1.addEventListener('click', callback, {
+              capture: true,
+              once: true,
+            });
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 2, 'called 2x');
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 2, 'calls not increased');
+            // can capture and non-capture can have different once options
+            el1.addEventListener('click', callback, {once: true});
+            el1.addEventListener('click', callback, {
+              capture: true,
+            });
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 4, 'called 2x again');
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 5, 'called for capture only');
+            el1.removeEventListener('click', callback, {
+              capture: true,
+            });
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 5, 'not called after removed');
+            // can remove captured event early.
+            el1.addEventListener('click', callback, {once: true});
+            el1.addEventListener('click', callback, true);
+            el1.removeEventListener('click', callback, true);
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 6, 'called 1x after early remove');
+            // can remove non-captured event early.
+            el1.addEventListener('click', callback, {once: true});
+            el1.addEventListener('click', callback, true);
+            el1.removeEventListener('click', callback);
+            el1.dispatchEvent(new Event('click'));
+            assert.equal(callback.callCount, 7, 'called 1x after early remove');
           });
 
           test('add null listener', function () {

--- a/packages/tests/webcomponentsjs_/event-listener-options.html
+++ b/packages/tests/webcomponentsjs_/event-listener-options.html
@@ -292,12 +292,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(callback.callCount, 0, 'not called if removed early');
             el1.addEventListener('click', callback, {once: true});
             el1.removeEventListener('click', callback, {once: true});
+            // use listener on another element
             el2.addEventListener('click', callback, {once: true});
             el1.dispatchEvent(new Event('click'));
-            assert.equal(callback.callCount, 0, 'not called if removed early');
+            assert.equal(
+              callback.callCount,
+              0,
+              'not called when re-used and event dispatched on previous element'
+            );
             el2.dispatchEvent(new Event('click'));
             el2.dispatchEvent(new Event('click'));
-            assert.equal(callback.callCount, 1, 'not called if removed early');
+            assert.equal(callback.callCount, 1, 'called once when re-used');
           });
 
           test('same listener with different `once` and `capture` options', function () {
@@ -357,6 +362,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(pThisRef, pCurrentTarget);
             assert.ok(cThisRef);
             assert.equal(cThisRef, cCurrentTarget);
+          });
+
+          test('`once` listener called with correct this when using listener with `handleEvent` function', function () {
+            let pThisRef, pCurrentTarget;
+            const pListener = {
+              handleEvent: function (e) {
+                pThisRef = this;
+                pCurrentTarget = e.currentTarget;
+              },
+            };
+            let cThisRef, cCurrentTarget;
+            const cListener = {
+              handleEvent: function (e) {
+                cThisRef = this;
+                cCurrentTarget = e.currentTarget;
+              },
+            };
+            parent.addEventListener('test', pListener, {once: true});
+            child.addEventListener('test', cListener, {once: true});
+            gchild.dispatchEvent(new Event('test', {bubbles: true}));
+            assert.ok(pThisRef);
+            assert.equal(pThisRef, pListener);
+            assert.ok(cThisRef);
+            assert.equal(cThisRef, cListener);
           });
 
           test('add null listener', function () {

--- a/packages/tests/webcomponentsjs_/event-listener-options.html
+++ b/packages/tests/webcomponentsjs_/event-listener-options.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>Event Listener Options</title>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
+    <script src="./wct-config.js"></script>
+    <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+  </head>
+  <body>
+    <script>
+      suite(
+        'addEventListener/removeEventListener with event listener options',
+        function () {
+          var el1, el2, parent, child, gchild, callback;
+
+          setup(function () {
+            el1 = document.createElement('button');
+            el1.textContent = 'hi';
+            document.body.appendChild(el1);
+
+            el2 = document.createElement('button');
+            el2.textContent = 'hi again';
+            document.body.appendChild(el2);
+
+            parent = document.createElement('div');
+            child = document.createElement('div');
+            gchild = document.createElement('div');
+            child.appendChild(gchild);
+            parent.appendChild(child);
+            document.body.appendChild(parent);
+
+            callback = sinon.stub();
+          });
+
+          teardown(function () {
+            el1.parentNode && el1.parentNode.removeChild(el1);
+            el2.parentNode && el2.parentNode.removeChild(el2);
+            parent.parentNode && parent.parentNode.removeChild(parent);
+          });
+
+          test('events bubble as expected with different listener options', function () {
+            const test = (options) => {
+              const targets = [];
+              const listener = (e) => targets.push(e.currentTarget);
+              const event = 'test-bubble-event';
+              parent.addEventListener(event, listener, options);
+              child.addEventListener(event, listener, options);
+              gchild.addEventListener(event, listener, options);
+              gchild.dispatchEvent(new CustomEvent(event, {bubbles: true}));
+              assert.deepEqual(targets, [gchild, child, parent]);
+              parent.removeEventListener(event, listener, options);
+              child.removeEventListener(event, listener, options);
+              gchild.removeEventListener(event, listener, options);
+            };
+            // no options
+            test();
+            // options as boolean
+            test(false);
+            // options as object
+            test({capture: false});
+            // options as function
+            const f = () => {};
+            f.capture = false;
+            test(f);
+          });
+
+          test('events capture as expected with different listener options', function () {
+            const test = (options) => {
+              const targets = [];
+              const listener = (e) => targets.push(e.currentTarget);
+              const event = 'test-event';
+              parent.addEventListener(event, listener, options);
+              child.addEventListener(event, listener, options);
+              gchild.addEventListener(event, listener, options);
+              gchild.dispatchEvent(new CustomEvent(event));
+              assert.deepEqual(targets, [parent, child, gchild]);
+              parent.removeEventListener(event, listener, options);
+              child.removeEventListener(event, listener, options);
+              gchild.removeEventListener(event, listener, options);
+            };
+            // options as boolean
+            test(true);
+            // options as object
+            test({capture: true});
+            // options as function
+            const f = () => {};
+            f.capture = true;
+            test(f);
+          });
+
+          test('different events, same callback', function () {
+            el1.addEventListener('test-event-1', callback);
+            el1.addEventListener('test-event-2', callback);
+            el1.dispatchEvent(new CustomEvent('test-event-1'));
+            el1.dispatchEvent(new CustomEvent('test-event-2'));
+            assert.equal(callback.callCount, 2, 'called twice');
+            el1.removeEventListener('test-event-1', callback);
+            el1.removeEventListener('test-event-2', callback);
+            el1.dispatchEvent(new CustomEvent('test-event-1'));
+            el1.dispatchEvent(new CustomEvent('test-event-2'));
+            assert.equal(
+              callback.callCount,
+              2,
+              'listeners removed (callCount did not increase)'
+            );
+          });
+
+          test('support `once` option', function () {
+            el1.addEventListener('click', callback, {once: true});
+            el1.click();
+            assert.equal(callback.callCount, 1, 'listener called once');
+            el1.click();
+            assert.equal(
+              callback.callCount,
+              1,
+              'listener automatically removed (callCount did not increase)'
+            );
+          });
+
+          test('same event, same callback, different options', function () {
+            el1.addEventListener('click', callback, {
+              passive: true,
+            });
+            el1.addEventListener('click', callback, {
+              capture: true,
+            });
+            el1.click();
+            assert.equal(callback.callCount, 2, 'called twice');
+            el1.removeEventListener('click', callback, {
+              passive: true,
+            });
+            el1.click();
+            assert.equal(callback.callCount, 3, 'called by capturing listener');
+            el1.removeEventListener('click', callback, {
+              capture: true,
+            });
+            el1.click();
+            assert.equal(
+              callback.callCount,
+              3,
+              'listeners removed (callCount did not increase)'
+            );
+          });
+
+          test('add same listener twice, invoke callback once', function () {
+            el1.addEventListener('click', callback);
+            el1.addEventListener('click', callback);
+            el1.click();
+            assert.equal(callback.callCount, 1, 'called once');
+            el1.removeEventListener('click', callback);
+            el1.click();
+            assert.equal(
+              callback.callCount,
+              1,
+              'listener removed (callCount did not increase)'
+            );
+          });
+
+          test('add same listener twice, invoke callback once (different useCapture notation)', function () {
+            el1.addEventListener('click', callback, true /* useCapture */);
+            el1.addEventListener('click', callback, {
+              capture: true,
+            });
+            el1.click();
+            assert.equal(callback.callCount, 1, 'listener called once');
+            el1.removeEventListener('click', callback, {
+              capture: true,
+            });
+            el1.click();
+            assert.equal(
+              callback.callCount,
+              1,
+              'listener removed (callCount did not increase)'
+            );
+          });
+
+          test('add same listener twice, different order of options keys', function () {
+            el1.addEventListener('click', callback, {
+              capture: false,
+              passive: true,
+            });
+            el1.addEventListener('click', callback, {
+              passive: true,
+              capture: false,
+            });
+            el1.click();
+            assert.equal(callback.callCount, 1, 'listener called once');
+            el1.removeEventListener('click', callback, {
+              passive: true,
+              capture: false,
+            });
+            el1.click();
+            assert.equal(
+              callback.callCount,
+              1,
+              'listener removed (callCount did not increase)'
+            );
+          });
+
+          test('add same listener on two different nodes', function () {
+            el1.addEventListener('click', callback);
+            el2.addEventListener('click', callback);
+            el1.click();
+            assert.equal(callback.callCount, 1, 'called once');
+            el2.click();
+            assert.equal(callback.callCount, 2, 'called twice');
+            el1.removeEventListener('click', callback);
+            el2.removeEventListener('click', callback);
+            el1.click();
+            el2.click();
+            assert.equal(
+              callback.callCount,
+              2,
+              'listeners removed (callCount did not increase)'
+            );
+          });
+
+          test('add listener with `handleEvent` function', function () {
+            var obj = {handleEvent: sinon.stub()};
+            el1.addEventListener('click', obj);
+            el2.addEventListener('click', obj);
+            el1.click();
+            assert.isTrue(
+              obj.handleEvent.calledOn(obj),
+              'called on object listened'
+            );
+            assert.isTrue(
+              obj.handleEvent.args[0][0] instanceof Event,
+              'called with event argument'
+            );
+            assert.equal(obj.handleEvent.callCount, 1, 'called once');
+            el2.click();
+            assert.equal(obj.handleEvent.callCount, 2, 'called twice');
+            el1.removeEventListener('click', obj);
+            el2.removeEventListener('click', obj);
+            el1.click();
+            el2.click();
+            assert.equal(
+              obj.handleEvent.callCount,
+              2,
+              'listeners removed (callCount did not increase)'
+            );
+          });
+
+          test('add null listener', function () {
+            assert.doesNotThrow(function () {
+              el1.addEventListener('baz', null);
+            });
+          });
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/packages/tests/webcomponentsjs_/event-listener-options.html
+++ b/packages/tests/webcomponentsjs_/event-listener-options.html
@@ -315,6 +315,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(callback.callCount, 7, 'called 1x after early remove');
           });
 
+          test('`once` listener called with correct this', function () {
+            let pThisRef, pCurrentTarget;
+            const pListener = function (e) {
+              pThisRef = this;
+              pCurrentTarget = e.currentTarget;
+            };
+            let cThisRef, cCurrentTarget;
+            const cListener = function (e) {
+              cThisRef = this;
+              cCurrentTarget = e.currentTarget;
+            };
+            parent.addEventListener('test', pListener, {once: true});
+            child.addEventListener('test', cListener, {once: true});
+            gchild.dispatchEvent(new Event('test', {bubbles: true}));
+            assert.ok(pThisRef);
+            assert.equal(pThisRef, pCurrentTarget);
+            assert.ok(cThisRef);
+            assert.equal(cThisRef, cCurrentTarget);
+          });
+
           test('add null listener', function () {
             assert.doesNotThrow(function () {
               el1.addEventListener('baz', null);

--- a/packages/tests/webcomponentsjs_/event-listener-options.html
+++ b/packages/tests/webcomponentsjs_/event-listener-options.html
@@ -227,6 +227,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             );
           });
 
+          test('add listener with function that has `handleEvent` function', function () {
+            let functionCalled = false;
+            let handleEventCalled = false;
+            var listener = () => {
+              functionCalled = true;
+            };
+            listener.handleEvent = () => {
+              handleEventCalled = true;
+            };
+
+            el1.addEventListener('click', listener, {
+              once: true,
+            });
+            el1.click();
+            assert.isTrue(
+              functionCalled,
+              'function called when handleEvent is defined on it'
+            );
+            assert.isFalse(
+              handleEventCalled,
+              'handleEvent not called when on listener function'
+            );
+          });
+
           test('support `once` option', function () {
             el1.addEventListener('click', callback, {once: true});
             el1.click();

--- a/packages/tests/webcomponentsjs_/runner.html
+++ b/packages/tests/webcomponentsjs_/runner.html
@@ -39,6 +39,7 @@
     'parent-node/index.html',
     'child-node/index.html',
     'svg-element-class-list.html',
+    'event-listener-options.html',
   ];
 </script>
 <script>

--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -11,7 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 - Polyfill `addEventListener/removeEventListener` event listener options,
-  including `{capture: boolean, once: boolean}`
+  including `{capture: boolean, once: boolean}`.
   ([#469]https://github.com/webcomponents/polyfills/pull/469)
 
 ## [2.6.0] - 2021-08-02

--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [Unreleased]
+
+- Polyfill `addEventListener/removeEventListener` event listener options,
+  including `{capture: boolean, once: boolean}`
+  ([#469]https://github.com/webcomponents/polyfills/pull/469)
+
 ## [2.6.0] - 2021-08-02
 
 - Add TS externs. ([#457](https://github.com/webcomponents/polyfills/pull/457))

--- a/packages/webcomponentsjs/src/entrypoints/webcomponents-pf_dom-index.js
+++ b/packages/webcomponentsjs/src/entrypoints/webcomponents-pf_dom-index.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import '../platform/custom-event.js';
+import '../platform/event-listener-options.js';
 import '../platform/baseuri.js';
 import '../platform/get-attribute-names.js';
 import '../platform/matches.js';

--- a/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
+++ b/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
@@ -29,7 +29,12 @@ const supportsEventOptions = (() => {
   return supported;
 })();
 
-if (!supportsEventOptions) {
+const nativeEventTarget = window.EventTarget ?? window.Node;
+
+if (
+  !supportsEventOptions &&
+  'addEventListener' in nativeEventTarget.prototype
+) {
   const parseEventOptions = (
     optionsOrCapture?: boolean | AddEventListenerOptions
   ) => {
@@ -50,10 +55,11 @@ if (!supportsEventOptions) {
     };
   };
 
-  const origAddEventListener = EventTarget.prototype.addEventListener;
-  const origRemoveEventListener = EventTarget.prototype.removeEventListener;
+  const origAddEventListener = nativeEventTarget.prototype.addEventListener;
+  const origRemoveEventListener =
+    nativeEventTarget.prototype.removeEventListener;
 
-  EventTarget.prototype.addEventListener = function (
+  nativeEventTarget.prototype.addEventListener = function (
     type: string,
     listener: EventListenerOrEventListenerObject | null,
     options?: boolean | AddEventListenerOptions | undefined
@@ -68,7 +74,7 @@ if (!supportsEventOptions) {
     origAddEventListener.call(this, type, nativeListener, capture);
   };
 
-  EventTarget.prototype.removeEventListener = function (
+  nativeEventTarget.prototype.removeEventListener = function (
     type: string,
     listener: EventListenerOrEventListenerObject | null,
     options?: boolean | AddEventListenerOptions | undefined

--- a/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
+++ b/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
@@ -32,7 +32,6 @@ const supportsEventOptions = (() => {
   const listener = () => {
     callCount++;
   };
-
   const d = document.createElement('div');
   // NOTE: These will be unpatched at this point.
   d.addEventListener('click', listener, eventOptions);
@@ -60,8 +59,7 @@ if (
     if (
       optionsOrCapture &&
       (typeof optionsOrCapture === 'object' ||
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (optionsOrCapture as any) instanceof Object)
+        typeof optionsOrCapture === 'function')
     ) {
       capture = Boolean((optionsOrCapture as AddEventListenerOptions).capture);
       once = Boolean((optionsOrCapture as AddEventListenerOptions).once);
@@ -114,7 +112,10 @@ if (
         ? (e: Event) => {
             map.delete(listener);
             origRemoveEventListener.call(this, type, cachedListener, capture);
-            ((listener as EventListenerObject).handleEvent ?? listener)(e);
+            ((listener as EventListenerObject).handleEvent ?? listener).call(
+              this,
+              e
+            );
           }
         : listener;
       map.set(listener, cachedListener);

--- a/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
+++ b/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
@@ -67,7 +67,7 @@ if (
     const {capture, once} = parseEventOptions(options);
     const nativeListener = once
       ? (e: Event) => {
-          this.removeEventListener(type, nativeListener, capture);
+          origRemoveEventListener.call(this, type, nativeListener, capture);
           ((listener as EventListenerObject).handleEvent ?? listener)(e);
         }
       : listener;

--- a/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
+++ b/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
@@ -123,9 +123,8 @@ if (
               return listener.call(this, e);
             }
 
-            const handleEvent = listener?.handleEvent;
-            if (typeof handleEvent === 'function') {
-              return handleEvent.call(e.currentTarget, e);
+            if (typeof listener?.handleEvent === 'function') {
+              return listener.handleEvent(e);
             }
           }
         : null;

--- a/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
+++ b/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
@@ -38,20 +38,22 @@ if (
   const parseEventOptions = (
     optionsOrCapture?: boolean | AddEventListenerOptions
   ) => {
-    let capture, once, passive;
-    if (optionsOrCapture && optionsOrCapture instanceof Object) {
-      capture = Boolean(optionsOrCapture.capture);
-      once = Boolean(optionsOrCapture.once);
-      passive = Boolean(optionsOrCapture.passive);
+    let capture, once;
+    if (
+      optionsOrCapture &&
+      (typeof optionsOrCapture === 'object' ||
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (optionsOrCapture as any) instanceof Object)
+    ) {
+      capture = Boolean((optionsOrCapture as AddEventListenerOptions).capture);
+      once = Boolean((optionsOrCapture as AddEventListenerOptions).once);
     } else {
       capture = Boolean(optionsOrCapture);
       once = false;
-      passive = false;
     }
     return {
       capture,
       once,
-      passive,
     };
   };
 

--- a/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
+++ b/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
@@ -112,10 +112,14 @@ if (
         ? (e: Event) => {
             map.delete(listener);
             origRemoveEventListener.call(this, type, cachedListener, capture);
-            ((listener as EventListenerObject).handleEvent ?? listener).call(
-              this,
-              e
-            );
+            if (typeof listener === 'function') {
+              return listener.call(this, e);
+            }
+
+            const handleEvent = listener?.handleEvent;
+            if (typeof handleEvent === 'function') {
+              return handleEvent.call(e.currentTarget, e);
+            }
           }
         : listener;
       map.set(listener, cachedListener);

--- a/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
+++ b/packages/webcomponentsjs/ts_src/platform/event-listener-options.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+export {};
+
+// Older browsers like IE do not support an object as the options parameter
+// to add/removeEventListener.
+// https://connect.microsoft.com/IE/feedback/details/790389/event-defaultprevented-returns-false-after-preventdefault-was-called
+const supportsEventOptions = (() => {
+  let supported = false;
+  const eventOptions = {
+    get capture() {
+      supported = true;
+      return false;
+    },
+  };
+  const listener = () => {};
+  // NOTE: These will be unpatched at this point.
+  window.addEventListener('test', listener, eventOptions);
+  window.removeEventListener('test', listener, eventOptions);
+  return supported;
+})();
+
+if (!supportsEventOptions) {
+  const parseEventOptions = (
+    optionsOrCapture?: boolean | AddEventListenerOptions
+  ) => {
+    let capture, once, passive;
+    if (optionsOrCapture && optionsOrCapture instanceof Object) {
+      capture = Boolean(optionsOrCapture.capture);
+      once = Boolean(optionsOrCapture.once);
+      passive = Boolean(optionsOrCapture.passive);
+    } else {
+      capture = Boolean(optionsOrCapture);
+      once = false;
+      passive = false;
+    }
+    return {
+      capture,
+      once,
+      passive,
+    };
+  };
+
+  const origAddEventListener = EventTarget.prototype.addEventListener;
+  const origRemoveEventListener = EventTarget.prototype.removeEventListener;
+
+  EventTarget.prototype.addEventListener = function (
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+    options?: boolean | AddEventListenerOptions | undefined
+  ) {
+    const {capture, once} = parseEventOptions(options);
+    const nativeListener = once
+      ? (e: Event) => {
+          this.removeEventListener(type, nativeListener, capture);
+          ((listener as EventListenerObject).handleEvent ?? listener)(e);
+        }
+      : listener;
+    origAddEventListener.call(this, type, nativeListener, capture);
+  };
+
+  EventTarget.prototype.removeEventListener = function (
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+    options?: boolean | AddEventListenerOptions | undefined
+  ) {
+    const {capture} = parseEventOptions(options);
+    origRemoveEventListener.call(this, type, listener, capture);
+  };
+}


### PR DESCRIPTION
Fixes #468 and #471

* Allows event listener options to be specified with any options that are `instanceof Object`. This allows functions to be used in addition to objects.
* Also fixes `eventPhase` to properly be `Event.AT_TARGET` on retargeted events.
