### PR TITLE
Adds an opt-out for polyfilling `element(s)FromPoint` on document

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Adds an opt-out for polyfilling `element(s)FromPoint` on `document` via setting `ShadyDOM.noPatchDocumentEFP` to `true`.
+- Adds an opt-out for polyfilling `element(s)FromPoint` on `document` via setting `ShadyDOM.useNativeDocumentEFP` to `true`.
 
 ## [1.9.0] - 2021-08-02
 

--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## Unreleased -->
 
+## Unreleased
+
+- Adds an opt-out for polyfilling `element(s)FromPoint` on `document` via setting `ShadyDOM.noPatchDocumentEFP` to `true`.
+
 ## [1.9.0] - 2021-08-02
 
 - Add `@this` annotation to new `elementFromPoint` wrappers.

--- a/packages/shadydom/src/patches/DocumentOrShadowRoot.js
+++ b/packages/shadydom/src/patches/DocumentOrShadowRoot.js
@@ -41,7 +41,7 @@ function getAncestorRoots(docOrRoot) {
   return roots;
 }
 
-const NO_PATCH_DOCUMENT_EFP = 'noPatchDocumentEFP';
+const USE_NATIVE_DOCUMENT_EFP = 'useNativeDocumentEFP';
 
 const elementsFromPointProperty =
   utils.NATIVE_PREFIX +
