### PR TITLE
Add type annotations for JSCompiler to `eventPhase` property descriptor.

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add type annotations for JSCompiler to `eventPhase` property descriptor.
+  ([#473](https://github.com/webcomponents/polyfills/pull/473))
 - Allow event listener options to be specified using a function in addition to
   an object. ([#469](https://github.com/webcomponents/polyfills/pull/469))
 - The `eventPhase` property of events is now properly set to `Event.AT_TARGET`

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -280,15 +280,22 @@ const eventPhaseDescriptor =
   utils.settings.hasDescriptors &&
   Object.getOwnPropertyDescriptor(Event.prototype, 'eventPhase');
 if (eventPhaseDescriptor) {
-  Object.defineProperty(EventPatches, 'eventPhase', {
-    get() {
-      return this.currentTarget === this.target
-        ? Event.AT_TARGET
-        : this[utils.NATIVE_PREFIX + 'eventPhase'];
-    },
-    enumerable: true,
-    configurable: true,
-  });
+  Object.defineProperty(
+    EventPatches,
+    'eventPhase',
+    /** @type {!ObjectPropertyDescriptor<!Event>} */ ({
+      /**
+       * @this {Event}
+       */
+      get() {
+        return this.currentTarget === this.target
+          ? Event.AT_TARGET
+          : this[utils.NATIVE_PREFIX + 'eventPhase'];
+      },
+      enumerable: true,
+      configurable: true,
+    })
+  );
 
   Object.defineProperty(
     EventPatches,


### PR DESCRIPTION
These two new annotations are needed to compile with internal conformance checks.