### PR TITLE
[scoped-custom-element-registry] Unconditionally install the polyfill

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -40,3 +40,7 @@ packages/webcomponentsjs/src/unresolved.*
 packages/webcomponentsjs/custom-elements-es5-adapter.js
 packages/webcomponentsjs/webcomponents-bundle.d.ts
 packages/webcomponentsjs/webcomponents-bundle.js*
+
+packages/scoped-custom-element-registry/**/.wireit/
+packages/scoped-custom-element-registry/**/.tsbuildinfo
+packages/scoped-custom-element-registry/**/build/

--- a/.eslintignore-sync
+++ b/.eslintignore-sync
@@ -1,2 +1,5 @@
 [local]
 .gitignore
+
+[relative]
+packages/*/{.gitignore,.eslintignore}

--- a/.prettierignore
+++ b/.prettierignore
@@ -42,6 +42,8 @@ packages/webcomponentsjs/webcomponents-bundle.d.ts
 packages/webcomponentsjs/webcomponents-bundle.js*
 
 packages/scoped-custom-element-registry/**/.wireit/
+packages/scoped-custom-element-registry/**/.tsbuildinfo
+packages/scoped-custom-element-registry/**/build/
 
 LICENSE
 packages/*/LICENSE.md

--- a/packages/scoped-custom-element-registry/.gitignore
+++ b/packages/scoped-custom-element-registry/.gitignore
@@ -1,1 +1,3 @@
 .wireit/
+.tsbuildinfo
+build/

--- a/packages/scoped-custom-element-registry/CHANGELOG.md
+++ b/packages/scoped-custom-element-registry/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Unconditionally install the polyfill so that pages doesn't break if native implementations differ.
 
 ## [0.0.9] - 2023-03-30
 

--- a/packages/scoped-custom-element-registry/closure-flags.txt
+++ b/packages/scoped-custom-element-registry/closure-flags.txt
@@ -3,8 +3,8 @@
 --language_in=STABLE
 --language_out=ECMASCRIPT5_STRICT
 --dependency_mode=PRUNE
---entry_point=./src/scoped-custom-element-registry.js
---js=./src/scoped-custom-element-registry.js
+--entry_point=./build/scoped-custom-element-registry.js
+--js=./build/scoped-custom-element-registry.js
 --js_output_file=./scoped-custom-element-registry.min.js
 --output_wrapper="(function(){
 %output%
@@ -14,4 +14,5 @@
 --assume_function_wrapper=true
 --rewrite_polyfills=false
 --create_source_map=./scoped-custom-element-registry.min.js.map
+--source_map_input="./build/scoped-custom-element-registry.js|./build/scoped-custom-element-registry.js.msp"
 --source_map_include_content

--- a/packages/scoped-custom-element-registry/closure-flags.txt
+++ b/packages/scoped-custom-element-registry/closure-flags.txt
@@ -14,5 +14,5 @@
 --assume_function_wrapper=true
 --rewrite_polyfills=false
 --create_source_map=./scoped-custom-element-registry.min.js.map
---source_map_input="./build/scoped-custom-element-registry.js|./build/scoped-custom-element-registry.js.msp"
+--source_map_input="./build/scoped-custom-element-registry.js|./build/scoped-custom-element-registry.js.map"
 --source_map_include_content

--- a/packages/scoped-custom-element-registry/package.json
+++ b/packages/scoped-custom-element-registry/package.json
@@ -19,6 +19,7 @@
   "main": "scoped-custom-element-registry.min.js",
   "scripts": {
     "build": "wireit",
+    "build:ts": "wireit",
     "test": "wireit"
   },
   "files": [
@@ -53,14 +54,29 @@
     },
     "build:closure": {
       "command": "google-closure-compiler --flagfile closure-flags.txt",
+      "dependencies": [
+        "build:ts"
+      ],
       "files": [
         "closure-flags.txt",
-        "src/**/*.js"
+        "build/**/*.js"
       ],
       "output": [
         "scoped-custom-element-registry.min.js",
         "scoped-custom-element-registry.min.js.map"
       ]
