### PR TITLE
Patch the registry class only when polyfilling

### DIFF
--- a/packages/custom-elements/CHANGELOG.md
+++ b/packages/custom-elements/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## Unreleased -->
 
+## Unreleased
+
+- Don't write to window.CustomElementsRegistry unless we're also writing to window.customElements. ([#524](https://github.com/webcomponents/polyfills/pull/524))
+
 ## [1.5.0] - 2021-08-02
 
 - Add TS externs. ([#457](https://github.com/webcomponents/polyfills/pull/457))

--- a/packages/custom-elements/ts_src/CustomElementRegistry.ts
+++ b/packages/custom-elements/ts_src/CustomElementRegistry.ts
@@ -351,9 +351,6 @@ export default class CustomElementRegistry {
 }
 
 // Closure compiler exports.
-window[
-  'CustomElementRegistry'
-] = (CustomElementRegistry as unknown) as typeof window['CustomElementRegistry'];
 /* eslint-disable no-self-assign */
 CustomElementRegistry.prototype['define'] =
   CustomElementRegistry.prototype.define;

--- a/packages/custom-elements/ts_src/custom-elements.ts
+++ b/packages/custom-elements/ts_src/custom-elements.ts
@@ -36,6 +36,10 @@ function installPolyfill() {
   PatchNode(internals);
   PatchElement(internals);
 
+  window[
+    'CustomElementRegistry'
+  ] = (CustomElementRegistry as unknown) as typeof window['CustomElementRegistry'];
+
   const customElements = new CustomElementRegistry(internals);
 
   // The main document is associated with the global registry.


### PR DESCRIPTION
Currently we always write/overwrite window.CustomElementsRegistry when the polyfill loads, even if we don't patch anything else, including window.customElements

If the browser has a native implementation of custom elements, this means that customElements isn't an instance of CustomElementsRegistry, so patching CustomElementsRegistry.prototype, as redefine_custom_elements does, does not effect how customElements behaves. This leads to fun and mysterious bugs!

Better to only write to CustomElementsRegistry when we're doing other patching, and otherwise leave it alone.

Fixes #340.