### PR TITLE
fix(scoped-custom-elements-registry): return value from HTMLElement p…

### DIFF
--- a/packages/scoped-custom-element-registry/CHANGELOG.md
+++ b/packages/scoped-custom-element-registry/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Polyfilled ElementInternals prototype methods now return their original value.
 
 # [0.0.5] - 2022-02-18
 

--- a/packages/scoped-custom-element-registry/package-lock.json
+++ b/packages/scoped-custom-element-registry/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@webcomponents/scoped-custom-element-registry",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@open-wc/testing": "^3.1.5",

--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js
@@ -486,7 +486,7 @@ if (!ShadowRoot.prototype.createElement) {
         const host = internalsToHostMap.get(this);
         const definition = definitionForElement.get(host);
         if (definition['formAssociated'] === true) {
-          originalMethod?.call(this, ...args);
+          return originalMethod?.call(this, ...args);
         } else {
           throw new DOMException(
             `Failed to execute ${originalMethod} on 'ElementInternals': The target element is not a form-associated custom element.`

--- a/packages/scoped-custom-element-registry/test/form-associated.test.js
+++ b/packages/scoped-custom-element-registry/test/form-associated.test.js
@@ -99,4 +99,22 @@ export const commonRegistryTests = (registry) => {
       expect(form.elements.length).to.equal(0);
     });
   });
+
+  describe('ElementInternals prototype method overrides', () => {
+    it('will still return the appropriate values', () => {
+      const {tagName, CustomElementClass} = getFormAssociatedTestElement();
+      registry.define(tagName, CustomElementClass);
+
+      const form = document.createElement('form');
+      const element = new CustomElementClass();
+
+      form.append(element);
+
+      expect(element.internals.checkValidity()).to.be.true;
+
+      element.internals.setValidity({valueMissing: true}, 'Test');
+
+      expect(element.internals.checkValidity()).to.be.false;
+    });
+  });
 };


### PR DESCRIPTION
…rototype methods in polyfill

<!--
Please include a clear and concise description of what bug this PR fixes, or
what feature this PR implements.

If it resolves an existing issue, please include a line like "Fixes #1234"
-->
This fixes an issue where the scoped custom element registry polyfill fails to return the value of a polyfilled internals method.
