### PR TITLE
Fix failing tests: patch `XMLHttpRequest` if no `EventTarget`; dispatch a 'proxy' if `currentTarget` is an own value property descriptor

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds an opt-out for polyfilling `element(s)FromPoint` on `document` via
   setting `ShadyDOM.useNativeDocumentEFP` to `true`.
   ([#472](https://github.com/webcomponents/polyfills/pull/472))
+- In browsers where `EventTarget` doesn't exist, `XMLHttpRequest.prototype`'s
+  `EventTarget`-like properties are now patched. In browsers where events'
+  `currentTarget` is an own value property and Shady DOM needs to manually
+  dispatch an event, Shady DOM will instead dispatch a new object having the
+  original event as its prototype so that it can update `currentTarget` without
+  modifying the built-in property descriptor.
+  ([#519](https://github.com/webcomponents/polyfills/pull/519))
 
 ## [1.9.0] - 2021-08-02
 

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -359,7 +359,10 @@ function fireHandlers(event, node, phase) {
   }
 }
 
-function shadyDispatchEvent(e) {
+function shadyDispatchEvent(originalEvent) {
+  const e = utils.settings.hasDescriptors
+    ? originalEvent
+    : Object.create(originalEvent);
   const path = e.composedPath();
   const retargetedPath = path.map((node) => retarget(node, path));
   const bubbles = e.bubbles;
@@ -414,17 +417,19 @@ function shadyDispatchEvent(e) {
       }
     }
   } finally {
-    // Restore previous currentTarget & eventPhase descriptors when
-    // dispatching is complete
-    if (prevCurrentTargetDesc) {
-      Object.defineProperty(e, 'currentTarget', prevCurrentTargetDesc);
-    } else {
-      delete e['currentTarget'];
-    }
-    if (prevEventPhaseDesc) {
-      Object.defineProperty(e, 'eventPhase', prevEventPhaseDesc);
-    } else {
-      delete e['eventPhase'];
+    if (utils.settings.hasDescriptors) {
+      // Restore previous currentTarget & eventPhase descriptors when
+      // dispatching is complete
+      if (prevCurrentTargetDesc) {
+        Object.defineProperty(e, 'currentTarget', prevCurrentTargetDesc);
+      } else {
+        delete e['currentTarget'];
+      }
+      if (prevEventPhaseDesc) {
+        Object.defineProperty(e, 'eventPhase', prevEventPhaseDesc);
+      } else {
+        delete e['eventPhase'];
+      }
     }
   }
 }

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -359,10 +359,38 @@ function fireHandlers(event, node, phase) {
   }
 }
 
+// In Chrome 41, `currentTarget` is an own property of every `Event` and its
+// descriptor is a _data_ descriptor and not an accessor descriptor (so there is
+// no getter that could be saved and wrapped) but the browser effectively treats
+// this property as if it had a getter and returns different values on getting
+// as necessary. Further, setting a new descriptor for `currentTarget`, as
+// `shadyDispatchEvent` does below, permanently breaks this special descriptor
+// behavior. In this case, `shadyDispatchEvent` creates a new object with the
+// original event as its prototype (via `Object.create`) and modifies that
+// object's `currentTarget` instead, to avoid breaking the descriptor on the
+// original event.
+//
+// In Chrome 104 and Safari 9, some getters on events do not allow `this` to be
+// anything other than exactly the original event object. This means that the
+// above process of using a proxy-like (not a `Proxy`) object for the event
+// fails because any user that attempts to use properties of the original event
+// will be using the proxy as `this`.
+//
+// Fortunately, these two issues seem to be mutually exclusive amongst the
+// browsers that we test on, so we can specifically check if `currentTarget`
+// exists on a new `Event` and switch based off of that. Safari 9 both doesn't
+// have working descriptors for `Event` properties and doesn't allow getter
+// contexts to be anything other than the original event, so
+// `utils.settings.hasDescriptors` is not a sufficient test for deciding this
+// behavior.
+const shadyDispatchEventNeedsProxyEvent = new Event('e').hasOwnProperty(
+  'currentTarget'
+);
+
 function shadyDispatchEvent(originalEvent) {
-  const e = utils.settings.hasDescriptors
-    ? originalEvent
-    : Object.create(originalEvent);
+  const e = shadyDispatchEventNeedsProxyEvent
+    ? Object.create(originalEvent)
+    : originalEvent;
   const path = e.composedPath();
   const retargetedPath = path.map((node) => retarget(node, path));
   const bubbles = e.bubbles;
@@ -417,7 +445,7 @@ function shadyDispatchEvent(originalEvent) {
       }
     }
   } finally {
-    if (utils.settings.hasDescriptors) {
+    if (!shadyDispatchEventNeedsProxyEvent) {
       // Restore previous currentTarget & eventPhase descriptors when
       // dispatching is complete
       if (prevCurrentTargetDesc) {

--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -378,11 +378,10 @@ function fireHandlers(event, node, phase) {
 //
 // Fortunately, these two issues seem to be mutually exclusive amongst the
 // browsers that we test on, so we can specifically check if `currentTarget`
-// exists on a new `Event` and switch based off of that. Safari 9 both doesn't
-// have working descriptors for `Event` properties and doesn't allow getter
-// contexts to be anything other than the original event, so
-// `utils.settings.hasDescriptors` is not a sufficient test for deciding this
-// behavior.
+// exists on a new `Event` and switch based off of that.
+// `utils.settings.hasDescriptors` is not sufficient for deciding this behavior
+// because, in Safari 9, `currentTarget` is not an own property of events, but
+// `.hasDescriptors` is still false.
 const shadyDispatchEventNeedsProxyEvent = new Event('e').hasOwnProperty(
   'currentTarget'
 );

--- a/packages/shadydom/src/patch-native.js
+++ b/packages/shadydom/src/patch-native.js
@@ -126,6 +126,7 @@ export const addNativePrefixedProperties = () => {
   } else {
     copyProperties(Node.prototype, eventProps);
     copyProperties(Window.prototype, eventProps);
+    copyProperties(XMLHttpRequest.prototype, eventProps);
   }
 
   // Node

--- a/packages/shadydom/src/patch-prototypes.js
+++ b/packages/shadydom/src/patch-prototypes.js
@@ -82,6 +82,7 @@ const patchMap = {
   ],
   Window: [WindowPatches],
   CharacterData: [ChildNodePatches],
+  XMLHttpRequest: [!window.EventTarget ? EventTargetPatches : null],
 };
 
 const getPatchPrototype = (name) => window[name] && window[name].prototype;

--- a/packages/tests/shadycss/chrome-devtools.html
+++ b/packages/tests/shadycss/chrome-devtools.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </script>
 <script src="test-flags.js"></script>
 <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+<script src="../node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-pf_dom.js"></script>
 <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
 <script src="module/generated/style-settings.js"></script>
 <script>

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -1648,10 +1648,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             );
             const el = document.createElement('unpatched-focus');
             document.body.appendChild(el);
-            el.input.dispatchEvent(new Event('focus'), {
-              bubbles: false,
-              composed: false,
-            });
+            el.input.dispatchEvent(
+              new Event('focus', {
+                bubbles: false,
+                composed: false,
+              })
+            );
             assert.equal(el.focusedInput, el.input);
             document.body.removeChild(el);
           });

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -1197,7 +1197,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           test('composedPath of events from non-Node subclasses works', function (done) {
             const xhr = new XMLHttpRequest();
             xhr.open('GET', window.location.href);
-            ShadyDOM.wrapIfNeeded(xhr).addEventListener('load', (e) => {
+            ShadyDOM.wrap(xhr).addEventListener('load', (e) => {
               assert.doesNotThrow(() => {
                 e.composedPath();
                 done();

--- a/packages/tests/shadydom/event-path.html
+++ b/packages/tests/shadydom/event-path.html
@@ -1197,7 +1197,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           test('composedPath of events from non-Node subclasses works', function (done) {
             const xhr = new XMLHttpRequest();
             xhr.open('GET', window.location.href);
-            xhr.addEventListener('load', (e) => {
+            ShadyDOM.wrapIfNeeded(xhr).addEventListener('load', (e) => {
               assert.doesNotThrow(() => {
                 e.composedPath();
                 done();


### PR DESCRIPTION
In at least Chrome 41, events' `currentTarget` is an own property with a broken descriptor. Setting a new descriptor on one of these events makes it impossible to restore the default behavior of `currentTarget` for that event, making it useless to any later listeners. Shady DOM occasionally has to manually dispatch an event, which involves temporarily setting a new `currentTarget` descriptor to allow Shady DOM to update this property. With this PR, if the `currentTarget` property of events is broken as it is in Chrome 41, Shady DOM will create a new object with the event as its prototype, modify that new object's `currentTarget` descriptor, and pass that new object to listeners during the manual dispatch.

`EventTarget` doesn't exist in some older browsers, so objects that would normally have `EventTarget.prototype` in their prototype chain in modern browsers instead have separate copies of those properties on other prototypes. `XMLHttpRequest` is one of these objects with `EventTarget`-like properties, but these properties were unpatched until this PR.