### PR TITLE
[scoped-custom-element-registry] Align patched HTMLElement with native inheritance

### DIFF
--- a/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
+++ b/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.ts
@@ -343,6 +343,8 @@ window.HTMLElement = (function HTMLElement(this: HTMLElement) {
   return instance;
 } as unknown) as typeof HTMLElement;
 window.HTMLElement.prototype = NativeHTMLElement.prototype;
+window.HTMLElement.prototype.constructor = window.HTMLElement;
+Object.setPrototypeOf(window.HTMLElement, NativeHTMLElement);
 
 // Helpers to return the scope for a node where its registry would be located
 const isValidScope = (node: Node) =>


### PR DESCRIPTION
This change adds the same inheritance safety measures already implemented in `native-shim.ts`

- Ensures that instances of the patched HTMLElement have a `.constructor` reference pointing to the patched constructor itself.

- Preserves the prototype chain by setting the patched constructor’s `[[Prototype]]` to the native HTMLElement.

Context
This issue was discovered in a very specific case involving legacy applications still using `custom-elements-es5-adapter.js`, the old @open-wc/scoped-elements for Lit 1, and the new @open-wc/scoped-elements for Lit 3.
