### PR TITLE
[scoped-custom-element-registry] Safari Tech Preview 214 fix

### DIFF
--- a/packages/scoped-custom-element-registry/CHANGELOG.md
+++ b/packages/scoped-custom-element-registry/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ### Changed -->
 <!-- ### Fixed -->
 
+## Unreleased
+
+### Fixed
+
+- Fixes [issue](https://github.com/webcomponents/polyfills/issues/613) with setting `shadowRoot.customElements` on Safari's native implementation
+
 ## [0.0.10] - 2025-02-26
 
 ### Added

--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
@@ -681,7 +681,13 @@ Element.prototype.attachShadow = function (
     ...(args as [])
   ) as ShadowRootWithSettableCustomElements;
   if (registry !== undefined) {
-    shadowRoot['customElements'] = shadowRoot['registry'] = registry;
+    const descriptor = {
+      value: registry,
+      configurable: true,
+      writable: true,
+    };
+    Object.defineProperty(shadowRoot, 'customElements', descriptor);
+    Object.defineProperty(shadowRoot, 'registry', descriptor);
   }
   return shadowRoot;
 };


### PR DESCRIPTION
Fixes https://github.com/webcomponents/polyfills/issues/613

Setting `shadowRoot.customEments = registry` generates an exception because the native implementation does not have a setter. This fix defines the property instead of setting it.

Note, we cannot easily run tests against this version of Safari, but this PR was locally tested to fix the issue on Safari Tech Preview 214.