### PR TITLE
[shadydom] Fix Closure types of `querySelector{,All}` patches for internal conformance checks.

### DIFF
--- a/packages/shadydom/CHANGELOG.md
+++ b/packages/shadydom/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#519](https://github.com/webcomponents/polyfills/pull/519))
 - Add `ShadyDOM.querySelectorImplementation` setting.
   ([#517](https://github.com/webcomponents/polyfills/pull/517))
+- Fix Closure types of `querySelector{,All}` patches for internal conformance
+  checks. ([#526](https://github.com/webcomponents/polyfills/pull/526))
 
 ## [1.9.0] - 2021-08-02
 

--- a/packages/shadydom/src/patches/ParentNode.js
+++ b/packages/shadydom/src/patches/ParentNode.js
@@ -389,9 +389,6 @@ export const QueryPatches = utils.getOwnPropertyDescriptors({
    * @param {string} selector
    * @param {boolean} useNative
    */
-  // TODO(sorvell): `useNative` option relies on native querySelectorAll and
-  // misses distributed nodes, see
-  // https://github.com/webcomponents/shadydom/pull/210#issuecomment-361435503
   querySelectorAll(selector, useNative) {
     if (useNative || querySelectorImplementation === 'native') {
       // Polyfilled `ShadowRoot`s don't have a native `querySelectorAll`.


### PR DESCRIPTION
These patches should be typed as if they could be applied to all prototypes that include `ParentNode`.