+    },
+    "build:ts": {
+      "command": "tsc",
+      "files": [
+        "tsconfig.json",
+        "src/**/*.ts"
+      ],
+      "output": [
+        ".tsbuildinfo",
+        "build"
+      ],
+      "clean": "if-file-deleted"
     },
     "test": {
       "command": "wtr",

--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
@@ -66,621 +66,601 @@ type ParametersOf<
   T extends ((...args: any) => any) | undefined
 > = T extends Function ? Parameters<T> : never;
 
-if (!ShadowRoot.prototype.createElement) {
-  const NativeHTMLElement = window.HTMLElement;
-  const nativeDefine = window.customElements.define;
-  const nativeGet = window.customElements.get;
-  const nativeRegistry = window.customElements;
+const NativeHTMLElement = window.HTMLElement;
+const nativeDefine = window.customElements.define;
+const nativeGet = window.customElements.get;
+const nativeRegistry = window.customElements;
 
-  const definitionForElement = new WeakMap();
-  const pendingRegistryForElement = new WeakMap();
-  const globalDefinitionForConstructor = new WeakMap();
-  // TBD: This part of the spec proposal is unclear:
-  // > Another option for looking up registries is to store an element's
-  // > originating registry with the element. The Chrome DOM team was concerned
-  // > about the small additional memory overhead on all elements. Looking up the
-  // > root avoids this.
-  const scopeForElement = new WeakMap();
+const definitionForElement = new WeakMap();
+const pendingRegistryForElement = new WeakMap();
+const globalDefinitionForConstructor = new WeakMap();
+// TBD: This part of the spec proposal is unclear:
+// > Another option for looking up registries is to store an element's
+// > originating registry with the element. The Chrome DOM team was concerned
+// > about the small additional memory overhead on all elements. Looking up the
+// > root avoids this.
+const scopeForElement = new WeakMap();
 
-  // Constructable CE registry class, which uses the native CE registry to
-  // register stand-in elements that can delegate out to CE classes registered
-  // in scoped registries
-  window.CustomElementRegistry = class {
-    private _definitionsByTag = new Map();
-    private _definitionsByClass = new Map();
-    private _whenDefinedPromises = new Map();
-    private _awaitingUpgrade = new Map();
+// Constructable CE registry class, which uses the native CE registry to
+// register stand-in elements that can delegate out to CE classes registered
+// in scoped registries
+window.CustomElementRegistry = class {
+  private _definitionsByTag = new Map();
+  private _definitionsByClass = new Map();
+  private _whenDefinedPromises = new Map();
+  private _awaitingUpgrade = new Map();
 
-    define(tagName: string, elementClass: CustomElementConstructor) {
-      tagName = tagName.toLowerCase();
-      if (this._getDefinition(tagName) !== undefined) {
-        throw new DOMException(
-          `Failed to execute 'define' on 'CustomElementRegistry': the name "${tagName}" has already been used with this registry`
-        );
-      }
-      if (this._definitionsByClass.get(elementClass) !== undefined) {
-        throw new DOMException(
-          `Failed to execute 'define' on 'CustomElementRegistry': this constructor has already been used with this registry`
-        );
-      }
-      // Since observedAttributes can't change, we approximate it by patching
-      // set/remove/toggleAttribute on the user's class
-      const attributeChangedCallback =
-        elementClass.prototype.attributeChangedCallback;
-      const observedAttributes = new Set(elementClass.observedAttributes || []);
-      patchAttributes(
-        elementClass,
-        observedAttributes,
-        attributeChangedCallback
+  define(tagName: string, elementClass: CustomElementConstructor) {
+    tagName = tagName.toLowerCase();
+    if (this._getDefinition(tagName) !== undefined) {
+      throw new DOMException(
+        `Failed to execute 'define' on 'CustomElementRegistry': the name "${tagName}" has already been used with this registry`
       );
-      // Register the definition
-      const definition: CustomElementDefinition = {
-        elementClass,
-        connectedCallback: elementClass.prototype.connectedCallback,
-        disconnectedCallback: elementClass.prototype.disconnectedCallback,
-        adoptedCallback: elementClass.prototype.adoptedCallback,
-        attributeChangedCallback,
-        'formAssociated': elementClass['formAssociated'],
-        'formAssociatedCallback':
-          elementClass.prototype['formAssociatedCallback'],
-        'formDisabledCallback': elementClass.prototype['formDisabledCallback'],
-        'formResetCallback': elementClass.prototype['formResetCallback'],
-        'formStateRestoreCallback':
-          elementClass.prototype['formStateRestoreCallback'],
-        observedAttributes,
-      };
-      this._definitionsByTag.set(tagName, definition);
-      this._definitionsByClass.set(elementClass, definition);
-      // Register a stand-in class which will handle the registry lookup & delegation
-      let standInClass = nativeGet.call(nativeRegistry, tagName);
-      if (!standInClass) {
-        standInClass = createStandInElement(tagName);
-        nativeDefine.call(nativeRegistry, tagName, standInClass);
-      }
-      if (this === window.customElements) {
-        globalDefinitionForConstructor.set(elementClass, definition);
-        definition.standInClass = standInClass;
-      }
-      // Upgrade any elements created in this scope before define was called
-      const awaiting = this._awaitingUpgrade.get(tagName);
-      if (awaiting) {
-        this._awaitingUpgrade.delete(tagName);
-        for (const element of awaiting) {
-          pendingRegistryForElement.delete(element);
-          customize(element, definition, true);
-        }
-      }
-      // Flush whenDefined callbacks
-      const info = this._whenDefinedPromises.get(tagName);
-      if (info !== undefined) {
-        info.resolve(elementClass);
-        this._whenDefinedPromises.delete(tagName);
-      }
-      return elementClass;
     }
-
-    upgrade(...args: Parameters<CustomElementRegistry['upgrade']>) {
-      creationContext.push(this);
-      nativeRegistry.upgrade(...args);
-      creationContext.pop();
+    if (this._definitionsByClass.get(elementClass) !== undefined) {
+      throw new DOMException(
+        `Failed to execute 'define' on 'CustomElementRegistry': this constructor has already been used with this registry`
+      );
     }
-
-    get(tagName: string) {
-      const definition = this._definitionsByTag.get(tagName);
-      return definition?.elementClass;
+    // Since observedAttributes can't change, we approximate it by patching
+    // set/remove/toggleAttribute on the user's class
+    const attributeChangedCallback =
+      elementClass.prototype.attributeChangedCallback;
+    const observedAttributes = new Set(elementClass.observedAttributes || []);
+    patchAttributes(elementClass, observedAttributes, attributeChangedCallback);
+    // Register the definition
+    const definition: CustomElementDefinition = {
+      elementClass,
+      connectedCallback: elementClass.prototype.connectedCallback,
+      disconnectedCallback: elementClass.prototype.disconnectedCallback,
+      adoptedCallback: elementClass.prototype.adoptedCallback,
+      attributeChangedCallback,
+      'formAssociated': elementClass['formAssociated'],
+      'formAssociatedCallback':
+        elementClass.prototype['formAssociatedCallback'],
+      'formDisabledCallback': elementClass.prototype['formDisabledCallback'],
+      'formResetCallback': elementClass.prototype['formResetCallback'],
+      'formStateRestoreCallback':
+        elementClass.prototype['formStateRestoreCallback'],
+      observedAttributes,
+    };
+    this._definitionsByTag.set(tagName, definition);
+    this._definitionsByClass.set(elementClass, definition);
+    // Register a stand-in class which will handle the registry lookup & delegation
+    let standInClass = nativeGet.call(nativeRegistry, tagName);
+    if (!standInClass) {
+      standInClass = createStandInElement(tagName);
+      nativeDefine.call(nativeRegistry, tagName, standInClass);
     }
-
-    _getDefinition(tagName: string) {
-      return this._definitionsByTag.get(tagName);
+    if (this === window.customElements) {
+      globalDefinitionForConstructor.set(elementClass, definition);
+      definition.standInClass = standInClass;
     }
-
-    whenDefined(tagName: string) {
-      const definition = this._getDefinition(tagName);
-      if (definition !== undefined) {
-        return Promise.resolve(definition.elementClass);
+    // Upgrade any elements created in this scope before define was called
+    const awaiting = this._awaitingUpgrade.get(tagName);
+    if (awaiting) {
+      this._awaitingUpgrade.delete(tagName);
+      for (const element of awaiting) {
+        pendingRegistryForElement.delete(element);
+        customize(element, definition, true);
       }
-      let info = this._whenDefinedPromises.get(tagName);
-      if (info === undefined) {
-        info = {};
-        info.promise = new Promise((r) => (info.resolve = r));
-        this._whenDefinedPromises.set(tagName, info);
-      }
-      return info.promise;
     }
+    // Flush whenDefined callbacks
+    const info = this._whenDefinedPromises.get(tagName);
+    if (info !== undefined) {
+      info.resolve(elementClass);
+      this._whenDefinedPromises.delete(tagName);
+    }
+    return elementClass;
+  }
 
-    _upgradeWhenDefined(
-      element: HTMLElement,
-      tagName: string,
-      shouldUpgrade: boolean
-    ) {
-      let awaiting = this._awaitingUpgrade.get(tagName);
-      if (!awaiting) {
-        this._awaitingUpgrade.set(tagName, (awaiting = new Set()));
-      }
-      if (shouldUpgrade) {
-        awaiting.add(element);
+  upgrade(...args: Parameters<CustomElementRegistry['upgrade']>) {
+    creationContext.push(this);
+    nativeRegistry.upgrade(...args);
+    creationContext.pop();
+  }
+
+  get(tagName: string) {
+    const definition = this._definitionsByTag.get(tagName);
+    return definition?.elementClass;
+  }
+
+  _getDefinition(tagName: string) {
+    return this._definitionsByTag.get(tagName);
+  }
+
+  whenDefined(tagName: string) {
+    const definition = this._getDefinition(tagName);
+    if (definition !== undefined) {
+      return Promise.resolve(definition.elementClass);
+    }
+    let info = this._whenDefinedPromises.get(tagName);
+    if (info === undefined) {
+      info = {};
+      info.promise = new Promise((r) => (info.resolve = r));
+      this._whenDefinedPromises.set(tagName, info);
+    }
+    return info.promise;
+  }
+
+  _upgradeWhenDefined(
+    element: HTMLElement,
+    tagName: string,
+    shouldUpgrade: boolean
+  ) {
+    let awaiting = this._awaitingUpgrade.get(tagName);
+    if (!awaiting) {
+      this._awaitingUpgrade.set(tagName, (awaiting = new Set()));
+    }
+    if (shouldUpgrade) {
+      awaiting.add(element);
+    } else {
+      awaiting.delete(element);
+    }
+  }
+};
+
+// User extends this HTMLElement, which returns the CE being upgraded
+let upgradingInstance: HTMLElement | undefined;
+window.HTMLElement = (function HTMLElement(this: HTMLElement) {
+  // Upgrading case: the StandInElement constructor was run by the browser's
+  // native custom elements and we're in the process of running the
+  // "constructor-call trick" on the natively constructed instance, so just
+  // return that here
+  let instance = upgradingInstance;
+  if (instance) {
+    upgradingInstance = undefined;
+    return instance;
+  }
+  // Construction case: we need to construct the StandInElement and return
+  // it; note the current spec proposal only allows new'ing the constructor
+  // of elements registered with the global registry
+  const definition = globalDefinitionForConstructor.get(this.constructor);
+  if (!definition) {
+    throw new TypeError(
+      'Illegal constructor (custom element class must be registered with global customElements registry to be newable)'
+    );
+  }
+  instance = Reflect.construct(NativeHTMLElement, [], definition.standInClass);
+  Object.setPrototypeOf(instance, this.constructor.prototype);
+  definitionForElement.set(instance!, definition);
+  return instance;
+} as unknown) as typeof HTMLElement;
+window.HTMLElement.prototype = NativeHTMLElement.prototype;
+
+// Helpers to return the scope for a node where its registry would be located
+const isValidScope = (node: Node) =>
+  node === document || node instanceof ShadowRoot;
+const registryForNode = (node: Node) => {
+  // TODO: the algorithm for finding the scope is a bit up in the air; assigning
+  // a one-time scope at creation time would require walking every tree ever
+  // created, which is avoided for now
+  let scope = node.getRootNode();
+  // If we're not attached to the document (i.e. in a disconnected tree or
+  // fragment), we need to get the scope from the creation context; that should
+  // be a Document or ShadowRoot, unless it was created via innerHTML
+  if (!isValidScope(scope)) {
+    const context = creationContext[creationContext.length - 1];
+    // When upgrading via registry.upgrade(), the registry itself is put on the
+    // creationContext stack
+    if (context instanceof CustomElementRegistry) {
+      return context;
+    }
+    // Otherwise, get the root node of the element this was created from
+    scope = context.getRootNode();
+    // The creation context wasn't a Document or ShadowRoot or in one; this
+    // means we're being innerHTML'ed into a disconnected element; for now, we
+    // hope that root node was created imperatively, where we stash _its_
+    // scopeForElement. Beyond that, we'd need more costly tracking.
+    if (!isValidScope(scope)) {
+      scope = scopeForElement.get(scope)?.getRootNode() || document;
+    }
+  }
+  // TODO (justinfagnani): I don't think this matches the proposal
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (scope as any).customElements as CustomElementRegistry | null;
+};
+
+// Helper to create stand-in element for each tagName registered that delegates
+// out to the registry for the given element
+const createStandInElement = (tagName: string): CustomElementConstructor => {
+  return (class ScopedCustomElementBase {
+    static get ['formAssociated']() {
+      return true;
+    }
+    constructor() {
+      // Create a raw HTMLElement first
+      const instance = Reflect.construct(
+        NativeHTMLElement,
+        [],
+        this.constructor
+      );
+      // We need to install the minimum HTMLElement prototype so that
+      // scopeForNode can use DOM API to determine our construction scope;
+      // upgrade will eventually install the full CE prototype
+      Object.setPrototypeOf(instance, HTMLElement.prototype);
+      // Get the node's scope, and its registry (falls back to global registry)
+      const registry = registryForNode(instance) || window.customElements;
+      const definition = registry._getDefinition(tagName);
+      if (definition) {
+        customize(instance, definition);
       } else {
-        awaiting.delete(element);
+        pendingRegistryForElement.set(instance, registry);
       }
-    }
-  };
-
-  // User extends this HTMLElement, which returns the CE being upgraded
-  let upgradingInstance: HTMLElement | undefined;
-  window.HTMLElement = (function HTMLElement(this: HTMLElement) {
-    // Upgrading case: the StandInElement constructor was run by the browser's
-    // native custom elements and we're in the process of running the
-    // "constructor-call trick" on the natively constructed instance, so just
-    // return that here
-    let instance = upgradingInstance;
-    if (instance) {
-      upgradingInstance = undefined;
       return instance;
     }
-    // Construction case: we need to construct the StandInElement and return
-    // it; note the current spec proposal only allows new'ing the constructor
-    // of elements registered with the global registry
-    const definition = globalDefinitionForConstructor.get(this.constructor);
-    if (!definition) {
-      throw new TypeError(
-        'Illegal constructor (custom element class must be registered with global customElements registry to be newable)'
+
+    connectedCallback(
+      ...args: ParametersOf<CustomHTMLElement['connectedCallback']>
+    ) {
+      const definition = definitionForElement.get(this);
+      if (definition) {
+        // Delegate out to user callback
+        definition.connectedCallback &&
+          definition.connectedCallback.apply(this, args);
+      } else {
+        // Register for upgrade when defined (only when connected, so we don't leak)
+        pendingRegistryForElement
+          .get(this)
+          ._upgradeWhenDefined(this, tagName, true);
+      }
+    }
+
+    disconnectedCallback(
+      ...args: ParametersOf<CustomHTMLElement['connectedCallback']>
+    ) {
+      const definition = definitionForElement.get(this);
+      if (definition) {
+        // Delegate out to user callback
+        definition.disconnectedCallback &&
+          definition.disconnectedCallback.apply(this, args);
+      } else {
+        // Un-register for upgrade when defined (so we don't leak)
+        pendingRegistryForElement
+          .get(this)
+          ._upgradeWhenDefined(this, tagName, false);
+      }
+    }
+
+    adoptedCallback(
+      ...args: ParametersOf<CustomHTMLElement['adoptedCallback']>
+    ) {
+      const definition = definitionForElement.get(this);
+      definition?.adoptedCallback?.apply(this, args);
+    }
+
+    // Form-associated custom elements lifecycle methods
+    ['formAssociatedCallback'](
+      ...args: ParametersOf<CustomHTMLElement['formAssociatedCallback']>
+    ) {
+      const definition = definitionForElement.get(this);
+      if (definition?.['formAssociated']) {
+        definition?.['formAssociatedCallback']?.apply(this, args);
+      }
+    }
+
+    ['formDisabledCallback'](
+      ...args: ParametersOf<CustomHTMLElement['formDisabledCallback']>
+    ) {
+      const definition = definitionForElement.get(this);
+      if (definition?.['formAssociated']) {
+        definition?.['formDisabledCallback']?.apply(this, args);
+      }
+    }
+
+    ['formResetCallback'](
+      ...args: ParametersOf<CustomHTMLElement['formResetCallback']>
+    ) {
+      const definition = definitionForElement.get(this);
+      if (definition?.['formAssociated']) {
+        definition?.['formResetCallback']?.apply(this, args);
+      }
+    }
+
+    ['formStateRestoreCallback'](
+      ...args: ParametersOf<CustomHTMLElement['formStateRestoreCallback']>
+    ) {
+      const definition = definitionForElement.get(this);
+      if (definition?.['formAssociated']) {
+        definition?.['formStateRestoreCallback']?.apply(this, args);
+      }
+    }
+
+    // no attributeChangedCallback or observedAttributes since these
+    // are simulated via setAttribute/removeAttribute patches
+  } as unknown) as CustomElementConstructor;
+};
+
+// Helper to patch CE class setAttribute/getAttribute/toggleAttribute to
+// implement attributeChangedCallback
+const patchAttributes = (
+  elementClass: CustomElementConstructor,
+  observedAttributes: Set<string>,
+  attributeChangedCallback?: CustomHTMLElement['attributeChangedCallback']
+) => {
+  if (observedAttributes.size === 0 || attributeChangedCallback === undefined) {
+    return;
+  }
+  const setAttribute = elementClass.prototype.setAttribute;
+  if (setAttribute) {
+    elementClass.prototype.setAttribute = function (n: string, value: string) {
+      const name = n.toLowerCase();
+      if (observedAttributes.has(name)) {
+        const old = this.getAttribute(name);
+        setAttribute.call(this, name, value);
+        attributeChangedCallback.call(this, name, old, value);
+      } else {
+        setAttribute.call(this, name, value);
+      }
+    };
+  }
+  const removeAttribute = elementClass.prototype.removeAttribute;
+  if (removeAttribute) {
+    elementClass.prototype.removeAttribute = function (n: string) {
+      const name = n.toLowerCase();
+      if (observedAttributes.has(name)) {
+        const old = this.getAttribute(name);
+        removeAttribute.call(this, name);
+        attributeChangedCallback.call(this, name, old, null);
+      } else {
+        removeAttribute.call(this, name);
+      }
+    };
+  }
+  const toggleAttribute = elementClass.prototype.toggleAttribute;
+  if (toggleAttribute) {
+    elementClass.prototype.toggleAttribute = function (
+      n: string,
+      force?: boolean
+    ) {
+      const name = n.toLowerCase();
+      if (observedAttributes.has(name)) {
+        const old = this.getAttribute(name);
+        toggleAttribute.call(this, name, force);
+        const newValue = this.getAttribute(name);
+        attributeChangedCallback.call(this, name, old, newValue);
+      } else {
+        toggleAttribute.call(this, name, force);
+      }
+    };
+  }
+};
+
+// Helper to patch CE class hierarchy changing those CE classes created before applying the polyfill
+// to make them work with the new patched CustomElementsRegistry
+const patchHTMLElement = (elementClass: CustomElementConstructor): unknown => {
+  const parentClass = Object.getPrototypeOf(elementClass);
+
+  if (parentClass !== window.HTMLElement) {
+    if (parentClass === NativeHTMLElement) {
+      return Object.setPrototypeOf(elementClass, window.HTMLElement);
+    }
+
+    return patchHTMLElement(parentClass);
+  }
+  return;
+};
+
+// Helper to upgrade an instance with a CE definition using "constructor call trick"
+const customize = (
+  instance: HTMLElement,
+  definition: CustomElementDefinition,
+  isUpgrade = false
+) => {
+  Object.setPrototypeOf(instance, definition.elementClass.prototype);
+  definitionForElement.set(instance, definition);
+  upgradingInstance = instance;
+  try {
+    new definition.elementClass();
+  } catch (_) {
+    patchHTMLElement(definition.elementClass);
+    new definition.elementClass();
+  }
+  if (definition.attributeChangedCallback) {
+    // Approximate observedAttributes from the user class, since the stand-in element had none
+    definition.observedAttributes.forEach((attr) => {
+      if (instance.hasAttribute(attr)) {
+        definition.attributeChangedCallback!.call(
+          instance,
+          attr,
+          null,
+          instance.getAttribute(attr)
+        );
+      }
+    });
+  }
+  if (isUpgrade && definition.connectedCallback && instance.isConnected) {
+    definition.connectedCallback.call(instance);
+  }
+};
+
+// Patch attachShadow to set customElements on shadowRoot when provided
+const nativeAttachShadow = Element.prototype.attachShadow;
+Element.prototype.attachShadow = function (
+  ...args: Parameters<Element['attachShadow']>
+) {
+  const init = args[0];
+  const shadowRoot = nativeAttachShadow.apply(this, args);
+  if (init.customElements) {
+    (shadowRoot as ShadowRootWithSettableCustomElements).customElements =
+      init.customElements;
+  }
+  return shadowRoot;
+};
+
+// Install scoped creation API on Element & ShadowRoot
+const creationContext: Array<Document | CustomElementRegistry> = [document];
+const installScopedCreationMethod = (
+  ctor: Function,
+  method: string,
+  from?: Document
+) => {
+  const native = (from ? Object.getPrototypeOf(from) : ctor.prototype)[method];
+  ctor.prototype[method] = function (...args: Array<unknown>) {
+    creationContext.push(this);
+    const ret = native.apply(from || this, args);
+    // For disconnected elements, note their creation scope so that e.g.
+    // innerHTML into them will use the correct scope; note that
+    // insertAdjacentHTML doesn't return an element, but that's fine since
+    // it will have a parent that should have a scope
+    if (ret !== undefined) {
+      scopeForElement.set(ret, this);
+    }
+    creationContext.pop();
+    return ret;
+  };
+};
+installScopedCreationMethod(ShadowRoot, 'createElement', document);
+installScopedCreationMethod(ShadowRoot, 'importNode', document);
+installScopedCreationMethod(Element, 'insertAdjacentHTML');
+
+// Install scoped innerHTML on Element & ShadowRoot
+const installScopedCreationSetter = (ctor: Function, name: string) => {
+  const descriptor = Object.getOwnPropertyDescriptor(ctor.prototype, name)!;
+  Object.defineProperty(ctor.prototype, name, {
+    ...descriptor,
+    set(value) {
+      creationContext.push(this);
+      descriptor.set!.call(this, value);
+      creationContext.pop();
+    },
+  });
+};
+installScopedCreationSetter(Element, 'innerHTML');
+installScopedCreationSetter(ShadowRoot, 'innerHTML');
+
+// Install global registry
+Object.defineProperty(window, 'customElements', {
+  value: new CustomElementRegistry(),
+  configurable: true,
+  writable: true,
+});
+
+if (
+  !!window['ElementInternals'] &&
+  !!window['ElementInternals'].prototype['setFormValue']
+) {
+  const internalsToHostMap = new WeakMap();
+  const attachInternals = HTMLElement.prototype['attachInternals'];
+  const methods: Array<keyof ElementInternals> = [
+    'setFormValue',
+    'setValidity',
+    'checkValidity',
+    'reportValidity',
+  ];
+
+  HTMLElement.prototype['attachInternals'] = function (...args) {
+    const internals = attachInternals.call(this, ...args);
+    internalsToHostMap.set(internals, this);
+    return internals;
+  };
+
+  methods.forEach((method) => {
+    const proto = window['ElementInternals'].prototype;
+    const originalMethod = proto[method] as Function;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (proto as any)[method] = function (...args: Array<unknown>) {
+      const host = internalsToHostMap.get(this);
+      const definition = definitionForElement.get(host);
+      if (definition['formAssociated'] === true) {
+        return originalMethod?.call(this, ...args);
+      } else {
+        throw new DOMException(
+          `Failed to execute ${originalMethod} on 'ElementInternals': The target element is not a form-associated custom element.`
+        );
+      }
+    };
+  });
+
+  // Emulate the native RadioNodeList object
+  const RadioNodeList = (class
+    extends Array<Node>
+    implements Omit<RadioNodeList, 'forEach'> {
+    private _elements: Array<HTMLInputElement>;
+
+    constructor(elements: Array<HTMLInputElement>) {
+      super(...elements);
+      this._elements = elements;
+    }
+    [index: number]: Node;
+
+    item(index: number): Node | null {
+      return this[index];
+    }
+
+    get ['value']() {
+      return (
+        this._elements.find((element) => element['checked'] === true)?.value ||
+        ''
       );
     }
-    instance = Reflect.construct(
-      NativeHTMLElement,
-      [],
-      definition.standInClass
-    );
-    Object.setPrototypeOf(instance, this.constructor.prototype);
-    definitionForElement.set(instance!, definition);
-    return instance;
-  } as unknown) as typeof HTMLElement;
-  window.HTMLElement.prototype = NativeHTMLElement.prototype;
+  } as unknown) as {new (elements: Array<HTMLInputElement>): RadioNodeList};
 
-  // Helpers to return the scope for a node where its registry would be located
-  const isValidScope = (node: Node) =>
-    node === document || node instanceof ShadowRoot;
-  const registryForNode = (node: Node) => {
-    // TODO: the algorithm for finding the scope is a bit up in the air; assigning
-    // a one-time scope at creation time would require walking every tree ever
-    // created, which is avoided for now
-    let scope = node.getRootNode();
-    // If we're not attached to the document (i.e. in a disconnected tree or
-    // fragment), we need to get the scope from the creation context; that should
-    // be a Document or ShadowRoot, unless it was created via innerHTML
-    if (!isValidScope(scope)) {
-      const context = creationContext[creationContext.length - 1];
-      // When upgrading via registry.upgrade(), the registry itself is put on the
-      // creationContext stack
-      if (context instanceof CustomElementRegistry) {
-        return context;
-      }
-      // Otherwise, get the root node of the element this was created from
-      scope = context.getRootNode();
-      // The creation context wasn't a Document or ShadowRoot or in one; this
-      // means we're being innerHTML'ed into a disconnected element; for now, we
-      // hope that root node was created imperatively, where we stash _its_
-      // scopeForElement. Beyond that, we'd need more costly tracking.
-      if (!isValidScope(scope)) {
-        scope = scopeForElement.get(scope)?.getRootNode() || document;
-      }
-    }
-    // TODO (justinfagnani): I don't think this matches the proposal
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (scope as any).customElements as CustomElementRegistry | null;
-  };
+  // Emulate the native HTMLFormControlsCollection object
+  const HTMLFormControlsCollection = class
+    implements HTMLFormControlsCollection {
+    length: number;
 
-  // Helper to create stand-in element for each tagName registered that delegates
-  // out to the registry for the given element
-  const createStandInElement = (tagName: string): CustomElementConstructor => {
-    return (class ScopedCustomElementBase {
-      static get ['formAssociated']() {
-        return true;
-      }
-      constructor() {
-        // Create a raw HTMLElement first
-        const instance = Reflect.construct(
-          NativeHTMLElement,
-          [],
-          this.constructor
-        );
-        // We need to install the minimum HTMLElement prototype so that
-        // scopeForNode can use DOM API to determine our construction scope;
-        // upgrade will eventually install the full CE prototype
-        Object.setPrototypeOf(instance, HTMLElement.prototype);
-        // Get the node's scope, and its registry (falls back to global registry)
-        const registry = registryForNode(instance) || window.customElements;
-        const definition = registry._getDefinition(tagName);
-        if (definition) {
-          customize(instance, definition);
+    constructor(elements: Array<HTMLElement>) {
+      const entries = new Map();
+      elements.forEach((element, index) => {
+        const name = element.getAttribute('name');
+        const nameReference = entries.get(name) || [];
+        this[+index] = element;
+        nameReference.push(element);
+        entries.set(name, nameReference);
+      });
+      this['length'] = elements.length;
+      entries.forEach((value, key) => {
+        if (!value) return;
+        if (value.length === 1) {
+          this[key] = value[0];
         } else {
-          pendingRegistryForElement.set(instance, registry);
-        }
-        return instance;
-      }
-
-      connectedCallback(
-        ...args: ParametersOf<CustomHTMLElement['connectedCallback']>
-      ) {
-        const definition = definitionForElement.get(this);
-        if (definition) {
-          // Delegate out to user callback
-          definition.connectedCallback &&
-            definition.connectedCallback.apply(this, args);
-        } else {
-          // Register for upgrade when defined (only when connected, so we don't leak)
-          pendingRegistryForElement
-            .get(this)
-            ._upgradeWhenDefined(this, tagName, true);
-        }
-      }
-
-      disconnectedCallback(
-        ...args: ParametersOf<CustomHTMLElement['connectedCallback']>
-      ) {
-        const definition = definitionForElement.get(this);
-        if (definition) {
-          // Delegate out to user callback
-          definition.disconnectedCallback &&
-            definition.disconnectedCallback.apply(this, args);
-        } else {
-          // Un-register for upgrade when defined (so we don't leak)
-          pendingRegistryForElement
-            .get(this)
-            ._upgradeWhenDefined(this, tagName, false);
-        }
-      }
-
-      adoptedCallback(
-        ...args: ParametersOf<CustomHTMLElement['adoptedCallback']>
-      ) {
-        const definition = definitionForElement.get(this);
-        definition?.adoptedCallback?.apply(this, args);
-      }
-
-      // Form-associated custom elements lifecycle methods
-      ['formAssociatedCallback'](
-        ...args: ParametersOf<CustomHTMLElement['formAssociatedCallback']>
-      ) {
-        const definition = definitionForElement.get(this);
-        if (definition?.['formAssociated']) {
-          definition?.['formAssociatedCallback']?.apply(this, args);
-        }
-      }
-
-      ['formDisabledCallback'](
-        ...args: ParametersOf<CustomHTMLElement['formDisabledCallback']>
-      ) {
-        const definition = definitionForElement.get(this);
-        if (definition?.['formAssociated']) {
-          definition?.['formDisabledCallback']?.apply(this, args);
-        }
-      }
-
-      ['formResetCallback'](
-        ...args: ParametersOf<CustomHTMLElement['formResetCallback']>
-      ) {
-        const definition = definitionForElement.get(this);
-        if (definition?.['formAssociated']) {
-          definition?.['formResetCallback']?.apply(this, args);
-        }
-      }
-
-      ['formStateRestoreCallback'](
-        ...args: ParametersOf<CustomHTMLElement['formStateRestoreCallback']>
-      ) {
-        const definition = definitionForElement.get(this);
-        if (definition?.['formAssociated']) {
-          definition?.['formStateRestoreCallback']?.apply(this, args);
-        }
-      }
-
-      // no attributeChangedCallback or observedAttributes since these
-      // are simulated via setAttribute/removeAttribute patches
-    } as unknown) as CustomElementConstructor;
-  };
-
-  // Helper to patch CE class setAttribute/getAttribute/toggleAttribute to
-  // implement attributeChangedCallback
-  const patchAttributes = (
-    elementClass: CustomElementConstructor,
-    observedAttributes: Set<string>,
-    attributeChangedCallback?: CustomHTMLElement['attributeChangedCallback']
-  ) => {
-    if (
-      observedAttributes.size === 0 ||
-      attributeChangedCallback === undefined
-    ) {
-      return;
-    }
-    const setAttribute = elementClass.prototype.setAttribute;
-    if (setAttribute) {
-      elementClass.prototype.setAttribute = function (
-        n: string,
-        value: string
-      ) {
-        const name = n.toLowerCase();
-        if (observedAttributes.has(name)) {
-          const old = this.getAttribute(name);
-          setAttribute.call(this, name, value);
-          attributeChangedCallback.call(this, name, old, value);
-        } else {
-          setAttribute.call(this, name, value);
-        }
-      };
-    }
-    const removeAttribute = elementClass.prototype.removeAttribute;
-    if (removeAttribute) {
-      elementClass.prototype.removeAttribute = function (n: string) {
-        const name = n.toLowerCase();
-        if (observedAttributes.has(name)) {
-          const old = this.getAttribute(name);
-          removeAttribute.call(this, name);
-          attributeChangedCallback.call(this, name, old, null);
-        } else {
-          removeAttribute.call(this, name);
-        }
-      };
-    }
-    const toggleAttribute = elementClass.prototype.toggleAttribute;
-    if (toggleAttribute) {
-      elementClass.prototype.toggleAttribute = function (
-        n: string,
-        force?: boolean
-      ) {
-        const name = n.toLowerCase();
-        if (observedAttributes.has(name)) {
-          const old = this.getAttribute(name);
-          toggleAttribute.call(this, name, force);
-          const newValue = this.getAttribute(name);
-          attributeChangedCallback.call(this, name, old, newValue);
-        } else {
-          toggleAttribute.call(this, name, force);
-        }
-      };
-    }
-  };
-
-  // Helper to patch CE class hierarchy changing those CE classes created before applying the polyfill
-  // to make them work with the new patched CustomElementsRegistry
-  const patchHTMLElement = (
-    elementClass: CustomElementConstructor
-  ): unknown => {
-    const parentClass = Object.getPrototypeOf(elementClass);
-
-    if (parentClass !== window.HTMLElement) {
-      if (parentClass === NativeHTMLElement) {
-        return Object.setPrototypeOf(elementClass, window.HTMLElement);
-      }
-
-      return patchHTMLElement(parentClass);
-    }
-    return;
-  };
-
-  // Helper to upgrade an instance with a CE definition using "constructor call trick"
-  const customize = (
-    instance: HTMLElement,
-    definition: CustomElementDefinition,
-    isUpgrade = false
-  ) => {
-    Object.setPrototypeOf(instance, definition.elementClass.prototype);
-    definitionForElement.set(instance, definition);
-    upgradingInstance = instance;
-    try {
-      new definition.elementClass();
-    } catch (_) {
-      patchHTMLElement(definition.elementClass);
-      new definition.elementClass();
-    }
-    if (definition.attributeChangedCallback) {
-      // Approximate observedAttributes from the user class, since the stand-in element had none
-      definition.observedAttributes.forEach((attr) => {
-        if (instance.hasAttribute(attr)) {
-          definition.attributeChangedCallback!.call(
-            instance,
-            attr,
-            null,
-            instance.getAttribute(attr)
-          );
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (this as any)[key] = new RadioNodeList(value);
         }
       });
     }
-    if (isUpgrade && definition.connectedCallback && instance.isConnected) {
-      definition.connectedCallback.call(instance);
+
+    [index: number]: Element;
+
+    ['item'](index: number): Element | null {
+      return this[index];
     }
-  };
 
-  // Patch attachShadow to set customElements on shadowRoot when provided
-  const nativeAttachShadow = Element.prototype.attachShadow;
-  Element.prototype.attachShadow = function (
-    ...args: Parameters<Element['attachShadow']>
-  ) {
-    const init = args[0];
-    const shadowRoot = nativeAttachShadow.apply(this, args);
-    if (init.customElements) {
-      (shadowRoot as ShadowRootWithSettableCustomElements).customElements =
-        init.customElements;
+    [Symbol.iterator](): IterableIterator<Element> {
+      throw new Error('Method not implemented.');
     }
-    return shadowRoot;
-  };
 
-  // Install scoped creation API on Element & ShadowRoot
-  const creationContext: Array<Document | CustomElementRegistry> = [document];
-  const installScopedCreationMethod = (
-    ctor: Function,
-    method: string,
-    from?: Document
-  ) => {
-    const native = (from ? Object.getPrototypeOf(from) : ctor.prototype)[
-      method
-    ];
-    ctor.prototype[method] = function (...args: Array<unknown>) {
-      creationContext.push(this);
-      const ret = native.apply(from || this, args);
-      // For disconnected elements, note their creation scope so that e.g.
-      // innerHTML into them will use the correct scope; note that
-      // insertAdjacentHTML doesn't return an element, but that's fine since
-      // it will have a parent that should have a scope
-      if (ret !== undefined) {
-        scopeForElement.set(ret, this);
-      }
-      creationContext.pop();
-      return ret;
-    };
-  };
-  installScopedCreationMethod(ShadowRoot, 'createElement', document);
-  installScopedCreationMethod(ShadowRoot, 'importNode', document);
-  installScopedCreationMethod(Element, 'insertAdjacentHTML');
-
-  // Install scoped innerHTML on Element & ShadowRoot
-  const installScopedCreationSetter = (ctor: Function, name: string) => {
-    const descriptor = Object.getOwnPropertyDescriptor(ctor.prototype, name)!;
-    Object.defineProperty(ctor.prototype, name, {
-      ...descriptor,
-      set(value) {
-        creationContext.push(this);
-        descriptor.set!.call(this, value);
-        creationContext.pop();
-      },
-    });
-  };
-  installScopedCreationSetter(Element, 'innerHTML');
-  installScopedCreationSetter(ShadowRoot, 'innerHTML');
-
-  // Install global registry
-  Object.defineProperty(window, 'customElements', {
-    value: new CustomElementRegistry(),
-    configurable: true,
-    writable: true,
-  });
-
-  if (
-    !!window['ElementInternals'] &&
-    !!window['ElementInternals'].prototype['setFormValue']
-  ) {
-    const internalsToHostMap = new WeakMap();
-    const attachInternals = HTMLElement.prototype['attachInternals'];
-    const methods: Array<keyof ElementInternals> = [
-      'setFormValue',
-      'setValidity',
-      'checkValidity',
-      'reportValidity',
-    ];
-
-    HTMLElement.prototype['attachInternals'] = function (...args) {
-      const internals = attachInternals.call(this, ...args);
-      internalsToHostMap.set(internals, this);
-      return internals;
-    };
-
-    methods.forEach((method) => {
-      const proto = window['ElementInternals'].prototype;
-      const originalMethod = proto[method] as Function;
-
+    ['namedItem'](key: string): RadioNodeList | Element | null {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (proto as any)[method] = function (...args: Array<unknown>) {
-        const host = internalsToHostMap.get(this);
-        const definition = definitionForElement.get(host);
-        if (definition['formAssociated'] === true) {
-          return originalMethod?.call(this, ...args);
-        } else {
-          throw new DOMException(
-            `Failed to execute ${originalMethod} on 'ElementInternals': The target element is not a form-associated custom element.`
-          );
+      return (this as any)[key];
+    }
+  };
+
+  // Override the built-in HTMLFormElements.prototype.elements getter
+  const formElementsDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLFormElement.prototype,
+    'elements'
+  )!;
+
+  Object.defineProperty(HTMLFormElement.prototype, 'elements', {
+    get: function () {
+      const nativeElements = formElementsDescriptor.get!.call(this);
+
+      const include: Array<HTMLElement> = [];
+
+      for (const element of nativeElements) {
+        const definition = definitionForElement.get(element);
+
+        // Only purposefully formAssociated elements or built-ins will feature in elements
+        if (!definition || definition['formAssociated'] === true) {
+          include.push(element);
         }
-      };
-    });
-
-    // Emulate the native RadioNodeList object
-    const RadioNodeList = (class
-      extends Array<Node>
-      implements Omit<RadioNodeList, 'forEach'> {
-      private _elements: Array<HTMLInputElement>;
-
-      constructor(elements: Array<HTMLInputElement>) {
-        super(...elements);
-        this._elements = elements;
-      }
-      [index: number]: Node;
-
-      item(index: number): Node | null {
-        return this[index];
       }
 
-      get ['value']() {
-        return (
-          this._elements.find((element) => element['checked'] === true)
-            ?.value || ''
-        );
-      }
-    } as unknown) as {new (elements: Array<HTMLInputElement>): RadioNodeList};
-
-    // Emulate the native HTMLFormControlsCollection object
-    const HTMLFormControlsCollection = class
-      implements HTMLFormControlsCollection {
-      length: number;
-
-      constructor(elements: Array<HTMLElement>) {
-        const entries = new Map();
-        elements.forEach((element, index) => {
-          const name = element.getAttribute('name');
-          const nameReference = entries.get(name) || [];
-          this[+index] = element;
-          nameReference.push(element);
-          entries.set(name, nameReference);
-        });
-        this['length'] = elements.length;
-        entries.forEach((value, key) => {
-          if (!value) return;
-          if (value.length === 1) {
-            this[key] = value[0];
-          } else {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (this as any)[key] = new RadioNodeList(value);
-          }
-        });
-      }
-
-      [index: number]: Element;
-
-      ['item'](index: number): Element | null {
-        return this[index];
-      }
-
-      [Symbol.iterator](): IterableIterator<Element> {
-        throw new Error('Method not implemented.');
-      }
-
-      ['namedItem'](key: string): RadioNodeList | Element | null {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (this as any)[key];
-      }
-    };
-
-    // Override the built-in HTMLFormElements.prototype.elements getter
-    const formElementsDescriptor = Object.getOwnPropertyDescriptor(
-      HTMLFormElement.prototype,
-      'elements'
-    )!;
-
-    Object.defineProperty(HTMLFormElement.prototype, 'elements', {
-      get: function () {
-        const nativeElements = formElementsDescriptor.get!.call(this);
-
-        const include: Array<HTMLElement> = [];
-
-        for (const element of nativeElements) {
-          const definition = definitionForElement.get(element);
-
-          // Only purposefully formAssociated elements or built-ins will feature in elements
-          if (!definition || definition['formAssociated'] === true) {
-            include.push(element);
-          }
-        }
-
-        return new HTMLFormControlsCollection(include);
-      },
-    });
-  }
+      return new HTMLFormControlsCollection(include);
+    },
+  });
 }

--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
@@ -32,8 +32,10 @@ interface CustomHTMLElement {
   formAssociatedCallback?(form: HTMLFormElement | null): void;
   formDisabledCallback?(disabled: boolean): void;
   formResetCallback?(): void;
-  // TODO(justinfagnani): what is the type of state? Does it matter?
-  formStateRestoreCallback?(state: unknown, mode: string): void;
+  formStateRestoreCallback?(
+    state: File | string | FormData | null,
+    mode: string
+  ): void;
 }
 
 interface CustomElementRegistry {

--- a/packages/scoped-custom-element-registry/src/types.d.ts
+++ b/packages/scoped-custom-element-registry/src/types.d.ts
@@ -1,0 +1,155 @@
+export {};
+
+declare global {
+  interface ShadowRoot {
+    // This overload is for roots that use the global registry
+    createElement<K extends keyof HTMLElementTagNameMap>(
+      tagName: K,
+      options?: ElementCreationOptions
+    ): HTMLElementTagNameMap[K];
+    // This overload is for roots that use a scoped registry
+    createElement<K extends keyof BuiltInHTMLElementTagNameMap>(
+      tagName: K,
+      options?: ElementCreationOptions
+    ): BuiltInHTMLElementTagNameMap[K];
+    createElement(
+      tagName: string,
+      options?: ElementCreationOptions
+    ): HTMLElement;
+  }
+
+  interface ShadowRootInit {
+    customElements?: CustomElementRegistry;
+  }
+
+  interface ShadowRoot {
+    readonly customElements?: CustomElementRegistry;
+  }
+
+  /*
+   * Many custom element definitions will add themselves to the global
+   * HTMLElementTagNameMap interface. Using that interface in
+   * ShadowRoot.prototype.createElement() would mean that TypeScript uses
+   * the global tag name map mapping for a scoped API which doesn't use
+   * global registrations.
+   *
+   * This interface allows us to only accept keys of known built-ins, and
+   * possibly create a typed API for scoped registrations.
+   *
+   * This interface should be kept in sync with HTMLElementTagNameMap.
+   */
+  interface BuiltInHTMLElementTagNameMap {
+    'a': HTMLAnchorElement;
+    'abbr': HTMLElement;
+    'address': HTMLElement;
+    'area': HTMLAreaElement;
+    'article': HTMLElement;
+    'aside': HTMLElement;
+    'audio': HTMLAudioElement;
+    'b': HTMLElement;
+    'base': HTMLBaseElement;
+    'bdi': HTMLElement;
+    'bdo': HTMLElement;
+    'blockquote': HTMLQuoteElement;
+    'body': HTMLBodyElement;
+    'br': HTMLBRElement;
+    'button': HTMLButtonElement;
+    'canvas': HTMLCanvasElement;
+    'caption': HTMLTableCaptionElement;
+    'cite': HTMLElement;
+    'code': HTMLElement;
+    'col': HTMLTableColElement;
+    'colgroup': HTMLTableColElement;
+    'data': HTMLDataElement;
+    'datalist': HTMLDataListElement;
+    'dd': HTMLElement;
+    'del': HTMLModElement;
+    'details': HTMLDetailsElement;
+    'dfn': HTMLElement;
+    'dialog': HTMLDialogElement;
+    'div': HTMLDivElement;
+    'dl': HTMLDListElement;
+    'dt': HTMLElement;
+    'em': HTMLElement;
+    'embed': HTMLEmbedElement;
+    'fieldset': HTMLFieldSetElement;
+    'figcaption': HTMLElement;
+    'figure': HTMLElement;
+    'footer': HTMLElement;
+    'form': HTMLFormElement;
+    'h1': HTMLHeadingElement;
+    'h2': HTMLHeadingElement;
+    'h3': HTMLHeadingElement;
+    'h4': HTMLHeadingElement;
+    'h5': HTMLHeadingElement;
+    'h6': HTMLHeadingElement;
+    'head': HTMLHeadElement;
+    'header': HTMLElement;
+    'hgroup': HTMLElement;
+    'hr': HTMLHRElement;
+    'html': HTMLHtmlElement;
+    'i': HTMLElement;
+    'iframe': HTMLIFrameElement;
+    'img': HTMLImageElement;
+    'input': HTMLInputElement;
+    'ins': HTMLModElement;
+    'kbd': HTMLElement;
+    'label': HTMLLabelElement;
+    'legend': HTMLLegendElement;
+    'li': HTMLLIElement;
+    'link': HTMLLinkElement;
+    'main': HTMLElement;
+    'map': HTMLMapElement;
+    'mark': HTMLElement;
+    'menu': HTMLMenuElement;
+    'meta': HTMLMetaElement;
+    'meter': HTMLMeterElement;
+    'nav': HTMLElement;
+    'noscript': HTMLElement;
+    'object': HTMLObjectElement;
+    'ol': HTMLOListElement;
+    'optgroup': HTMLOptGroupElement;
+    'option': HTMLOptionElement;
+    'output': HTMLOutputElement;
+    'p': HTMLParagraphElement;
+    'picture': HTMLPictureElement;
+    'pre': HTMLPreElement;
+    'progress': HTMLProgressElement;
+    'q': HTMLQuoteElement;
+    'rp': HTMLElement;
+    'rt': HTMLElement;
+    'ruby': HTMLElement;
+    's': HTMLElement;
+    'samp': HTMLElement;
+    'script': HTMLScriptElement;
+    'search': HTMLElement;
+    'section': HTMLElement;
+    'select': HTMLSelectElement;
+    'slot': HTMLSlotElement;
+    'small': HTMLElement;
+    'source': HTMLSourceElement;
+    'span': HTMLSpanElement;
+    'strong': HTMLElement;
+    'style': HTMLStyleElement;
+    'sub': HTMLElement;
+    'summary': HTMLElement;
+    'sup': HTMLElement;
+    'table': HTMLTableElement;
+    'tbody': HTMLTableSectionElement;
+    'td': HTMLTableCellElement;
+    'template': HTMLTemplateElement;
+    'textarea': HTMLTextAreaElement;
+    'tfoot': HTMLTableSectionElement;
+    'th': HTMLTableCellElement;
+    'thead': HTMLTableSectionElement;
+    'time': HTMLTimeElement;
+    'title': HTMLTitleElement;
+    'tr': HTMLTableRowElement;
+    'track': HTMLTrackElement;
+    'u': HTMLElement;
+    'ul': HTMLUListElement;
+    'var': HTMLElement;
+    'video': HTMLVideoElement;
+    'wbr': HTMLElement;
+  }
+}

--- a/packages/scoped-custom-element-registry/tsconfig.json
+++ b/packages/scoped-custom-element-registry/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "target": "es2020",
+    "tsBuildInfoFile": ".tsbuildinfo",
+    "module": "es2020",
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./build",
+    "importHelpers": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "noEmitOnError": false
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Fixes https://github.com/webcomponents/polyfills/issues/549

This is the simplest way to do it - just remove the dangerous feature check. I would maybe want to export a function to install the polyfill, but this is directly built as a classic script that can't have imports, so that would require a different approach. I'm not sure how optional installation is handled in other polyfills - we can add that later. The import part is not getting more deploys in the wild with the conditional installation.