### PR TITLE
Added `toggleAttribute` to patched methods to make sure `attributeC…

### DIFF
--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
@@ -346,6 +346,20 @@ if (!ShadowRoot.prototype.createElement) {
         }
       };
     }
+    const toggleAttribute = elementClass.prototype.toggleAttribute;
+    if (toggleAttribute) {
+      elementClass.prototype.toggleAttribute = function (n) {
+        const name = n.toLowerCase();
+        if (observedAttributes.has(name)) {
+          const old = this.hasAttribute(name);
+          toggleAttribute.call(this, name);
+          const hasAttribute = this.hasAttribute(name);
+          attributeChangedCallback.call(this, name, old, hasAttribute);
+        } else {
+          toggleAttribute.call(this, name);
+        }
+      };
+    }
   };
 
   // Helper to patch CE class hierarchy changing those CE classes created before applying the polyfill

--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
@@ -351,10 +351,10 @@ if (!ShadowRoot.prototype.createElement) {
       elementClass.prototype.toggleAttribute = function (n) {
         const name = n.toLowerCase();
         if (observedAttributes.has(name)) {
-          const old = this.hasAttribute(name);
+          const old = this.getAttribute(name);
           toggleAttribute.call(this, name);
-          const hasAttribute = this.hasAttribute(name);
-          attributeChangedCallback.call(this, name, old, hasAttribute);
+          const newValue = this.getAttribute(name);
+          attributeChangedCallback.call(this, name, old, newValue);
         } else {
           toggleAttribute.call(this, name);
         }


### PR DESCRIPTION
Added `toggleAttribute` to patched methods to make sure `attributeChangedCallback` is executed when it is called

When this polyfill is used and an attribute of a Custom Element is added or removed through `toggleAttribute`, the `attributeChangedCallback` method is not called.

This PR adds `toggleAttribute` to the patched methods so `attributeChangedCallback` is executed when `toggleAttribute` is called.
