### PR TITLE
Revert "Update packages/template/template.js"

### DIFF
--- a/packages/template/template.js
+++ b/packages/template/template.js
@@ -323,7 +323,15 @@
     var defineOuterHTML = function defineOuterHTML(obj) {
       Object.defineProperty(obj, 'outerHTML', {
         get: function () {
-          return `<${TEMPLATE_TAG}>${this.innerHTML}</${TEMPLATE_TAG}>`;
+          return (
+            '<' +
+            TEMPLATE_TAG +
+            '>' +
+            this.innerHTML +
+            '</' +
+            TEMPLATE_TAG +
+            '>'
+          );
         },
         set: function (innerHTML) {
           if (this.parentNode) {


### PR DESCRIPTION
This reverts commit 041c940a9333f00a2386f8a2951d918dd5e89c28.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals

Template literals are not supported in older browsers.
This reverts a commit where template literals were added.