### PR TITLE
Replace __proto__ with prototype in attach-shadow.js

### DIFF
--- a/packages/shadydom/src/attach-shadow.js
+++ b/packages/shadydom/src/attach-shadow.js
@@ -593,7 +593,7 @@ export const attachShadow = (host, options) => {
   // creating one.
   if (options['shadyUpgradeFragment'] && utils.canUpgrade()) {
     root = options['shadyUpgradeFragment'];
-    root.__proto__ = ShadowRoot.prototype;
+    root.prototype = ShadowRoot.prototype;
     root._init(host, options);
     recordChildNodes(root, root);
     // Note: qsa is native when used with noPatch.


### PR DESCRIPTION
<!--
Please include a clear and concise description of what bug this PR fixes, or
what feature this PR implements.

If it resolves an existing issue, please include a line like "Fixes #1234"
-->
`__proto__` - is not a standard property to change.