@@ -96,7 +96,7 @@ export const DocumentOrShadowRootPatches = utils.getOwnPropertyDescriptors({
   elementsFromPoint(x, y) {
     const nativeResult = document[elementsFromPointProperty](x, y);
     // support optionally opt-ing out for document
-    if (this === document && utils.settings[NO_PATCH_DOCUMENT_EFP]) {
+    if (this === document && utils.settings[USE_NATIVE_DOCUMENT_EFP]) {
       return nativeResult;
     }
     const nativeArray = utils.arrayFrom(nativeResult);
@@ -118,7 +118,7 @@ export const DocumentOrShadowRootPatches = utils.getOwnPropertyDescriptors({
   /** @this {Document|ShadowRoot} */
   elementFromPoint(x, y) {
     // support optionally opt-ing out for document
-    return this === document && utils.settings[NO_PATCH_DOCUMENT_EFP]
+    return this === document && utils.settings[USE_NATIVE_DOCUMENT_EFP]
       ? this[utils.NATIVE_PREFIX + 'elementFromPoint'](x, y)
       : this[utils.SHADY_PREFIX + 'elementsFromPoint'](x, y)[0] || null;
   },

--- a/packages/shadydom/src/patches/DocumentOrShadowRoot.js
+++ b/packages/shadydom/src/patches/DocumentOrShadowRoot.js
@@ -41,6 +41,8 @@ function getAncestorRoots(docOrRoot) {
   return roots;
 }
 
+const NO_PATCH_DOCUMENT_EFP = 'noPatchDocumentEFP';
+
 const elementsFromPointProperty =
   utils.NATIVE_PREFIX +
   utils.getPropertyName(Document.prototype, 'elementsFromPoint');
@@ -92,17 +94,20 @@ export const DocumentOrShadowRootPatches = utils.getOwnPropertyDescriptors({
 
   /** @this {Document|ShadowRoot} */
   elementsFromPoint(x, y) {
-    const nativeResult = utils.arrayFrom(
-      document[elementsFromPointProperty](x, y)
-    );
+    const nativeResult = document[elementsFromPointProperty](x, y);
+    // support optionally opt-ing out for document
+    if (this === document && utils.settings[NO_PATCH_DOCUMENT_EFP]) {
+      return nativeResult;
+    }
+    const nativeArray = utils.arrayFrom(nativeResult);
     // Filter native result to return the element in this root
     // OR an above root.
     // Set containing this root and its ancestor roots.
     const ancestorRoots = getAncestorRoots(this);
     // Use a Set since the elements can repeat.
     const rootedResult = new Set();
-    for (let i = 0; i < nativeResult.length; i++) {
-      rootedResult.add(getElInRoot(ancestorRoots, nativeResult[i]));
+    for (let i = 0; i < nativeArray.length; i++) {
+      rootedResult.add(getElInRoot(ancestorRoots, nativeArray[i]));
     }
     // Note, for IE compat avoid Array.from(set).
     const r = [];
@@ -112,6 +117,9 @@ export const DocumentOrShadowRootPatches = utils.getOwnPropertyDescriptors({
 
   /** @this {Document|ShadowRoot} */
   elementFromPoint(x, y) {
-    return this[utils.SHADY_PREFIX + 'elementsFromPoint'](x, y)[0] || null;
+    // support optionally opt-ing out for document
+    return this === document && utils.settings[NO_PATCH_DOCUMENT_EFP]
+      ? this[utils.NATIVE_PREFIX + 'elementFromPoint'](x, y)
+      : this[utils.SHADY_PREFIX + 'elementsFromPoint'](x, y)[0] || null;
   },
 });

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -1624,10 +1624,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             const inner2 = createAndPosition(shadowRoot, 0);
             const background = [document.body, document.documentElement];
             ShadyDOM.settings.useNativeDocumentEFP = true;
-            let e = ShadyDOM.wrap(document).elementsFromPoint(5, 5);
+            let e = Array.from(ShadyDOM.wrap(document).elementsFromPoint(5, 5));
             assert.deepEqual(e, [inner2, inner1, host, ...background]);
             ShadyDOM.settings.useNativeDocumentEFP = false;
-            e = ShadyDOM.wrap(document).elementsFromPoint(5, 5);
+            e = Array.from(ShadyDOM.wrap(document).elementsFromPoint(5, 5));
             assert.deepEqual(e, [host, ...background]);
             ShadyDOM.wrapIfNeeded(host).remove();
           });

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -1516,16 +1516,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ShadyDOM.wrapIfNeeded(host).remove();
           });
 
-          test('elementFromPoint (noPatch)', function () {
+          test('elementFromPoint (useNative)', function () {
             const host = createAndPosition(document.body, 10);
             const shadowRoot = ShadyDOM.wrapIfNeeded(host).attachShadow({
               mode: 'open',
             });
             const inner = createAndPosition(shadowRoot, 0);
-            ShadyDOM.settings.noPatchDocumentEFP = true;
+            ShadyDOM.settings.useNativeDocumentEFP = true;
             let e = ShadyDOM.wrap(document).elementFromPoint(5, 5);
             assert.equal(e, inner);
-            ShadyDOM.settings.noPatchDocumentEFP = false;
+            ShadyDOM.settings.useNativeDocumentEFP = false;
             e = ShadyDOM.wrap(document).elementFromPoint(5, 5);
             assert.equal(e, host);
             ShadyDOM.wrapIfNeeded(host).remove();
@@ -1615,7 +1615,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ShadyDOM.wrapIfNeeded(el2).remove();
           });
 
-          test('elementsFromPoint (noPatch)', function () {
+          test('elementsFromPoint (useNative)', function () {
             const host = createAndPosition(document.body, 0);
             const shadowRoot = ShadyDOM.wrapIfNeeded(host).attachShadow({
               mode: 'open',
@@ -1623,10 +1623,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             const inner1 = createAndPosition(shadowRoot, 0);
             const inner2 = createAndPosition(shadowRoot, 0);
             const background = [document.body, document.documentElement];
-            ShadyDOM.settings.noPatchDocumentEFP = true;
+            ShadyDOM.settings.useNativeDocumentEFP = true;
             let e = ShadyDOM.wrap(document).elementsFromPoint(5, 5);
             assert.deepEqual(e, [inner2, inner1, host, ...background]);
-            ShadyDOM.settings.noPatchDocumentEFP = false;
+            ShadyDOM.settings.useNativeDocumentEFP = false;
             e = ShadyDOM.wrap(document).elementsFromPoint(5, 5);
             assert.deepEqual(e, [host, ...background]);
             ShadyDOM.wrapIfNeeded(host).remove();

--- a/packages/tests/shadydom/shady.html
+++ b/packages/tests/shadydom/shady.html
@@ -1516,6 +1516,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ShadyDOM.wrapIfNeeded(host).remove();
           });
 
+          test('elementFromPoint (noPatch)', function () {
+            const host = createAndPosition(document.body, 10);
+            const shadowRoot = ShadyDOM.wrapIfNeeded(host).attachShadow({
+              mode: 'open',
+            });
+            const inner = createAndPosition(shadowRoot, 0);
+            ShadyDOM.settings.noPatchDocumentEFP = true;
+            let e = ShadyDOM.wrap(document).elementFromPoint(5, 5);
+            assert.equal(e, inner);
+            ShadyDOM.settings.noPatchDocumentEFP = false;
+            e = ShadyDOM.wrap(document).elementFromPoint(5, 5);
+            assert.equal(e, host);
+            ShadyDOM.wrapIfNeeded(host).remove();
+          });
+
           test('elementsFromPoint', function () {
             // elements:
             // 1. with .shadowRoot with 2 elements each with shadowRoot + 1 el
@@ -1598,6 +1613,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.deepEqual(els, [el1.el1.el, ...background]);
             ShadyDOM.wrapIfNeeded(el1).remove();
             ShadyDOM.wrapIfNeeded(el2).remove();
+          });
+
+          test('elementsFromPoint (noPatch)', function () {
+            const host = createAndPosition(document.body, 0);
+            const shadowRoot = ShadyDOM.wrapIfNeeded(host).attachShadow({
+              mode: 'open',
+            });
+            const inner1 = createAndPosition(shadowRoot, 0);
+            const inner2 = createAndPosition(shadowRoot, 0);
+            const background = [document.body, document.documentElement];
+            ShadyDOM.settings.noPatchDocumentEFP = true;
+            let e = ShadyDOM.wrap(document).elementsFromPoint(5, 5);
+            assert.deepEqual(e, [inner2, inner1, host, ...background]);
+            ShadyDOM.settings.noPatchDocumentEFP = false;
+            e = ShadyDOM.wrap(document).elementsFromPoint(5, 5);
+            assert.deepEqual(e, [host, ...background]);
+            ShadyDOM.wrapIfNeeded(host).remove();
           });
         }
       );


### PR DESCRIPTION
This can be used when test environments rely on an un-polyfilled version of these APIs.