### PR TITLE
fix(scoped-custom-element-registry): remove square brackets from method names

### DIFF
--- a/packages/scoped-custom-element-registry/CHANGELOG.md
+++ b/packages/scoped-custom-element-registry/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed form-associated custom element definitions (`static formAssociated = true`) when used with the polyfill.
+- Fixed patched callback names in form-associated custom element support.
 
 ## [0.0.3] - 2021-08-02
 

--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
@@ -281,21 +281,21 @@ if (!ShadowRoot.prototype.createElement) {
         }
       }
 
-      '[formDisabledCallback]'() {
+      ['formDisabledCallback']() {
         const definition = definitionForElement.get(this);
         if (definition?.['formAssociated']) {
           definition?.['formDisabledCallback']?.apply(this, arguments);
         }
       }
 
-      '[formResetCallback]'() {
+      ['formResetCallback']() {
         const definition = definitionForElement.get(this);
         if (definition?.['formAssociated']) {
           definition?.['formResetCallback']?.apply(this, arguments);
         }
       }
 
-      '[formStateRestoreCallback]'() {
+      ['formStateRestoreCallback']() {
         const definition = definitionForElement.get(this);
         if (definition?.['formAssociated']) {
           definition?.['formStateRestoreCallback']?.apply(this, arguments);


### PR DESCRIPTION
#482 contained a couple of typos that break certain form-associated callbacks. Instead of putting these three names inside square brackets to prevent closure from mangling them, the square brackets were placed inside the method names.