### PR TITLE
[scoped-custom-element-registry] Add module flag to scoped-custom-element-registry

### DIFF
--- a/packages/scoped-custom-element-registry/package.json
+++ b/packages/scoped-custom-element-registry/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/webcomponents/polyfills/issues"
   },
   "main": "scoped-custom-element-registry.min.js",
+  "module": "scoped-custom-element-registry.min.js",
   "scripts": {
     "build": "gulp",
     "test": "cd ../.. && wtr 'packages/scoped-custom-element-registry/test/**/*.test.(js|html)'"


### PR DESCRIPTION
When trying to use `@webcomponents/scoped-custom-element-registry` [through unpkg using the `?module` flag](https://unpkg.com/@webcomponents/scoped-custom-element-registry@0.0.5?module), unpkg throws an error since the package doesn't include a module entry point

While [removing the `?module` flag in unpkg works](https://unpkg.com/@webcomponents/scoped-custom-element-registry@0.0.5) when using this package directly, this is still a problem when using packages that depend on this package such as `@open-wc/scoped-elements`

I noticed that [similar polyfills](https://github.com/PolymerLabs/blocking-elements/commit/669e20b00459167fb55999bb28301edb7b634102) have solved this issue by adding a `module` entry point to the package.json so I tried doing the same

Please let me know if you would prefer the `module` entry point to be the unminified file instead