### PR TITLE
[scoped-custom-element-registry] Stringify values passed to setAttribute()

### DIFF
--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
@@ -520,7 +520,8 @@ const patchAttributes = (
       if (observedAttributes.has(name)) {
         const old = this.getAttribute(name);
         setAttribute.call(this, name, value);
-        attributeChangedCallback.call(this, name, old, value);
+        const newValue = this.getAttribute(name);
+        attributeChangedCallback.call(this, name, old, newValue);
       } else {
         setAttribute.call(this, name, value);
       }

--- a/packages/scoped-custom-element-registry/test/Element.test.html.js
+++ b/packages/scoped-custom-element-registry/test/Element.test.html.js
@@ -114,13 +114,21 @@ describe('Element', () => {
     it('should call setAttribute', () => {
       const {tagName, CustomElementClass} = getObservedAttributesTestElement([
         'foo',
+        'boo',
+        'int',
       ]);
       customElements.define(tagName, CustomElementClass);
       const $el = document.createElement(tagName);
 
       $el.setAttribute('foo', 'bar');
+      $el.setAttribute('boo', true);
+      $el.setAttribute('boo', false);
+      $el.setAttribute('int', 42);
       expect($el.attributeChanges).to.be.deep.equal([
         {name: 'foo', old: null, value: 'bar'},
+        {name: 'boo', old: null, value: 'true'},
+        {name: 'boo', old: 'true', value: 'false'},
+        {name: 'int', old: null, value: '42'},
       ]);
       expect($el.getAttribute('foo')).to.equal('bar');
     });


### PR DESCRIPTION
Any value set via `setAttribute` gets converted to a plain string, because that's how HTML attributes work. However, this polyfil was missing this step, and it was passing the raw non-string value to the custom element attributeChangedCallback. This behavior is wrong, and it is a regression when compared to not using the polyfill.

Fixes #607, supersedes #616

(I should have checked the open PRs before creating this one. Oh, well, this one includes tests, while #616 didn't.)