### PR TITLE
Fix focus/blur events to be usable without wrapped addEventListener

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix focus/blur events to be usable without wrapped `addEventListener` in
+  `noPatch` mode. ([#502](https://github.com/webcomponents/polyfills/pull/502))
 - Add type annotations for JSCompiler to `eventPhase` property descriptor.
   ([#473](https://github.com/webcomponents/polyfills/pull/473))
 - Allow event listener options to be specified using a function in addition to

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -1627,6 +1627,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             ShadyDOM.wrap(document.body).removeChild(fixtureRoot);
           });
+
+          test('focus currentTarget is valid when unwrapped in noPatch', () => {
+            customElements.define(
+              'unpatched-focus',
+              class extends HTMLElement {
+                connectedCallback() {
+                  const root = ShadyDOM.wrapIfNeeded(this).attachShadow({
+                    mode: 'open',
+                  });
+                  this.input = document.createElement('input');
+                  ShadyDOM.wrapIfNeeded(root).appendChild(this.input);
+                  ShadyDOM.wrap(this.input).addEventListener(
+                    'focus',
+                    (event) => {
+                      this.focusedInputPatched = event.currentTarget;
+                    }
+                  );
+                  this.input.addEventListener('focus', (event) => {
+                    this.focusedInputUnpatched = event.currentTarget;
+                  });
+                }
+              }
+            );
+            const el = document.createElement('unpatched-focus');
+            document.body.appendChild(el);
+            el.input.dispatchEvent(new Event('focus'), {
+              bubbles: false,
+              composed: false,
+            });
+            assert.equal(el.focusedInputPatched, el.input);
+            assert.equal(el.focusedInputUnpatched, el.input);
+            document.body.removeChild(el);
+          });
         });
       });
     </script>

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -1638,14 +1638,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                   });
                   this.input = document.createElement('input');
                   ShadyDOM.wrapIfNeeded(root).appendChild(this.input);
-                  ShadyDOM.wrap(this.input).addEventListener(
-                    'focus',
-                    (event) => {
-                      this.focusedInputPatched = event.currentTarget;
-                    }
-                  );
+                  // Note this is intentionally an unpatched listener
                   this.input.addEventListener('focus', (event) => {
-                    this.focusedInputUnpatched = event.currentTarget;
+                    this.focusedInput = event.currentTarget;
                   });
                 }
               }
@@ -1656,8 +1651,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               bubbles: false,
               composed: false,
             });
-            assert.equal(el.focusedInputPatched, el.input);
-            assert.equal(el.focusedInputUnpatched, el.input);
+            assert.equal(el.focusedInput, el.input);
             document.body.removeChild(el);
           });
         });


### PR DESCRIPTION
When `focus` and `blur` are dispatched, a global capturing event listener sees the event and manually dispatches it through the tree to listeners added with wrapped `addEventListener` calls. The manual dispatching patches `currentTarget` to return retargeted values (along with `eventPhase`, since we are simulating the bubbling phase via a capturing listener).  When all `addEventListener` calls are wrapped this works fine. 

However, because the capturing listener does not stop propagation, the event will also natively fire to any native listeners added with an unwrapped `addEventListener` call (note that Polymer [does not wrap](https://github.com/Polymer/polymer/blob/master/lib/mixins/template-stamp.js#L555) `addEventListener` for listeners added via templates when in `noPatch` mode, as a performance optimization/correctness tradeoff). Because the manual dispatching code leaves the  patched `currentTarget` accessor installed, it can cause the subsequent native listeners to see the same event, but with patched accessors that return invalid values (like `null`), rather than just the unpatched values.

This change restores the original accessors for those fields when the manual dispatching is complete, so that native listeners see native fields on the event.

Fixes https://github.com/webcomponents/polyfills/issues/503.