### PR TITLE
Shady ondemand fixes

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Adds improvements to `noPatch: 'on-demand'` mode, including:
+  `ShadyDOM.validateNodePatch` which can reset a patch on a node if needed,
+  `ShadyDOM.onDemandPatches` which is a list of properties to always patch,
+  always patches styling related properties, and allows a limited form of
+  overriding native methods.
+  ([#484](https://github.com/webcomponents/polyfills/pull/484))
 - Add type annotations for JSCompiler to `eventPhase` property descriptor.
   ([#473](https://github.com/webcomponents/polyfills/pull/473))
 - Allow event listener options to be specified using a function in addition to

--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adds improvements to `noPatch: 'on-demand'` mode, including:
   `ShadyDOM.validateNodePatch` which can reset a patch on a node if needed,
-  `ShadyDOM.onDemandPatches` which is a list of properties to always patch,
+  `ShadyDOM.onDemandGlobalPatches` which is a list of properties to always patch,
   always patches styling related properties, and allows a limited form of
   overriding native methods.
   ([#484](https://github.com/webcomponents/polyfills/pull/484))

--- a/packages/shadydom/LICENSE.md
+++ b/packages/shadydom/LICENSE.md
@@ -2,7 +2,7 @@
 
 Everything in this repo is BSD style license unless otherwise specified.
 
-Copyright (c) 2015 The Polymer Authors. All rights reserved.
+Copyright (c) 2022 The Polymer Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/packages/shadydom/externs/shadydom.d.ts
+++ b/packages/shadydom/externs/shadydom.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2021 The Polymer Project Authors. All rights reserved. This
+ * Copyright (c) 2022 The Polymer Project Authors. All rights reserved. This
  * code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
  * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
@@ -21,7 +21,8 @@ declare global {
       querySelectorAll: typeof document.querySelectorAll;
     };
     noPatch: boolean | string;
-    patchElementProto: (node: Object) => void;
+    patchElementProto: (node: object) => void;
+    validateNodePatch: (node: object) => void;
     wrap: (node: Node) => Node;
   }
 

--- a/packages/shadydom/externs/shadydom.d.ts
+++ b/packages/shadydom/externs/shadydom.d.ts
@@ -24,6 +24,7 @@ declare global {
     patchElementProto: (node: object) => void;
     validateNodePatch: (node: object) => void;
     wrap: (node: Node) => Node;
+    onDemandPatches: {[index: string]: boolean};
   }
 
   // This type alias exists because Tsickle will replace any type name used in the

--- a/packages/shadydom/gulpfile.js
+++ b/packages/shadydom/gulpfile.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
  * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt

--- a/packages/shadydom/src/array-splice.js
+++ b/packages/shadydom/src/array-splice.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 function newSplice(index, removed, addedCount) {

--- a/packages/shadydom/src/attach-shadow.js
+++ b/packages/shadydom/src/attach-shadow.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import {calculateSplices} from './array-splice.js';

--- a/packages/shadydom/src/env.d.ts
+++ b/packages/shadydom/src/env.d.ts
@@ -1,13 +1,13 @@
 /**
- * @license
- * Copyright (c) 2021 The Polymer Project Authors. All rights reserved. This
- * code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
- * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
- * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
- * Google as part of the polymer project is also subject to an additional IP
- * rights grant found at http://polymer.github.io/PATENTS.txt
- */
+@license
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
+*/
 
 // When building externally, this file is always assumed to be a module, but by
 // default it isn't when building internally, so we need this export statement.

--- a/packages/shadydom/src/flush.js
+++ b/packages/shadydom/src/flush.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from './utils.js';

--- a/packages/shadydom/src/innerHTML.js
+++ b/packages/shadydom/src/innerHTML.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 // Cribbed from ShadowDOM polyfill

--- a/packages/shadydom/src/link-nodes.js
+++ b/packages/shadydom/src/link-nodes.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from './utils.js';

--- a/packages/shadydom/src/observe-changes.js
+++ b/packages/shadydom/src/observe-changes.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from './utils.js';

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from './utils.js';

--- a/packages/shadydom/src/patch-instances.js
+++ b/packages/shadydom/src/patch-instances.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from './utils.js';

--- a/packages/shadydom/src/patch-native.js
+++ b/packages/shadydom/src/patch-native.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 import * as utils from './utils.js';
 import {patchProperties} from './utils.js';

--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -108,19 +108,22 @@ const getPatchPrototype = (name) => window[name] && window[name].prototype;
 // accessors.
 const disallowedNativePatches = utils.settings.hasDescriptors
   ? null
-  : ['innerHTML', 'textContent'];
+  : {innerHTML: true, textContent: true};
 
 /**
  * Patch a group of accessors on an object.
  * @param {!Object} proto
  * @param {!Array<Object>} list
  * @param {string=} prefix
- * @param {Array=} disallowed
+ * @param {Object=} disallowed
+ * @param {Object=} allowed
  */
-function applyPatchList(proto, list, prefix, disallowed) {
+function applyPatchList(proto, list, prefix, disallowed, allowed) {
   list.forEach(
     (patch) =>
-      proto && patch && utils.patchProperties(proto, patch, prefix, disallowed)
+      proto &&
+      patch &&
+      utils.patchProperties(proto, patch, prefix, disallowed, allowed)
   );
 }
 
@@ -130,6 +133,16 @@ export const applyPatches = (prefix) => {
   for (let p in patchMap) {
     const proto = getPatchPrototype(p);
     applyPatchList(proto, patchMap[p], prefix, disallowed);
+  }
+};
+
+export const applySelectedPatches = (allowedPatches) => {
+  if (!allowedPatches) {
+    return;
+  }
+  for (let p in patchMap) {
+    const proto = getPatchPrototype(p);
+    applyPatchList(proto, patchMap[p], '', undefined, allowedPatches);
   }
 };
 

--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -1,28 +1,33 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
-import * as utils from './utils.js';
-import {EventTargetPatches} from './patches/EventTarget.js';
-import {NodePatches} from './patches/Node.js';
-import {SlotablePatches} from './patches/Slotable.js';
-// prettier-ignore
-import {ParentNodePatches, ParentNodeDocumentOrFragmentPatches} from './patches/ParentNode.js';
 import {ChildNodePatches} from './patches/ChildNode.js';
-import {ElementPatches, ElementShadowPatches} from './patches/Element.js';
-import {ElementOrShadowRootPatches} from './patches/ElementOrShadowRoot.js';
-import {HTMLElementPatches} from './patches/HTMLElement.js';
-import {SlotPatches} from './patches/Slot.js';
+import {DocumentPatches} from './patches/Document.js';
 import {DocumentOrFragmentPatches} from './patches/DocumentOrFragment.js';
 import {DocumentOrShadowRootPatches} from './patches/DocumentOrShadowRoot.js';
-import {DocumentPatches} from './patches/Document.js';
+import {
+  ElementPatches,
+  ElementShadowPatches,
+  ElementStylePatches,
+} from './patches/Element.js';
+import {ElementOrShadowRootPatches} from './patches/ElementOrShadowRoot.js';
+import {EventTargetPatches} from './patches/EventTarget.js';
+import {HTMLElementPatches} from './patches/HTMLElement.js';
+import {NodePatches} from './patches/Node.js';
+// prettier-ignore
+import {ParentNodeDocumentOrFragmentPatches, ParentNodePatches} from './patches/ParentNode.js';
+import {SlotPatches} from './patches/Slot.js';
+import {SlotablePatches} from './patches/Slotable.js';
 import {WindowPatches} from './patches/Window.js';
+import * as utils from './utils.js';
 
 // Some browsers (IE/Edge) have non-standard HTMLElement accessors.
 const NonStandardHTMLElement = {};
@@ -52,6 +57,16 @@ if (Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'className')) {
 const ElementShouldHaveInnerHTML =
   !utils.settings.hasDescriptors || 'innerHTML' in Element.prototype;
 
+const ElementOnDemandPatchList = [
+  ElementPatches,
+  ParentNodePatches,
+  ChildNodePatches,
+  SlotablePatches,
+  ElementShouldHaveInnerHTML ? ElementOrShadowRootPatches : null,
+  !window.HTMLSlotElement ? SlotPatches : null,
+];
+const ElementGlobalPatchList = [ElementStylePatches, ElementShadowPatches];
+
 // setup patching
 const patchMap = {
   EventTarget: [EventTargetPatches],
@@ -60,14 +75,7 @@ const patchMap = {
   Comment: [SlotablePatches],
   CDATASection: [SlotablePatches],
   ProcessingInstruction: [SlotablePatches],
-  Element: [
-    ElementPatches,
-    ParentNodePatches,
-    ChildNodePatches,
-    SlotablePatches,
-    ElementShouldHaveInnerHTML ? ElementOrShadowRootPatches : null,
-    !window.HTMLSlotElement ? SlotPatches : null,
-  ],
+  Element: [...ElementOnDemandPatchList, ...ElementGlobalPatchList],
   HTMLElement: [HTMLElementPatches, NonStandardHTMLElement],
   HTMLSlotElement: [SlotPatches],
   DocumentFragment: [
@@ -84,11 +92,20 @@ const patchMap = {
   CharacterData: [ChildNodePatches],
 };
 
+const allHTMLElementPatches = [
+  patchMap.EventTarget,
+  patchMap.Node,
+  ElementOnDemandPatchList,
+  patchMap.HTMLElement,
+  patchMap.HTMLSlotElement,
+];
+
 const getPatchPrototype = (name) => window[name] && window[name].prototype;
 
-// Note, must avoid patching accessors on prototypes when descriptors are not correct
-// because the CustomElements polyfill checks if these exist before patching instances.
-// CustomElements polyfill *only* cares about these accessors.
+// Note, must avoid patching accessors on prototypes when descriptors are not
+// correct because the CustomElements polyfill checks if these exist before
+// patching instances. CustomElements polyfill *only* cares about these
+// accessors.
 const disallowedNativePatches = utils.settings.hasDescriptors
   ? null
   : ['innerHTML', 'textContent'];
@@ -128,7 +145,8 @@ const PROTO_IS_PATCHED = utils.SHADY_PREFIX + 'protoIsPatched';
 const PATCHED_PROTO = utils.SHADY_PREFIX + 'patchedProto';
 
 // Patch non-element prototypes up front so that we don't have to check
-// the type of Node when patching an can always assume we're patching an element.
+// the type of Node when patching an can always assume we're patching an
+// element.
 ['Text', 'Comment', 'CDATASection', 'ProcessingInstruction'].forEach((name) => {
   const ctor = window[name];
   const patchedProto = Object.create(ctor.prototype);
@@ -141,21 +159,39 @@ const PATCHED_PROTO = utils.SHADY_PREFIX + 'patchedProto';
   ctor.prototype[PATCHED_PROTO] = patchedProto;
 });
 
+const applyAllHTMLElementProtoPatches = (proto) => {
+  allHTMLElementPatches.forEach((patches) => {
+    applyPatchList(proto, patches);
+  });
+};
+
+/**
+ * Patch class prototype in "on demand" patching mode.
+ *
+ */
 export const patchElementProto = (proto) => {
   proto[PROTO_IS_PATCHED] = true;
-  applyPatchList(proto, patchMap.EventTarget);
-  applyPatchList(proto, patchMap.Node);
-  applyPatchList(proto, patchMap.Element);
-  applyPatchList(proto, patchMap.HTMLElement);
-  applyPatchList(proto, patchMap.HTMLSlotElement);
+  applyAllHTMLElementProtoPatches(proto);
   return proto;
 };
 
-export const patchNodeProto = (node) => {
-  if (node[PROTO_IS_PATCHED] || utils.isShadyRoot(node)) {
-    return;
-  }
-  const nativeProto = Object.getPrototypeOf(node);
+/**
+ * If a custom element proto implements a method which will be patched (it is
+ * different from the cached shady or native version), copy the implementation
+ * to the native prefixed version of the property. This allows the installed
+ * shady patch to call the implemented version, and it assumes the user's
+ * implementation will call the native version if necessary.
+ */
+const copyAllImplementedNativeProperties = (proto) => {
+  allHTMLElementPatches.forEach((patches) => {
+    patches.forEach((patch) => {
+      utils.copyImplementedNativeProperties(proto, patch);
+    });
+  });
+};
+
+const getPatchedProto = (obj) => {
+  const nativeProto = Object.getPrototypeOf(obj);
   // Note, this hasOwnProperty check is critical to avoid seeing a patched
   // prototype lower in the prototype chain, e.g. if an <s> element has been
   // patched, without this check, an <input> element would get the wrong patch.
@@ -163,22 +199,64 @@ export const patchNodeProto = (node) => {
     nativeProto.hasOwnProperty(PATCHED_PROTO) && nativeProto[PATCHED_PROTO];
   if (!proto) {
     proto = Object.create(nativeProto);
+    // Note, patches are installed at the top of the prototype chain, shadowing
+    // any custom implementations. This is for simplicity and not a problem
+    // since `super` calls cannot be patched properly anyway due to being
+    // statically bound. Instead, implemented methods are copied to their native
+    // locations to preserve custom implementations.
+    const isCustomElement = !!customElements?.get(obj?.localName);
+    if (isCustomElement) {
+      copyAllImplementedNativeProperties(proto);
+    }
     patchElementProto(proto);
     nativeProto[PATCHED_PROTO] = proto;
   }
+  return proto;
+};
+
+const applyNodeProtoPatch = (node) => {
+  // Note, it's important to set this on the instance so that
+  // `validateNodePatch` can function.
+  node[PROTO_IS_PATCHED] = true;
+  const proto = getPatchedProto(node);
   Object.setPrototypeOf(node, proto);
 };
 
+/**
+ * Patch node in "on demand" patching mode.
+ */
+export const patchNodeProto = (node) => {
+  if (node[PROTO_IS_PATCHED] || utils.isShadyRoot(node)) {
+    return;
+  }
+  applyNodeProtoPatch(node);
+};
+
+/**
+ * Validates the patching state for the node. If the prototype is swizzled
+ * after patching, the node can report that it is patched without having a
+ * patched prototype. This method "fixes" this case by ensuring the prototype
+ * is patched if the instance says it's patched.
+ */
+export const validateNodePatch = (node) => {
+  if (node[PROTO_IS_PATCHED]) {
+    const proto = Object.getPrototypeOf(node);
+    if (!proto[PROTO_IS_PATCHED]) {
+      applyNodeProtoPatch(node);
+    }
+  }
+};
+
 export const patchShadowOnElement = () => {
-  utils.patchProperties(Element.prototype, ElementShadowPatches);
+  applyPatchList(Element.prototype, ElementGlobalPatchList);
 };
 
 export const addShadyPrefixedProperties = () => {
   // perform shady patches
   applyPatches(utils.SHADY_PREFIX);
 
-  // install `_activeElement` because some browsers (older Chrome/Safari) do not have
-  // a 'configurable' `activeElement` accesssor.
+  // install `_activeElement` because some browsers (older Chrome/Safari) do not
+  // have a 'configurable' `activeElement` accesssor.
   const descriptor = DocumentOrShadowRootPatches.activeElement;
   Object.defineProperty(document, '_activeElement', descriptor);
 

--- a/packages/shadydom/src/patch-shadyRoot.js
+++ b/packages/shadydom/src/patch-shadyRoot.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from './utils.js';

--- a/packages/shadydom/src/patches/ChildNode.js
+++ b/packages/shadydom/src/patches/ChildNode.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/Document.js
+++ b/packages/shadydom/src/patches/Document.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/DocumentOrFragment.js
+++ b/packages/shadydom/src/patches/DocumentOrFragment.js
@@ -1,12 +1,14 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
+
 import * as utils from '../utils.js';
 import {query} from './ParentNode.js';
 

--- a/packages/shadydom/src/patches/DocumentOrShadowRoot.js
+++ b/packages/shadydom/src/patches/DocumentOrShadowRoot.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/Element.js
+++ b/packages/shadydom/src/patches/Element.js
@@ -1,19 +1,20 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
-import * as utils from '../utils.js';
-import {scopeClassAttribute} from '../style-scoping.js';
-import {shadyDataForNode} from '../shady-data.js';
 import {attachShadow, ownerShadyRootForNode} from '../attach-shadow.js';
 // prettier-ignore
 import {eventPropertyNamesForElement, wrappedDescriptorForEventProperty} from '../patch-events.js';
+import {shadyDataForNode} from '../shady-data.js';
+import {scopeClassAttribute} from '../style-scoping.js';
+import * as utils from '../utils.js';
 
 const doc = window.document;
 
@@ -77,7 +78,9 @@ export const ElementPatches = utils.getOwnPropertyDescriptors({
   set slot(value) {
     this[utils.SHADY_PREFIX + 'setAttribute']('slot', value);
   },
+});
 
+export const ElementStylePatches = utils.getOwnPropertyDescriptors({
   /** @this {Element} */
   get className() {
     return this.getAttribute('class') || '';
@@ -116,7 +119,8 @@ export const ElementPatches = utils.getOwnPropertyDescriptors({
       this[utils.NATIVE_PREFIX + 'removeAttribute'](attr);
       distributeAttributeChange(this, attr);
     } else if (this.getAttribute(attr) === '') {
-      // ensure that "class" attribute is fully removed if ShadyCSS does not keep scoping
+      // ensure that "class" attribute is fully removed if ShadyCSS does not
+      // keep scoping
       this[utils.NATIVE_PREFIX + 'removeAttribute'](attr);
     }
   },
@@ -140,7 +144,8 @@ export const ElementShadowPatches = utils.getOwnPropertyDescriptors({
     // and cannot set its own special tracking for shadowRoot. It does this
     // to be able to see closed shadowRoots.
     // This is necessary so that the CE polyfill can traverse into nodes
-    // with shadowRoot that will under `on-demand` have their childNodes patched.
+    // with shadowRoot that will under `on-demand` have their childNodes
+    // patched.
     this['__CE_shadowRoot'] = root;
     return root;
   },
@@ -154,5 +159,3 @@ export const ElementShadowPatches = utils.getOwnPropertyDescriptors({
     return (nodeData && nodeData.publicRoot) || null;
   },
 });
-
-utils.assign(ElementPatches, ElementShadowPatches);

--- a/packages/shadydom/src/patches/ElementOrShadowRoot.js
+++ b/packages/shadydom/src/patches/ElementOrShadowRoot.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/EventTarget.js
+++ b/packages/shadydom/src/patches/EventTarget.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/HTMLElement.js
+++ b/packages/shadydom/src/patches/HTMLElement.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/Node.js
+++ b/packages/shadydom/src/patches/Node.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/ParentNode.js
+++ b/packages/shadydom/src/patches/ParentNode.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/ShadowRoot.js
+++ b/packages/shadydom/src/patches/ShadowRoot.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/Slot.js
+++ b/packages/shadydom/src/patches/Slot.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/Slotable.js
+++ b/packages/shadydom/src/patches/Slotable.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from '../utils.js';

--- a/packages/shadydom/src/patches/Window.js
+++ b/packages/shadydom/src/patches/Window.js
@@ -1,12 +1,14 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
+
 import * as utils from '../utils.js';
 // prettier-ignore
 import {addEventListener, removeEventListener, dispatchEvent} from '../patch-events.js';

--- a/packages/shadydom/src/shady-data.js
+++ b/packages/shadydom/src/shady-data.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 export class ShadyData {

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -14,7 +14,7 @@ found at http://polymer.github.io/PATENTS.txt
  * such that tree traversal and mutation apis act like they would under
  * ShadowDOM.
  *
- * This import enables seemless interaction with ShadyDOM powered
+ * This import enables seamless interaction with ShadyDOM powered
  * custom elements, enabling better interoperation with 3rd party code,
  * libraries, and frameworks that use DOM tree manipulation apis.
  */

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 /**
@@ -18,19 +19,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
  * libraries, and frameworks that use DOM tree manipulation apis.
  */
 
-import * as utils from './utils.js';
-import {flush, enqueue} from './flush.js';
+import {ShadyRoot} from './attach-shadow.js';
+import {enqueue, flush} from './flush.js';
 // prettier-ignore
-import {observeChildren, unobserveChildren, filterMutations} from './observe-changes.js';
+import {filterMutations, observeChildren, unobserveChildren} from './observe-changes.js';
+import {composedPath, patchClick, patchEvents} from './patch-events.js';
+// prettier-ignore
+import {patchInsideElementAccessors, patchOutsideElementAccessors} from './patch-instances.js';
 // prettier-ignore
 import {addNativePrefixedProperties, nativeMethods, nativeTree} from './patch-native.js';
 // prettier-ignore
-import {patchInsideElementAccessors, patchOutsideElementAccessors} from './patch-instances.js';
-import {patchEvents, patchClick, composedPath} from './patch-events.js';
-import {ShadyRoot} from './attach-shadow.js';
+import {addShadyPrefixedProperties, applyPatches, patchElementProto, patchShadowOnElement, validateNodePatch} from './patch-prototypes.js';
+import * as utils from './utils.js';
 import {wrap, Wrapper} from './wrapper.js';
-// prettier-ignore
-import {addShadyPrefixedProperties, applyPatches, patchShadowOnElement, patchElementProto} from './patch-prototypes.js';
 
 if (utils.settings.inUse) {
   const patch = utils.settings.hasDescriptors
@@ -102,7 +103,8 @@ if (utils.settings.inUse) {
     // Shadow DOM compatible behavior is only available when accessing DOM
     // API using `ShadyDOM.wrap`, e.g. `ShadyDOM.wrap(element).shadowRoot`.
     // This setting provides a small performance boost, but requires all DOM API
-    // access that requires Shadow DOM behavior to be proxied via `ShadyDOM.wrap`.
+    // access that requires Shadow DOM behavior to be proxied via
+    // `ShadyDOM.wrap`.
     //
     // WARNING: When `noPatch` is set and the Custom Elements polyfill is
     // needed, the Custom Elements polyfill must be loaded before this
@@ -118,6 +120,7 @@ if (utils.settings.inUse) {
     'nativeMethods': nativeMethods,
     'nativeTree': nativeTree,
     'patchElementProto': patchElementProto,
+    'validateNodePatch': validateNodePatch,
   };
 
   window['ShadyDOM'] = ShadyDOM;
@@ -155,7 +158,8 @@ if (utils.settings.inUse) {
     // Patch click event behavior only if we're patching
     patchClick();
   } else if (utils.settings.patchOnDemand) {
-    // In `on-demand` patching, do patch `attachShadow` and `shadowRoot`.
+    // In `on-demand` patching, do patch `attachShadow` and `shadowRoot` and
+    // styling (e.g. `set/getAttribute` and `className`).
     // These are the only patched properties in `on-demand` mode and these
     // patches kick off patching "on-demand" for other nodes.
     patchShadowOnElement();

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -29,7 +29,7 @@ import {patchInsideElementAccessors, patchOutsideElementAccessors} from './patch
 // prettier-ignore
 import {addNativePrefixedProperties, nativeMethods, nativeTree} from './patch-native.js';
 // prettier-ignore
-import {addShadyPrefixedProperties, applyPatches, patchElementProto, patchShadowOnElement, validateNodePatch, applySelectedPatches} from './patch-prototypes.js';
+import {addShadyPrefixedProperties, applyPatches, patchElementProto, patchShadowOnElement, validateNodePatch, applyOnDemandGlobalPatches} from './patch-prototypes.js';
 import * as utils from './utils.js';
 import {wrap, Wrapper} from './wrapper.js';
 
@@ -163,7 +163,7 @@ if (utils.settings.inUse) {
     // These are the only patched properties in `on-demand` mode and these
     // patches kick off patching "on-demand" for other nodes.
     patchShadowOnElement();
-    applySelectedPatches(utils.settings.onDemandPatches);
+    applyOnDemandGlobalPatches();
   }
 
   // For simplicity, patch events unconditionally.

--- a/packages/shadydom/src/shadydom.js
+++ b/packages/shadydom/src/shadydom.js
@@ -29,7 +29,7 @@ import {patchInsideElementAccessors, patchOutsideElementAccessors} from './patch
 // prettier-ignore
 import {addNativePrefixedProperties, nativeMethods, nativeTree} from './patch-native.js';
 // prettier-ignore
-import {addShadyPrefixedProperties, applyPatches, patchElementProto, patchShadowOnElement, validateNodePatch} from './patch-prototypes.js';
+import {addShadyPrefixedProperties, applyPatches, patchElementProto, patchShadowOnElement, validateNodePatch, applySelectedPatches} from './patch-prototypes.js';
 import * as utils from './utils.js';
 import {wrap, Wrapper} from './wrapper.js';
 
@@ -163,6 +163,7 @@ if (utils.settings.inUse) {
     // These are the only patched properties in `on-demand` mode and these
     // patches kick off patching "on-demand" for other nodes.
     patchShadowOnElement();
+    applySelectedPatches(utils.settings.onDemandPatches);
   }
 
   // For simplicity, patch events unconditionally.

--- a/packages/shadydom/src/style-scoping.js
+++ b/packages/shadydom/src/style-scoping.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from './utils.js';

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -37,6 +37,8 @@ settings.noPatch = /** @type {string|boolean} */ (settings['noPatch'] || false);
 // eslint-disable-next-line no-self-assign
 settings.preferPerformance = settings['preferPerformance'];
 settings.patchOnDemand = settings.noPatch === 'on-demand';
+// eslint-disable-next-line no-self-assign
+settings.onDemandPatches = settings['onDemandPatches'];
 
 const IS_IE = navigator.userAgent.match('Trident');
 settings.IS_IE = IS_IE;
@@ -213,16 +215,23 @@ const patchProperty = (proto, name, descriptor) => {
  * @param {!Object} proto
  * @param {!Object} descriptors
  * @param {string=} prefix
- * @param {Array=} disallowedPatches
+ * @param {Object=} disallowedPatches
+ * @param {Object=} allowedPatches
  */
 export const patchProperties = (
   proto,
   descriptors,
   prefix = '',
-  disallowedPatches
+  disallowedPatches,
+  allowedPatches
 ) => {
   for (let name in descriptors) {
-    if (disallowedPatches && disallowedPatches.indexOf(name) >= 0) {
+    // optionally do *not* apply disallowed patches
+    if (disallowedPatches && disallowedPatches[name]) {
+      continue;
+    }
+    // optionally *only* apply allowed patches
+    if (allowedPatches && !allowedPatches[name]) {
       continue;
     }
     patchProperty(proto, prefix + name, descriptors[name]);

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -38,7 +38,7 @@ settings.noPatch = /** @type {string|boolean} */ (settings['noPatch'] || false);
 settings.preferPerformance = settings['preferPerformance'];
 settings.patchOnDemand = settings.noPatch === 'on-demand';
 // eslint-disable-next-line no-self-assign
-settings.onDemandPatches = settings['onDemandPatches'];
+settings.onDemandGlobalPatches = settings['onDemandGlobalPatches'];
 
 const IS_IE = navigator.userAgent.match('Trident');
 settings.IS_IE = IS_IE;
@@ -252,11 +252,19 @@ export const patchExistingProperties = (proto, descriptors) => {
  * and the property will be patched with a valued function (not accessor), then
  * copy the existing property value to the native location for the value.
  */
-export const copyImplementedNativeProperties = (proto, descriptors) => {
+export const copyImplementedNativeProperties = (
+  proto,
+  descriptors,
+  disallowed
+) => {
   for (let name in descriptors) {
     const d = descriptors[name];
     // Only check methods.
     if (!d.value && typeof d.value !== 'function') {
+      continue;
+    }
+    // skip if this property has been disallowed.
+    if (disallowed && disallowed[name]) {
       continue;
     }
     const nativeName = NATIVE_PREFIX + name;

--- a/packages/shadydom/src/utils.js
+++ b/packages/shadydom/src/utils.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 import {shadyDataForNode} from './shady-data.js';
 
@@ -133,7 +134,8 @@ const getNodeHTMLCollectionName = (node) =>
 const isValidHTMLCollectionName = (name) => name !== 'length' && isNaN(name);
 
 export const createPolyfilledHTMLCollection = (nodes) => {
-  // Note: loop in reverse so that the first named item matches the named property
+  // Note: loop in reverse so that the first named item matches the named
+  // property
   for (let l = nodes.length - 1; l >= 0; l--) {
     const node = nodes[l];
     const name = getNodeHTMLCollectionName(node);
@@ -231,6 +233,39 @@ export const patchExistingProperties = (proto, descriptors) => {
   for (let name in descriptors) {
     if (name in proto) {
       patchProperty(proto, name, descriptors[name]);
+    }
+  }
+};
+
+/**
+ * If a prototype will receive a patch for an existing property
+ * that is valued differently from the native or shady value for that property
+ * and the property will be patched with a valued function (not accessor), then
+ * copy the existing property value to the native location for the value.
+ */
+export const copyImplementedNativeProperties = (proto, descriptors) => {
+  for (let name in descriptors) {
+    const d = descriptors[name];
+    // Only check methods.
+    if (!d.value && typeof d.value !== 'function') {
+      continue;
+    }
+    const nativeName = NATIVE_PREFIX + name;
+    const shadyName = SHADY_PREFIX + name;
+    const existingValue = proto[name];
+    const nativeValue = proto[nativeName];
+    const shadyValue = proto[shadyName];
+    if (
+      nativeValue &&
+      existingValue !== nativeValue &&
+      existingValue !== shadyValue
+    ) {
+      patchProperty(proto, nativeName, {
+        value: existingValue,
+        configurable: true,
+        writable: true,
+        enumerable: true,
+      });
     }
   }
 };

--- a/packages/shadydom/src/wrapper.js
+++ b/packages/shadydom/src/wrapper.js
@@ -1,11 +1,12 @@
 /**
 @license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+Copyright (c) 2022 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt The complete set of contributors may be
+found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by Google as
+part of the polymer project is also subject to an additional IP rights grant
+found at http://polymer.github.io/PATENTS.txt
 */
 
 import * as utils from './utils.js';

--- a/packages/tests/shadydom/loader.js
+++ b/packages/tests/shadydom/loader.js
@@ -1,4 +1,5 @@
 ShadyDOM = {
+  ...(window.ShadyDOM || {}),
   force: true,
   noPatch: window.location.search.match('noPatch=on-demand')
     ? 'on-demand'

--- a/packages/tests/shadydom/shady-dynamic.html
+++ b/packages/tests/shadydom/shady-dynamic.html
@@ -27,7 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
 
       ShadyDOM = {
-        onDemandPatches: {
+        onDemandGlobalPatches: {
           // typically this is just set to true but using the pre-patched
           // implementation for testing
           blur: document.head.blur,

--- a/packages/tests/shadydom/shady-dynamic.html
+++ b/packages/tests/shadydom/shady-dynamic.html
@@ -25,6 +25,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           'firstElementChild'
         ),
       };
+
+      ShadyDOM = {
+        onDemandPatches: {
+          // typically this is just set to true but using the pre-patched
+          // implementation for testing
+          blur: document.head.blur,
+        },
+      };
     </script>
     <script src="loader.js"></script>
     <script>
@@ -1506,6 +1514,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           el.appendChild(child);
           assert.sameMembers(el.appended, [child]);
           ShadyDOM.wrapIfNeeded(document.body).removeChild(host);
+        });
+
+        (ShadyDOM.patchOnDemand
+          ? test
+          : test.skip)('can select global patches in on demand mode', function () {
+          const alwaysPatch = ShadyDOM.settings.onDemandPatches;
+          for (const p in alwaysPatch) {
+            assert.ok(document.head[p]);
+            assert.notEqual(alwaysPatch[p], document.head[p]);
+          }
         });
       });
 

--- a/packages/tests/shadydom/shady-dynamic.html
+++ b/packages/tests/shadydom/shady-dynamic.html
@@ -296,7 +296,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </script>
 
     <template id="x-has-input">
-      <s>element with HTMLElement protoype</s>
+      <s>element with HTMLElement prototype</s>
       <input value="hi" />
     </template>
 
@@ -979,13 +979,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(ShadyDOM.wrapIfNeeded(echo).nextElementSibling, s2);
           ShadyDOM.wrapIfNeeded(echo).appendChild(s2);
           ShadyDOM.flush();
+
           assert.equal(ShadyDOM.wrapIfNeeded(container).children.length, 1);
           assert.equal(ShadyDOM.wrapIfNeeded(echo).nextElementSibling, null);
-          ShadyDOM.wrapIfNeeded(container).appendChild(s1);
+          ShadyDOM.wrap(container).appendChild(s1);
           ShadyDOM.flush();
+
           assert.equal(ShadyDOM.wrapIfNeeded(container).children.length, 2);
           assert.equal(ShadyDOM.wrapIfNeeded(echo).nextElementSibling, s1);
-          ShadyDOM.wrapIfNeeded(container).appendChild(s2);
+          ShadyDOM.wrap(container).appendChild(s2);
           ShadyDOM.flush();
           assert.equal(ShadyDOM.wrapIfNeeded(container).children.length, 3);
           assert.equal(ShadyDOM.wrapIfNeeded(echo).nextElementSibling, s1);
@@ -1467,6 +1469,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           );
           assert.equal(input.value, 'hi');
           ShadyDOM.wrapIfNeeded(document.body).removeChild(e);
+        });
+
+        test('custom elements can implement DOM methods when patched', function () {
+          class XOverride extends HTMLElement {
+            events = [];
+            appended = [];
+            dispatchEvent(e) {
+              this.events.push(e);
+              return super.dispatchEvent(e);
+            }
+            appendChild(node) {
+              this.appended.push(node);
+              return super.appendChild(node);
+            }
+          }
+          ShadyDOM.patchElementProto(XOverride.prototype);
+          customElements.define('x-override', XOverride);
+          const host = document.createElement('div');
+          ShadyDOM.wrapIfNeeded(document.body).appendChild(host);
+          ShadyDOM.wrapIfNeeded(host).attachShadow({mode: 'open'});
+          const el = new XOverride();
+          ShadyDOM.wrapIfNeeded(host).shadowRoot.appendChild(el);
+          const name = 'test';
+          const event = new Event(name);
+          let eventHeard = false;
+          ShadyDOM.wrapIfNeeded(el).addEventListener(
+            name,
+            () => (eventHeard = true)
+          );
+          el.dispatchEvent(event);
+          assert.isTrue(eventHeard);
+          assert.sameMembers(el.events, [event]);
+          //
+          const child = document.createElement('span');
+          el.appendChild(child);
+          assert.sameMembers(el.appended, [child]);
+          ShadyDOM.wrapIfNeeded(document.body).removeChild(host);
         });
       });
 
@@ -2890,8 +2929,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           const d = document.createElement('div');
           document.body.appendChild(d);
           d.innerHTML = `
-      <x-echo> <!-- comment --><![CDATA[ data ]]><? processing ?></x-echo>
-    `;
+        <x-echo> <!-- comment --><![CDATA[ data ]]><? processing ?></x-echo>
+      `;
           ShadyDOM.flush();
           const el = d.firstElementChild;
           assert.equal(el.childNodes.length, 4);

--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- ShadyDOM improvements to `noPatch: 'on-demand'` mode.
+  ([#484](https://github.com/webcomponents/polyfills/pull/484))
 - Polyfill `addEventListener/removeEventListener` event listener options,
   including `{capture: boolean, once: boolean}`.
   ([#469](https://github.com/webcomponents/polyfills/pull/469))


### PR DESCRIPTION
* adds `ShadyDOM.validateNodePatch` which can reset a patch on a node if needed.
* can specify `ShadyDOM.onDemandPatches`, a list of properties to always patch when in on-demand mode.
* always patches styling related properties (`setAttribute`, `className`) on elements
* allows a limited form of overriding native methods in custom elements by copying implemented methods to the "native" version
