### PR TITLE
[scoped-custom-element-registry] Non-string Values Are Not Properly Stringified Before Calling attributeChangedCallback in setAttribute

### DIFF
--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
@@ -520,7 +520,8 @@ const patchAttributes = (
       if (observedAttributes.has(name)) {
         const old = this.getAttribute(name);
         setAttribute.call(this, name, value);
-        attributeChangedCallback.call(this, name, old, value);
+        const newValue = this.getAttribute(name);
+        attributeChangedCallback.call(this, name, old, newValue);
       } else {
         setAttribute.call(this, name, value);
       }


### PR DESCRIPTION
The patched class setAttribute calls attributeChangedCallback without converting value to a string. This can lead to unexpected behavior when passing numeric or otherwise non-string values.

Fixes #607 

