### PR TITLE
Remove an arrow function in `webcomponents-loader.js`.

### DIFF
--- a/packages/webcomponentsjs/CHANGELOG.md
+++ b/packages/webcomponentsjs/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   ([#469](https://github.com/webcomponents/polyfills/pull/469))
 - Make `webcomponents-loader.js` compatible with the Trusted Types API
   ([#501](https://github.com/webcomponents/polyfills/pull/501))
+- Remove an arrow function in `webcomponents-loader.js`.
+  ([#507](https://github.com/webcomponents/polyfills/pull/507))
 
 ## [2.6.0] - 2021-08-02
 

--- a/packages/webcomponentsjs/webcomponents-loader.js
+++ b/packages/webcomponentsjs/webcomponents-loader.js
@@ -168,7 +168,7 @@
     // If the Trusted Types API is not available, the returned object exposes a
     // similar interface to a `TrustedTypePolicy`, but all of its functions are
     // the identity function.
-    var policy = (() => {
+    var policy = (function () {
       var identity = function (x) {
         return x;
       };


### PR DESCRIPTION
I'm not sure why this wasn't caught in the earlier internal test runs, but the pre-submit tests caught it. This is another reason I need to get the test situation in this repo back in shape.