### PR TITLE
Fix closure compiler error

### DIFF
--- a/packages/shadydom/src/patch-events.js
+++ b/packages/shadydom/src/patch-events.js
@@ -283,7 +283,14 @@ if (eventPhaseDescriptor) {
   Object.defineProperty(
     EventPatches,
     'eventPhase',
-    /** @type {!ObjectPropertyDescriptor<!Event>} */ ({
+    /** @type {!ObjectPropertyDescriptor<!{
+  composed: ?,
+  composedPath: function(this:Event): ?,
+  relatedTarget: ?,
+  stopImmediatePropagation: function(this:Event): undefined,
+  stopPropagation: function(this:Event): undefined,
+  target: ?
+}>} */ ({
       /**
        * @this {Event}
        */


### PR DESCRIPTION
I'm trying to fix some bugs in the Closure compiler template type checker. The fix has revealed a type error in shadydom, which this PR attempts to fix.

With the fix, the following error occurs:

```
shadydom/src/patch-events.js:286:53: ERROR - [JSC_TYPE_MISMATCH] actual parameter 3 of Object.defineProperty does not match formal parameter
found   : ObjectPropertyDescriptor<Event>
required: ObjectPropertyDescriptor<(Event|{
  composed: ?,
  composedPath: function(this:Event): ?,
  relatedTarget: ?,
  stopImmediatePropagation: function(this:Event): undefined,
  stopPropagation: function(this:Event): undefined,
  target: ?
})>
  286|     /** @type {!ObjectPropertyDescriptor<!Event>} */ ({
                                                            ^^
  287|       /**
       ^^^^^^^^^
...
  296|       configurable: true,
       ^^^^^^^^^^^^^^^^^^^^^^^^^
  297|     })
       ^^^^^^

```

This error is correct because EventPatches is an object literal, which can never be an Event because Event is a nominal type in Closure.

I think this change should be OK and will unblock Closure compiler fixes.

<!--
Please include a clear and concise description of what bug this PR fixes, or
what feature this PR implements.

If it resolves an existing issue, please include a line like "Fixes #1234"
-->
